### PR TITLE
guarded_move wait +1 sec & stow arm on abort

### DIFF
--- a/src/plans/GuardedMove.plp
+++ b/src/plans/GuardedMove.plp
@@ -16,5 +16,5 @@ GuardedMove:
 
   SynchronousCommand guarded_move (X, Y, Z, DirX, DirY, DirZ, SearchDistance);
   SynchronousCommand publish_trajectory ();
-  Wait 4; // Add some delay to make sure the status has been updated
+  Wait 5; // Add some delay to make sure the status has been updated
 }

--- a/src/plans/ReferenceMission1.plp
+++ b/src/plans/ReferenceMission1.plp
@@ -72,7 +72,11 @@ ReferenceMission1: Concurrence
       LibraryCall StartSampleAnalysis;
       Wait 2;  // Wait for (stubbed) sample analysis to finish.
     }
-    else log_error ("Failed to find ground, aborting.");
+    else
+    {
+      log_error ("Failed to find ground, aborting.");
+      LibraryCall Stow();
+    }
     endif;
     MissionInProgress = false;
     log_info ("Reference Mission 1, Sol 0 complete.");


### PR DESCRIPTION
## Summary of Changes
On rare cases the _guarded_move_result_ takes a bit longer than 4 seconds to be received by the autonomy node.
This changes allows a little more time for the message to be received.
Additionally, in the case where this still happen (i.e even after increasing the time) the autonomy plan has been modified to restrow the arm. 

## Verify
1. Launch the simulator
```bash
roslaunch ow atacma_y1a.launch
```
2. Run the reference mission
```bash
roslaunch ow_autonomy autonomy_node.launch plan:=ReferenceMission1.plx
```

>Note: If you want to force ground detection failure, comment line 106 in trajectory_publisher.py
```python
# guarded_move_pub.publish(True, ground_detector.ground_position, 'base_link')
```

**Linked Issues:**
https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-488
This also touches briefly on issue: https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-510