### PR TITLE
OCEANWATER-356: use geometry_msgs/Point

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,19 +9,19 @@ find_package(catkin REQUIRED COMPONENTS
   roslib
   actionlib
   actionlib_msgs
-	geometry_msgs
+  geometry_msgs
   ow_lander
 )
 
 list(INSERT CMAKE_MODULE_PATH 0
-	"${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
 find_package(PLEXIL REQUIRED)
 
 add_action_files(
   DIRECTORY action
   FILES GuardedMove.action
-	)
+  )
 
 generate_messages(
   DEPENDENCIES actionlib_msgs geometry_msgs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   roslib
   actionlib
   actionlib_msgs
+	geometry_msgs
   ow_lander
 )
 
@@ -23,7 +24,7 @@ add_action_files(
 	)
 
 generate_messages(
-  DEPENDENCIES actionlib_msgs
+  DEPENDENCIES actionlib_msgs geometry_msgs
 )
 
 
@@ -32,7 +33,7 @@ generate_messages(
 ###################################
 
 catkin_package(
-  CATKIN_DEPENDS roscpp roslib ow_lander actionlib_msgs
+  CATKIN_DEPENDS roscpp roslib ow_lander actionlib_msgs geometry_msgs
   CFG_EXTRAS ow_autonomy-extras.cmake
 )
 

--- a/action/GuardedMove.action
+++ b/action/GuardedMove.action
@@ -1,23 +1,10 @@
-#goal definition
-bool use_defaults           # Set to true to use the default touch location
-bool delete_prev_traj       # Set to true to cleanup ~/.ros
-float32 x                   # x,y,z coordinates of guarded move starting point
-float32 y
-float32 z
-float32 direction_x         # x,y,z coordinates of the vector normal to the
-float32 direction_y         # surface to be approached (direction of approach)
-float32 direction_z
-float32 search_distance     # How deep along normal vector the scoop moves
+# goal
+geometry_msgs/Point start     # arm start position
+geometry_msgs/Point normal    # vector normal to direction of approach
+float32 search_distance       # How deep along normal vector the scoop moves
 ---
-
-#result definition
-float32 final_x             # Final x,y,z coordinates 
-float32 final_y
-float32 final_z
-
+# result
+geometry_msgs/Point final     # arm final position
 ---
-
-#feedback
-float32 current_x           # Current x,y,z coordinates
-float32 current_y
-float32 current_z
+# feedback
+geometry_msgs/Point current   # arm current position

--- a/package.xml
+++ b/package.xml
@@ -12,8 +12,8 @@
   <depend>roscpp</depend>
   <depend>roslib</depend>
   <depend>ow_lander</depend>
-
   <depend>actionlib_msgs</depend>
+  <depend>geometry_msgs</depend>
   <depend>message_generation</depend>
 
   <export>

--- a/src/plexil-adapter/GuardedMoveClient.cpp
+++ b/src/plexil-adapter/GuardedMoveClient.cpp
@@ -5,6 +5,7 @@
 // Temporary file.  An experimental dummy action client for GuardedMove.
 
 #include <ros/ros.h>
+#include <geometry_msgs/Point.h>
 #include <actionlib/client/simple_action_client.h>
 #include <ow_autonomy/GuardedMoveAction.h>
 #include <thread>
@@ -29,7 +30,7 @@ static void activeCB()
 static void feedbackCB (const ow_autonomy::GuardedMoveFeedbackConstPtr& feedback)
 {
   ROS_INFO ("Feedback: (%f, %f, %f)",
-            feedback->current_x, feedback->current_y, feedback->current_z);
+            feedback->current.x, feedback->current.y, feedback->current.z);
 }
 
 int main (int argc, char **argv)
@@ -48,14 +49,10 @@ int main (int argc, char **argv)
 
   ROS_INFO("GuardedMove action server available, sending goal.");
   ow_autonomy::GuardedMoveGoal goal;
-  goal.use_defaults = false;
-  goal.delete_prev_traj = false;
-  goal.x = 1.2;
-  goal.y = 0.8;
-  goal.z = 0.3;
-  goal.direction_x = 0;
-  goal.direction_y = 0;
-  goal.direction_z = 0;
+  goal.start.x = 1.2;
+  goal.start.y = 0.8;
+  goal.start.z = 0.3;
+  goal.normal.x = goal.normal.y = goal.normal.z = 0;
   goal.search_distance = 0;
   client.sendGoal (goal, &doneCB, &activeCB, &feedbackCB);
 
