### PR TITLE
reset GroundFound at beginning of GuardedMove

### DIFF
--- a/src/plans/TestGuardedMoves.plp
+++ b/src/plans/TestGuardedMoves.plp
@@ -14,7 +14,7 @@ TestGuardedMoves:
                            SearchDistance = 0.5);
   if (Lookup(GroundFound)) {
     log_info ("Found ground (first attempt) at ", Lookup(GroundPosition));
-    LibraryCall GuardedMove (X = 3.0, Y = 0, Z = 0.3,
+    LibraryCall GuardedMove (X = 1.8, Y = 0, Z = 0.3,
                              DirX = 0, DirY = 0, DirZ = 1,
                              SearchDistance = 0.5);
     if (Lookup(GroundFound)) {

--- a/src/plans/TestGuardedMoves.plp
+++ b/src/plans/TestGuardedMoves.plp
@@ -2,9 +2,9 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Perform several guarded moves in sequence at different locations.
+// Perform two guarded moves in sequence at different locations, and report the
+// ground position.
 
-// #include "plexil_defs.h"
 #include "plan-interface.h"
 
 TestGuardedMoves:
@@ -25,4 +25,5 @@ TestGuardedMoves:
   }
   else log_error ("First guarded move failed.");
   endif
+  log_info ("TestGuardedMoves plan complete.");
 }

--- a/src/plans/TestGuardedMoves.plp
+++ b/src/plans/TestGuardedMoves.plp
@@ -1,0 +1,28 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// Perform several guarded moves in sequence at different locations.
+
+// #include "plexil_defs.h"
+#include "plan-interface.h"
+
+TestGuardedMoves:
+{
+  LibraryCall GuardedMove (X = 2.0, Y = 0, Z = 0.3,
+                           DirX = 0, DirY = 0, DirZ = 1,
+                           SearchDistance = 0.5);
+  if (Lookup(GroundFound)) {
+    log_info ("Found ground (first attempt) at ", Lookup(GroundPosition));
+    LibraryCall GuardedMove (X = 3.0, Y = 0, Z = 0.3,
+                             DirX = 0, DirY = 0, DirZ = 1,
+                             SearchDistance = 0.5);
+    if (Lookup(GroundFound)) {
+      log_info ("Found ground (second attempt) at ", Lookup(GroundPosition));
+    }
+    else log_error ("Second guarded move failed.");
+    endif
+  }
+  else log_error ("First guarded move failed.");
+  endif
+}

--- a/src/plans/TorqueTest.plp
+++ b/src/plans/TorqueTest.plp
@@ -21,7 +21,7 @@ TorqueTest:
   {
     Dig:
     {
-      // This node attempts to dig too deep (note -1 Z target), in an effort to
+      // This node attempts to dig too deep (grind depth), in an effort to
       // overtorque one or more arm joints.
 
       // First, find ground.

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -399,11 +399,8 @@ static void rul_callback (const std_msgs::Float64::ConstPtr& msg)
 
 //////////////////// GuardedMove Service support ////////////////////////////////
 
-// NOTE: A severe limitation of this approach and data representation is that
-// only ONE instance of GuardedMove is properly supported.  This is a first cut.
-
 static bool GroundFound = false;
-static double GroundPosition = 0; // value is not used unless GroundFound
+static double GroundPosition = 0; // should not be queried unless GroundFound
 
 bool OwInterface::groundFound () const
 {
@@ -427,7 +424,7 @@ static void guarded_move_callback
       return;
     }
     GroundPosition = msg->position.z;
-    publish ("GroundFound", GroundFound);
+    publish ("GroundFound", true);
     publish ("GroundPosition", GroundPosition);
   }
   else {
@@ -640,6 +637,7 @@ void OwInterface::guardedMove (double x, double y, double z,
     srv.request.direction_y = direction_y;
     srv.request.direction_z = direction_z;
     srv.request.search_distance = search_distance;
+    GroundFound = false;
     thread service_thread (call_ros_service<ow_lander::GuardedMove>,
                            client, srv, Op_GuardedMove, id);
     service_thread.detach();


### PR DESCRIPTION
This simple fix does two things:

- removes a long-standing limitation in GuardedMove, in which ground would be detected only on its first use
- seems to fix an intermittent bug in which the ground is not perceived to be found, even though it was found

[Release 7 autonomy test 4.3 ](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST007+-+release-7-0)is a good test for this fix.