### PR TITLE
Get up to date with newest PLEXIL

### DIFF
--- a/src/plans/CollectAndTransfer.plp
+++ b/src/plans/CollectAndTransfer.plp
@@ -140,7 +140,7 @@ CollectAndTransfer:
         else{
           CollectMore = false;
         }
-        endif;
+        endif
         Wait 1;
         set_checkpoint(OurName,true,Lookup(ToString(6,"_",CollectMore)));
         SynchronousCommand flush_checkpoints();

--- a/src/plans/Demo.plp
+++ b/src/plans/Demo.plp
@@ -34,7 +34,7 @@ Demo:
                              Parallel = true);
   }
   else log_error ("Failed to find ground, skipping grind and dig.");
-  endif;
+  endif
   log_info ("Stowing arm...");
   LibraryCall Stow();
   log_info ("Autonomy demo finished.");

--- a/src/plans/IdentifySampleTarget.plp
+++ b/src/plans/IdentifySampleTarget.plp
@@ -22,7 +22,7 @@ IdentifySampleTarget:
                            SearchDistance = 0.5);
   if (Lookup (GroundFound)) GroundPos = Lookup (GroundPosition);
   else log_warning ("GuardedMove failed to find ground.");
-  endif;
+  endif
 
   // The chosen X/Y sampling location, as well as choice for Radial trench
   // direction are stubbed here; these choices are arbitrary.

--- a/src/plans/ImagePass.plp
+++ b/src/plans/ImagePass.plp
@@ -33,7 +33,7 @@ ImagePass: UncheckedSequence
       LibraryCall PanAndShoot (PanAngle = PanAngle);
       set_checkpoint(CheckpointName,true,Lookup(ToString(ReversePan,"_",Tilt,"_",PanAngle)));
     }
-    endif;
+    endif
   }
   else {
     log_debug ("Forward pan. Pan =", PanAngle, "Hi=", PanHi,
@@ -48,8 +48,8 @@ ImagePass: UncheckedSequence
       LibraryCall PanAndShoot (PanAngle = PanAngle);
       set_checkpoint(CheckpointName,true,Lookup(ToString(ReversePan,"_",Tilt,"_",PanAngle)));
     }
-    endif;
+    endif
   }
-  endif;
+  endif
   ReversePan = !ReversePan;
 }

--- a/src/plans/ReferenceMission1.plp
+++ b/src/plans/ReferenceMission1.plp
@@ -77,7 +77,7 @@ ReferenceMission1: Concurrence
       log_error ("Failed to find ground, aborting.");
       LibraryCall Stow();
     }
-    endif;
+    endif
     MissionInProgress = false;
     log_info ("Reference Mission 1, Sol 0 complete.");
   }

--- a/src/plans/TakePanorama.plp
+++ b/src/plans/TakePanorama.plp
@@ -79,25 +79,25 @@ TakePanorama:
     log_error ("TakePanorama: Tilt spec outside valid range, exiting.");
     exit = true;
   }
-  endif;
+  endif
 
   if (PanLo > PanHi || PanLo < PAN_MIN || PanHi > PAN_MAX) {
     log_error ("TakePanorama: Pan spec outside valid range, exiting.");
     exit = true;
   }
-  endif;
+  endif
 
   if (VERT_FOV/2 <= VertOverlap) {
     log_error ("TakePanorama: Vertical overlap too high, exiting.");
     exit = true;
   }
-  endif;
+  endif
 
   if (HORIZ_FOV/2 <= HorizOverlap) {
     log_error ("TakePanorama: Horizontal overlap too high, exiting.");
     exit = true;
   }
-  endif;
+  endif
 
   // Initialize plan variables
   tilt = TiltLo;
@@ -182,7 +182,7 @@ TakePanorama:
                                   CheckpointName=OurName,
                                   ReversePan = reverse_pan);
   }
-  endif;
+  endif
   set_checkpoint(OurName+"__End",true,"");
   SynchronousCommand flush_checkpoints();
 }

--- a/src/plans/TorqueTest.plp
+++ b/src/plans/TorqueTest.plp
@@ -33,7 +33,7 @@ TorqueTest:
                            GroundPos=Lookup(GroundPosition));
       }
       else log_error ("TorqueTest failed to find ground!");
