### PR TITLE
Require python 2.

### DIFF
--- a/scripts/set-faults.py
+++ b/scripts/set-faults.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
 # Research and Simulation can be found in README.md in the root directory of


### PR DESCRIPTION
After communicating with an external user, he found his Ubuntu 18 system was defaulting to python 3 instead of python 2. I made changes to scripts to ask for python 2 explicitly. He and I both tested this branch successfully.