### PR TITLE
Drop all references to trajectory_publisher + prefix services with '/'

### DIFF
--- a/src/plans/DeliverSample.plp
+++ b/src/plans/DeliverSample.plp
@@ -11,5 +11,4 @@ DeliverSample:
   In Real Z;
 
   SynchronousCommand deliver_sample (X, Y, Z);
-  SynchronousCommand publish_trajectory ();
 }

--- a/src/plans/DigCircular.plp
+++ b/src/plans/DigCircular.plp
@@ -13,5 +13,4 @@ DigCircular:
   In Boolean Parallel;
 
   SynchronousCommand dig_circular (X, Y, Depth, GroundPos, Parallel);
-  SynchronousCommand publish_trajectory ();
 }

--- a/src/plans/Grind.plp
+++ b/src/plans/Grind.plp
@@ -18,5 +18,4 @@ Grind:
   //            " GroundPos=",GroundPos);
 
   SynchronousCommand grind (X, Y, Depth, Length, Parallel, GroundPos);
-  SynchronousCommand publish_trajectory ();
 }

--- a/src/plans/GuardedMove.plp
+++ b/src/plans/GuardedMove.plp
@@ -15,6 +15,5 @@ GuardedMove:
   In Real SearchDistance;
 
   SynchronousCommand guarded_move (X, Y, Z, DirX, DirY, DirZ, SearchDistance);
-  SynchronousCommand publish_trajectory ();
   Wait 5; // Add some delay to make sure the status has been updated
 }

--- a/src/plans/Stow.plp
+++ b/src/plans/Stow.plp
@@ -3,7 +3,5 @@
 Stow:
 {
   SynchronousCommand unstow();
-  SynchronousCommand publish_trajectory();
   SynchronousCommand stow();
-  SynchronousCommand publish_trajectory();
 }

--- a/src/plans/TestAntennaWithArm.plp
+++ b/src/plans/TestAntennaWithArm.plp
@@ -28,7 +28,6 @@ TestAntennaWithArm:
                               VertOverlap = 0,
                               InstanceName = "TestAntennaWithArm",
                               IgnoreCrash=true);
-    publish_trajectory();
   }
 
   log_info ("Antenna/Arm demo finished.");

--- a/src/plans/Unstow.plp
+++ b/src/plans/Unstow.plp
@@ -3,5 +3,4 @@
 Unstow:
 {
   SynchronousCommand unstow();
-  SynchronousCommand publish_trajectory();
 }

--- a/src/plans/plan-interface.h
+++ b/src/plans/plan-interface.h
@@ -36,9 +36,6 @@ Command unstow();  // move from stowed position to a "ready" position
 Command stow();
 
 
-// This command sends the planned trajectory to Gazebo, i.e. moves real arm
-Command publish_trajectory();
-
 // Utility commands
 
 Command log_info (...);

--- a/src/plexil-adapter/OwAdapter.cpp
+++ b/src/plexil-adapter/OwAdapter.cpp
@@ -143,14 +143,6 @@ static void unstow (Command* cmd, AdapterExecInterface* intf)
   CommandId++;
 }
 