@@ -67,7 +64,7 @@ int main (int argc, char **argv)
     ROS_INFO("GuardedMove action finished: %s", state.toString().c_str());
     ow_autonomy::GuardedMoveResultConstPtr result = client.getResult();
     ROS_INFO("GuardedMove action result: (%f, %f, %f)",
-             result->final_x, result->final_y, result->final_z);
+             result->final.x, result->final.y, result->final.z);
   }
   else {
     ROS_INFO("GuardedMove action did not finish before the time out.");

--- a/src/plexil-adapter/GuardedMoveServer.cpp
+++ b/src/plexil-adapter/GuardedMoveServer.cpp
@@ -5,6 +5,7 @@
 // Temporary file.  A dummy action server for GuardedMove.
 
 #include <ros/ros.h>
+#include <geometry_msgs/Point.h>
 #include <actionlib/server/simple_action_server.h>
 #include <ow_autonomy/GuardedMoveAction.h>
 #include <string>
@@ -41,11 +42,12 @@ class GuardedMoveAction
     ros::Rate r(1);
     bool success = true;
     int iterations = 10; // one per second
-    float x_incr = goal->x / iterations;
-    float y_incr = goal->y / iterations;
-    float z_incr = goal->z / iterations;
 
-    m_feedback.current_x = m_feedback.current_y = m_feedback.current_z = 0;
+    float x_incr = goal->start.x / iterations;
+    float y_incr = goal->start.y / iterations;
+    float z_incr = goal->start.z / iterations;
+
+    m_feedback.current.x = m_feedback.current.y = m_feedback.current.z = 0;
     ROS_INFO ("%s: Executing", m_actionName.c_str());
 
     // start executing the action
@@ -56,17 +58,15 @@ class GuardedMoveAction
         success = false;
         break;
       }
-      m_feedback.current_x += x_incr;
-      m_feedback.current_y += y_incr;
-      m_feedback.current_z += z_incr;
+      m_feedback.current.x += x_incr;
+      m_feedback.current.y += y_incr;
+      m_feedback.current.z += z_incr;
       m_actionServer.publishFeedback (m_feedback);
       r.sleep();
     }
 
     if (success) {
-      m_result.final_x = goal->x;
-      m_result.final_y = goal->y;
-      m_result.final_z = goal->z;
+      m_result.final = goal->start;
       ROS_INFO ("%s: Succeeded", m_actionName.c_str());
       m_actionServer.setSucceeded (m_result);
     }

--- a/src/plexil-adapter/OwAdapter.cpp
+++ b/src/plexil-adapter/OwAdapter.cpp
@@ -12,6 +12,7 @@
 
 // ROS
 #include <ros/ros.h>
+#include <geometry_msgs/Point.h>
 
 // PLEXIL API
 #include <AdapterConfiguration.hh>
@@ -182,8 +183,13 @@ static void guarded_move_action_demo (Command* cmd,
   args[5].getValue(dir_z);
   args[6].getValue(search_distance);
   CommandRegistry[CommandId] = make_pair (cmd, intf);
-  OwInterface::instance()->guardedMoveActionDemo (x, y, z, dir_x, dir_y, dir_z,
-                                                  search_distance, CommandId);
+  // Unfortunately, ROS does not provide a constructor taking x,y,z
+  geometry_msgs::Point start;
+  start.x = x; start.y = y; start.z = z;
+  geometry_msgs::Point normal;
+  normal.x = dir_x; normal.y = dir_y; normal.z = dir_z;
+  OwInterface::instance()->guardedMoveActionDemo (start, normal, search_distance,
+                                                  CommandId);
   ack_sent (cmd, intf);
   CommandId++;
 }

--- a/src/plexil-adapter/OwInterface.h
+++ b/src/plexil-adapter/OwInterface.h
@@ -14,6 +14,7 @@
 #include <ow_autonomy/GuardedMoveAction.h>
 #include <control_msgs/JointControllerState.h>
 #include <sensor_msgs/JointState.h>
+#include <geometry_msgs/Point.h>
 #include <string>
 
 class OwInterface
@@ -52,11 +53,10 @@ class OwInterface
   void publishTrajectory (int id);
 
   // Temporary, proof of concept for ROS Actions
-  void guardedMoveActionDemo (double x, double y, double z,
-                              double direction_x,
-                              double direction_y,
-                              double direction_z,
-                              double search_distance, int id);
+  void guardedMoveActionDemo (const geometry_msgs::Point& start,
+                              const geometry_msgs::Point& normal,
+                              double search_distance,
+                              int id);
 
   // State interface
   double getTilt () const;
@@ -82,12 +82,8 @@ class OwInterface
 
  private:
   // Temporary, support for public version above
-  void guardedMoveActionDemo1 (double x,
-                               double y,
-                               double z,
-                               double direction_x,
-                               double direction_y,
-                               double direction_z,
+  void guardedMoveActionDemo1 (const geometry_msgs::Point& start,
+                               const geometry_msgs::Point& normal,
                                double search_distance,
                                int id);
 

--- a/src/plexil-adapter/README.md
+++ b/src/plexil-adapter/README.md
@@ -16,7 +16,9 @@ ROS Action prototype
 
 This directory also contains a dummy stand-in ROS action server for GuardedMove,
 as well as a standalone node for testing it.  (GuardedMoveServer,
-GuardedMoveClient).  Run the following sequence, in three separate shells.
+GuardedMoveClient).  Run the following sequence, in three separate shells.  Note
+that the latter two executables are found in the `devel/lib/ow_autonomy` directory
+of your OceanWATERS workspace.
 
 
 ```bash


### PR DESCRIPTION
This is a simple but pervasive change that replaces the use of x/y/z scalars in several places with the Point type.   The changes only affect a dummy action server/client, but are useful footwork for another Epic in the works which will use Points.  This change adds the required catkin and package dependencies.

Two tests are sufficient.  First, run the standalone server/client demo as described in `src/plexil-adapter/README.md`.  Second, start the simulator (any world) and then: ` roslaunch ow_autonomy autonomy_node.launch plan:=TestActions.plx.`  Both should run without error.  There is no associated behavior in the simulator since it's a dummy action.