### PR TITLE
hotfix for the "Ground-finding problem in autonomy node"

### DIFF
--- a/src/plans/IdentifySampleTarget.plp
+++ b/src/plans/IdentifySampleTarget.plp
@@ -21,6 +21,7 @@ IdentifySampleTarget:
                            DirX = 0, DirY = 0, DirZ = 1,
                            SearchDistance = 0.5);
 
+  Wait 4; // Add some delay to make sure the status has been updated 
   if (Lookup (GroundFound)) GroundPos = Lookup (GroundPosition);
   else log_warning ("GuardedMove failed to find ground.");
   endif;


### PR DESCRIPTION
## Summary of Changes
* Add a short delay of 4 units before checking if ground is found or not


## Verify
launch the simulation then run the reference mission
```bash
roslaunch ow_autonomy autonomy_node.launch plan:=ReferenceMission1.plx
```

The reference mission should be able to find the ground this time and keep progressing..

_Note_: this will be merged to the release-6.0 branch

**Linked Issue:** https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-488