-static void publish_trajectory (Command* cmd, AdapterExecInterface* intf)
-{
-  CommandRegistry[CommandId] = make_pair (cmd, intf);
-  OwInterface::instance()->publishTrajectory (CommandId);
-  ack_sent (cmd, intf);
-  CommandId++;
-}
-
 static void guarded_move (Command* cmd, AdapterExecInterface* intf)
 {
   double x, y, z, dir_x, dir_y, dir_z, search_distance;
@@ -397,8 +389,7 @@ bool OwAdapter::initialize()
   g_configuration->registerCommandHandler("tilt_antenna", tilt_antenna);
   g_configuration->registerCommandHandler("pan_antenna", pan_antenna);
   g_configuration->registerCommandHandler("take_picture", take_picture);
-  g_configuration->registerCommandHandler("publish_trajectory",
-                                          publish_trajectory);
+  
   TheAdapter = this;
   setSubscriber (receiveBool);
   setSubscriber (receiveString);

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -641,7 +641,7 @@ void OwInterface::guardedMove (double x, double y, double z,
   ros::NodeHandle nhandle ("planning");
 
   ros::ServiceClient client =
-    nhandle.serviceClient<ow_lander::GuardedMove>("arm/guarded_move");
+    nhandle.serviceClient<ow_lander::GuardedMove>("/arm/guarded_move");
 
   if (check_service_client (client)) {
     ow_lander::GuardedMove srv;
@@ -655,25 +655,6 @@ void OwInterface::guardedMove (double x, double y, double z,
     srv.request.search_distance = search_distance;
     thread service_thread (call_ros_service<ow_lander::GuardedMove>,
                            client, srv, Op_GuardedMove, id);
-    service_thread.detach();
-  }
-}
-
-void OwInterface::publishTrajectory (int id)
-{
-  if (! mark_operation_running (Op_PublishTrajectory, id)) return;
-
-  ros::NodeHandle nhandle ("planning");
-
-  ros::ServiceClient client =
-    nhandle.serviceClient<ow_lander::PublishTrajectory>("arm/publish_trajectory");
-
-  if (check_service_client (client)) {
-    ow_lander::PublishTrajectory srv;
-    srv.request.use_latest = true;
-    srv.request.trajectory_filename = "";
-    thread service_thread (call_ros_service<ow_lander::PublishTrajectory>,
-                           client, srv, Op_PublishTrajectory, id);
     service_thread.detach();
   }
 }
@@ -725,7 +706,7 @@ void OwInterface::digLinear (double x, double y,
   ros::NodeHandle nhandle ("planning");
 
   ros::ServiceClient client =
-    nhandle.serviceClient<ow_lander::DigLinear>("arm/dig_linear");
+    nhandle.serviceClient<ow_lander::DigLinear>("/arm/dig_linear");
 
   if (check_service_client (client)) {
     ow_lander::DigLinear srv;
@@ -749,7 +730,7 @@ void OwInterface::digCircular (double x, double y, double depth,
   ros::NodeHandle nhandle ("planning");
 
   ros::ServiceClient client =
-    nhandle.serviceClient<ow_lander::DigCircular>("arm/dig_circular");
+    nhandle.serviceClient<ow_lander::DigCircular>("/arm/dig_circular");
 
   if (check_service_client (client)) {
     ow_lander::DigCircular srv;
@@ -773,7 +754,7 @@ void OwInterface::grind (double x, double y, double depth, double length,
   ros::NodeHandle nhandle ("planning");
 
   ros::ServiceClient client =
-    nhandle.serviceClient<ow_lander::Grind>("arm/grind");
+    nhandle.serviceClient<ow_lander::Grind>("/arm/grind");
 
   if (check_service_client (client)) {
     ow_lander::Grind srv;
@@ -814,7 +795,8 @@ void OwInterface::unstow (int id)
   ros::NodeHandle nhandle ("planning");
 
   ros::ServiceClient client =
-    nhandle.serviceClient<ow_lander::Unstow>("arm/unstow");
+    nhandle.serviceClient<ow_lander::Unstow>("/arm/unstow");
+
 
   if (check_service_client (client)) {
     ow_lander::Unstow srv;
@@ -831,7 +813,8 @@ void OwInterface::deliverSample (double x, double y, double z, int id)
   ros::NodeHandle nhandle ("planning");
 
   ros::ServiceClient client =
-    nhandle.serviceClient<ow_lander::DeliverSample>("arm/deliver_sample");
+    nhandle.serviceClient<ow_lander::DeliverSample>("/arm/deliver_sample");
+
 
   if (check_service_client (client)) {
     ow_lander::DeliverSample srv;

--- a/src/plexil-adapter/OwInterface.h
+++ b/src/plexil-adapter/OwInterface.h
@@ -48,9 +48,6 @@ class OwInterface
   void takePanorama (double elev_lo, double elev_hi,
                      double lat_overlap, double vert_overlap);
 
-  // Pubishes trajectory saved by those operations above that are ROS actions.
-  void publishTrajectory (int id);
-
   // Temporary, proof of concept for ROS Actions
   void guardedMoveActionDemo (double x, double y, double z,
                               double direction_x,


### PR DESCRIPTION
>Note: you need to be OCEANWATER-518 branch for **ow_simulator**

## Summary of Changes
* Drop all references to *trajectory_publisher* from **ow_autonomy**
* Prefix all services calls with '/'

## Test
Start the simulation
```bash
roslaunch ow atacama_y1a.launch
```
Run the *Reference Mission 1* plan
```bash
roslaunch ow_autonomy autonomy_node.launch plan:=ReferenceMission1.plx
```