### PR TITLE
fix the race condition

### DIFF
--- a/src/plexil-adapter/OwAdapter.cpp
+++ b/src/plexil-adapter/OwAdapter.cpp
@@ -79,12 +79,13 @@ static void ack_sent (Command* cmd, AdapterExecInterface* intf)
   ack_command (cmd, COMMAND_SENT_TO_SYSTEM, intf);
 }
 
-static void send_ack_once(Command* cmd, AdapterExecInterface* intf, bool* sent_flag)
+static void send_ack_once(Command* cmd, AdapterExecInterface* intf, bool* sent_flag, bool skip=false)
 {
   std::lock_guard<std::mutex> g(g_shared_mutex);
   if (! (*sent_flag) )
   {
-    ack_sent (cmd, intf);
+    if (!skip)
+      ack_sent (cmd, intf);
     *sent_flag = true;
   }
 }
@@ -101,7 +102,7 @@ static void command_status_callback (int id, bool success)
   std::unique_ptr<CommandRecord>& cr = it->second;
   Command* cmd = std::get<0>(*cr);
   AdapterExecInterface* intf = std::get<1>(*cr);
-  send_ack_once(cmd, intf, &std::get<2>(*cr));
+  send_ack_once(cmd, intf, &std::get<2>(*cr), true);
   if (success) ack_success (cmd, intf);
   else ack_failure (cmd, intf);
 }

--- a/src/plexil-adapter/OwAdapter.cpp
+++ b/src/plexil-adapter/OwAdapter.cpp
@@ -210,14 +210,7 @@ static void grind (Command* cmd, AdapterExecInterface* intf)
   std::unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwInterface::instance()->grind(x, y, depth, length, parallel, ground_pos,
                                  CommandId);
-  {
-    std::lock_guard<std::mutex> g(g_shared_mutex);
-    if (!std::get<2>(*cr))
-    {
-      ack_sent (cmd, intf);
-      std::get<2>(*cr) = true;
-    }
-  }
+  send_ack_once(cmd, intf, &std::get<2>(*cr));
 }
 
 static void dig_circular (Command* cmd, AdapterExecInterface* intf)

--- a/src/plexil-adapter/OwAdapter.cpp
+++ b/src/plexil-adapter/OwAdapter.cpp
@@ -24,19 +24,10 @@
 #include <StateCacheEntry.hh>
 
 // C++
-#include <utility>  // for std::pair
-#include <list>
 #include <map>
-#include <iostream>
 #include <mutex>
 using std::string;
 using std::vector;
-using std::pair;
-using std::make_pair;
-using std::list;
-using std::copy;
-using std::cout;
-using std::endl;
 
 
 ///////////////////////////// Conveniences //////////////////////////////////

--- a/src/plexil-adapter/OwAdapter.cpp
+++ b/src/plexil-adapter/OwAdapter.cpp
@@ -53,7 +53,8 @@ enum CommandRecordFields {CR_COMMAND, CR_ADAPTER, CR_ACK_SENT};
 
 static std::map<int, std::unique_ptr<CommandRecord>> CommandRegistry;
 
-std::unique_ptr<CommandRecord>& new_command_record(Command* cmd, AdapterExecInterface* intf)
+std::unique_ptr<CommandRecord>& new_command_record(Command* cmd,
+                                                   AdapterExecInterface* intf)
 {
   auto cr = std::make_tuple(cmd, intf, false);
   CommandRegistry[++CommandId] = std::make_unique<CommandRecord>(cr);
@@ -90,8 +91,9 @@ static void send_ack_once(CommandRecord& cr, bool skip=false)
   bool& sent_flag = std::get<CR_ACK_SENT>(cr);
   if (!sent_flag)
   {
-    if (!skip)
+    if (!skip) {
       ack_sent(std::get<CR_COMMAND>(cr), std::get<CR_ADAPTER>(cr));
+    }
     sent_flag = true;
   }
 }
@@ -101,7 +103,8 @@ static void command_status_callback (int id, bool success)
   auto it = CommandRegistry.find(id);
   if (it == CommandRegistry.end())
   {
-    ROS_ERROR_STREAM("command_status_callback: no command registered under id" << id);
+    ROS_ERROR_STREAM("command_status_callback: no command registered under id"
+                     << id);
     return;
   }
 

--- a/src/plexil-adapter/OwAdapter.cpp
+++ b/src/plexil-adapter/OwAdapter.cpp
@@ -173,6 +173,29 @@ static void guarded_move (Command* cmd, AdapterExecInterface* intf)
   send_ack_once(cmd, intf, &std::get<2>(*cr));
 }
 
+static void guarded_move_action_demo (Command* cmd,
+                                      AdapterExecInterface* intf)
+{
+  double x, y, z, dir_x, dir_y, dir_z, search_distance;
+  const vector<Value>& args = cmd->getArgValues();
+  args[0].getValue(x);
+  args[1].getValue(y);
+  args[2].getValue(z);
+  args[3].getValue(dir_x);
+  args[4].getValue(dir_y);
+  args[5].getValue(dir_z);
+  args[6].getValue(search_distance);
+  std::unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
+  // Unfortunately, ROS does not provide a constructor taking x,y,z
+  geometry_msgs::Point start;
+  start.x = x; start.y = y; start.z = z;
+  geometry_msgs::Point normal;
+  normal.x = dir_x; normal.y = dir_y; normal.z = dir_z;
+  OwInterface::instance()->guardedMoveActionDemo (start, normal, search_distance,
+                                                  CommandId);
+  send_ack_once(cmd, intf, &std::get<2>(*cr));
+}
+
 static void grind (Command* cmd, AdapterExecInterface* intf)
 {
   double x, y, depth, length, ground_pos;

--- a/src/plexil-adapter/autonomy_node.cpp
+++ b/src/plexil-adapter/autonomy_node.cpp
@@ -25,8 +25,16 @@ int main(int argc, char* argv[])
 
   OwInterface::instance()->initialize();
 
+  // wait for the first proper clock message before running the plan
+  ros::Rate warmup_rate(0.1);
+  ros::Time begin = ros::Time::now();
+  while (ros::Time::now() - begin == ros::Duration(0.0))
+  {
+    ros::spinOnce();
+    warmup_rate.sleep();
+  }
+  
   // Run the specified plan
-
   if (argc == 2) {
     ROS_INFO ("Running plan %s", argv[1]);
     OwExecutive::instance()->runPlan (argv[1]); // asynchronous


### PR DESCRIPTION
## Linked Issues
* [OCEANWATER-489 | ReferenceMission 1 stalls during the execution of TakePanorama__ReferenceMission1](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-489)

## Summary of Changes
* Avoid sending the acknowledgement to PLEXIL once we got 

## Verify
Launch simulation and an autonomy plan and verify no stalling is taking place. 