### PR TITLE
Hotfix/oceanwater 489

### DIFF
--- a/src/plans/Pan.plp
+++ b/src/plans/Pan.plp
@@ -10,13 +10,5 @@
 Pan:
 {
   In Real Degrees;
-  Boolean started;
-  PostCondition (! started);
-  
-  SynchronousCommand started = pan_antenna (Degrees);
-
-  if (! started) {
-    log_error ("Failed to start antenna pan to ", Degrees, " degrees.");
-  }
-  endif
+  SynchronousCommand pan_antenna (Degrees);
 }

--- a/src/plans/Pan.plp
+++ b/src/plans/Pan.plp
@@ -5,22 +5,18 @@
 // Antenna pan procedure.
 // Input: degrees
 
-Boolean Command pan_antenna (Real);
-Boolean Lookup Running (String operation_name);
-Boolean Lookup Finished (String operation_name);
+#include "plan-interface.h"
 
 Pan:
 {
   In Real Degrees;
   Boolean started;
+  PostCondition (! started);
+  
+  SynchronousCommand started = pan_antenna (Degrees);
 
-  started = pan_antenna (Degrees);
-
-  if (started) {
-    WaitForFinish:
-    {
-      StartCondition Lookup (Running ("PanAntenna"));
-      EndCondition Lookup (Finished ("PanAntenna"));
-    }
+  if (! started) {
+    log_error ("Failed to start antenna pan to ", Degrees, " degrees.");
   }
+  endif
 }

--- a/src/plans/Tilt.plp
+++ b/src/plans/Tilt.plp
@@ -5,22 +5,18 @@
 // Antenna tilt procedure.
 // Input: degrees
 
-Boolean Command tilt_antenna (Real);
-Boolean Lookup Running (String operation_name);
-Boolean Lookup Finished (String operation_name);
+#include "plan-interface.h"
 
 Tilt:
 {
   In Real Degrees;
   Boolean started;
-  Exit (! started);
-  
-  started = tilt_antenna (Degrees);
+  PostCondition (! started);
 
-  WaitForFinish:
-  {
-    StartCondition Lookup (Running ("TiltAntenna"));
-    EndCondition Lookup (Finished ("TiltAntenna"));
+  SynchronousCommand started = tilt_antenna (Degrees);
+
+  if (! started) {
+    log_error ("Failed to start antenna tilt to ", Degrees, " degrees.");
   }
-
+  endif
 }

--- a/src/plans/Tilt.plp
+++ b/src/plans/Tilt.plp
@@ -10,13 +10,5 @@
 Tilt:
 {
   In Real Degrees;
-  Boolean started;
-  PostCondition (! started);
-
-  SynchronousCommand started = tilt_antenna (Degrees);
-
-  if (! started) {
-    log_error ("Failed to start antenna tilt to ", Degrees, " degrees.");
-  }
-  endif
+  SynchronousCommand tilt_antenna (Degrees);
 }

--- a/src/plans/plan-interface.h
+++ b/src/plans/plan-interface.h
@@ -9,8 +9,8 @@
 
 // Lander commands
 
-Boolean Command tilt_antenna (Real);
-Boolean Command pan_antenna (Real);
+Command tilt_antenna (Real);
+Command pan_antenna (Real);
 
 // The following commands perform only the path planning for the given activity.
 

--- a/src/plans/plan-interface.h
+++ b/src/plans/plan-interface.h
@@ -9,6 +9,9 @@
 
 // Lander commands
 
+Boolean Command tilt_antenna (Real);
+Boolean Command pan_antenna (Real);
+
 // The following commands perform only the path planning for the given activity.
 
 Command dig_circular (Real x, Real y, Real depth, Real ground_pos,

--- a/src/plexil-adapter/OwAdapter.cpp
+++ b/src/plexil-adapter/OwAdapter.cpp
@@ -243,27 +243,23 @@ static void deliver_sample (Command* cmd)
 
 static void tilt_antenna (Command* cmd)
 {
-  Value retval = Unknown;
   double degrees;
   const vector<Value>& args = cmd->getArgValues();
   args[0].getValue (degrees);
   CommandRegistry[CommandId] = cmd;
-  retval = OwInterface::instance()->tiltAntenna (degrees, CommandId);
+  OwInterface::instance()->tiltAntenna (degrees, CommandId);
   command_sent (cmd);
-  if (retval != Unknown) g_execInterface->handleCommandReturn(cmd, retval);
   CommandId++;
 }
 
 static void pan_antenna (Command* cmd)
 {
-  Value retval = Unknown;
   double degrees;
   const vector<Value>& args = cmd->getArgValues();
   args[0].getValue (degrees);
   CommandRegistry[CommandId] = cmd;
-  retval = OwInterface::instance()->panAntenna (degrees, CommandId);
+  OwInterface::instance()->panAntenna (degrees, CommandId);
   command_sent (cmd);
-  if (retval != Unknown) g_execInterface->handleCommandReturn(cmd, retval);
   CommandId++;
 }
 

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -43,7 +43,7 @@ using std::ref;
 const double D2R = M_PI / 180.0 ;
 const double R2D = 180.0 / M_PI ;
 
-const double DegreeTolerance = 0.2;    // made up, degees
+const double DegreeTolerance = 0.3;    // made up, degees
 const double VelocityTolerance = 0.01; // made up, unitless
 
 static bool within_tolerance (double val1, double val2, double tolerance)

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -679,11 +679,11 @@ void OwInterface::publishTrajectory (int id)
   }
 }
 
-static bool antenna_op (const string& opname, double degrees,
+static void antenna_op (const string& opname, double degrees,
                         ros::Publisher* pub, int id)
 {
   if (! mark_operation_running (opname, id)) {
-    return false;
+    return;
   }
 
   std_msgs::Float64 radians;
@@ -693,21 +693,20 @@ static bool antenna_op (const string& opname, double degrees,
   thread fault_thread (monitor_for_faults, opname);
   fault_thread.detach();
   pub->publish (radians);
-  return true;
 }
 
-bool OwInterface::tiltAntenna (double degrees, int id)
+void OwInterface::tiltAntenna (double degrees, int id)
 {
   m_goalTilt = degrees;
   m_tiltStart = ros::Time::now();
-  return antenna_op (Op_TiltAntenna, degrees, m_antennaTiltPublisher, id);
+  antenna_op (Op_TiltAntenna, degrees, m_antennaTiltPublisher, id);
 }
 
-bool OwInterface::panAntenna (double degrees, int id)
+void OwInterface::panAntenna (double degrees, int id)
 {
   m_goalPan = degrees;
   m_panStart = ros::Time::now();
-  return antenna_op (Op_PanAntenna, degrees, m_antennaPanPublisher, id);
+  antenna_op (Op_PanAntenna, degrees, m_antennaPanPublisher, id);
 }
 
 void OwInterface::takePicture ()

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -43,7 +43,7 @@ using std::ref;
 const double D2R = M_PI / 180.0 ;
 const double R2D = 180.0 / M_PI ;
 
-const double DegreeTolerance = 0.3;    // made up, degees
+const double DegreeTolerance = 0.2;    // made up, degees
 const double VelocityTolerance = 0.01; // made up, unitless
 
 static bool within_tolerance (double val1, double val2, double tolerance)

--- a/src/plexil-adapter/OwInterface.h
+++ b/src/plexil-adapter/OwInterface.h
@@ -33,8 +33,8 @@ class OwInterface
   void guardedMove (double x, double y, double z,
                     double direction_x, double direction_y, double direction_z,
                     double search_distance, int id);
-  bool tiltAntenna (double degrees, int id);
-  bool panAntenna (double degrees, int id);
+  void tiltAntenna (double degrees, int id);
+  void panAntenna (double degrees, int id);
   void takePicture ();
   void digLinear (double x, double y, double depth, double length,
                   double ground_pos, int id);


### PR DESCRIPTION
This improvement in how pan/tilt is commanded from PLEXIL, by using SynchronousCommand and _not_ returning a value, may be a fix to the intermittent "freeze" problem, which I suspect stemmed in the process checking code in PLEXIL that used to follow the pan/tilt commands.   In any case, this approach is simpler and more robust.

To test it, launch any simulation, and then invoke the autonomy node _a few times_ with any combination of plans that do pan/tilt.  Some examples:

roslaunch ow_autonomy autonomy_node.launch plan:=TestAntennaCamera.plx
roslaunch ow_autonomy autonomy_node.launch plan:=ReferenceMission1.plx
roslaunch ow_autonomy autonomy_node.launch

The last example starts the default plan Demo.plx.
You should see error-free (visually and in terminal) antenna movement.
NOTE: I get instabilities in the antenna (shakes, jerks) and I assume this is an unrelated issue.