-      endif;
+      endif
       Digging = false;
     }
 
@@ -47,7 +47,7 @@ TorqueTest:
         elseif (Lookup(SoftTorqueLimitReached(JointNames[i]))) {
           log_warning ("Joint ", JointNames[i], " exceeding its soft limit.");
         }
-        endif;
+        endif
       }
       Wait 1;
     }

--- a/src/plexil-adapter/OwAdapter.h
+++ b/src/plexil-adapter/OwAdapter.h
@@ -12,6 +12,8 @@
 #include "InterfaceAdapter.hh"
 #include "Value.hh"
 
+#include <set>
+
 using namespace PLEXIL;
 
 class OwAdapter : public InterfaceAdapter

--- a/src/plexil-adapter/OwExecutive.cpp
+++ b/src/plexil-adapter/OwExecutive.cpp
@@ -13,20 +13,16 @@
 
 // PLEXIL
 #include "AdapterFactory.hh"
+#include "AdapterExecInterface.hh"
 #include "Debug.hh"
 #include "Error.hh"
 #include "PlexilExec.hh"
 #include "ExecApplication.hh"
-#include "InterfaceManager.hh"
 #include "InterfaceSchema.hh"
 #include "parsePlan.hh"
 #include "State.hh"
 using PLEXIL::Error;
-using PLEXIL::ExecApplication;
-using PLEXIL::InterfaceManager;
 using PLEXIL::InterfaceSchema;
-using PLEXIL::State;
-using PLEXIL::Value;
 
 // C++
 #include <fstream>
@@ -40,7 +36,7 @@ using std::ostringstream;
 static string PlexilDir = "";
 
 // The embedded PLEXIL application
-static ExecApplication* PlexilApp = NULL;
+static PLEXIL::ExecApplication* PlexilApp = NULL;
 
 OwExecutive* OwExecutive::m_instance = NULL;
 
@@ -75,7 +71,7 @@ bool OwExecutive::runPlan (const string& filename)
   }
 
   try {
-    g_execInterface->handleAddPlan(doc->document_element());
+    PlexilApp->addPlan (doc);
   }
   catch (PLEXIL::ParserException const &e) {
     ROS_ERROR("Add of PLEXIL plan %s failed: %s", plan.c_str(), e.what());
@@ -83,7 +79,7 @@ bool OwExecutive::runPlan (const string& filename)
   }
 
   try {
-    g_execInterface->handleValueChange(State::timeState(), 0);
+    g_execInterface->handleValueChange(PLEXIL::State::timeState(), 0);
     PlexilApp->run();
   }
   catch (const Error& e) {
@@ -170,7 +166,7 @@ bool OwExecutive::initialize ()
 
   try {
     REGISTER_ADAPTER(OwAdapter, "Ow");
-    PlexilApp = new ExecApplication();
+    PlexilApp = new PLEXIL::ExecApplication();
     if (!plexilInitializeInterfaces()) {
       ROS_ERROR("plexilInitializeInterfaces failed");
       return false;
@@ -193,4 +189,3 @@ bool OwExecutive::initialize ()
   }
   return true;
 }
-


### PR DESCRIPTION
This change brings OW PLEXIL code and its underlying C++ support up to date with the newest PLEXIL.  It required many small code changes, but should have no effect on behavior.  There was some minor refactoring done in the process.

The version of PLEXIL used has been tagged, and this tag is documented in the OW setup guide, which is on the same hotfix branch of ow_simulator.  See this in https://github.com/nasa/ow_simulator/pull/38

To test this change, you must first bring your PLEXIL installation up to date:

```
cd $PLEXIL_HOME
git checkout releases/plexil-4
git pull
make squeaky-clean
make
```
Next, rebuild ow_autonomy:
```
cd <ow_workspace>/build
rm -rf ow_autonomy
cd <ow_workspace>/src
catkin build ow_autonomy
```

ow_autonomy should build without errors or warnings.  Next, start a simulation (any) and run a plan of your choice (one should be a sufficient test).   E.g. you can run the default demo plan with:
```
roslaunch ow_autonomy autonomy_node.launch
```
