### PR TITLE
Oceanwater 585 streamline image capture

### DIFF
--- a/src/plans/ImagePass.plp
+++ b/src/plans/ImagePass.plp
@@ -19,7 +19,7 @@ ImagePass: UncheckedSequence
   InOut Real PanAngle;
   InOut Boolean ReversePan;
 
-  LibraryCall TakePicture(); // can fail, failure ignored for now
+  LibraryCall TakePicture();
   if (ReversePan) {
     log_debug ("Reverse pan. Pan =", PanAngle, "Lo=", PanLo,
                "Increment=", PanIncrement);

--- a/src/plans/PanAndShoot.plp
+++ b/src/plans/PanAndShoot.plp
@@ -14,5 +14,5 @@ PanAndShoot:
   In Real PanAngle;
 
   LibraryCall Pan (Degrees = PanAngle);
-  LibraryCall TakePicture(); // can fail, failure ignored for now
+  LibraryCall TakePicture();
 }

--- a/src/plans/TakePicture.plp
+++ b/src/plans/TakePicture.plp
@@ -5,31 +5,8 @@
 // Take a picture with the stereo camera.
 
 #include "plan-interface.h"
-Real Lookup time;
 
 TakePicture:
 {
-  Real TimeOut = 5.0;  // unitless, made up
-  Boolean GotImage = false;
-
-  PostCondition GotImage;
-
-  // Command the operation
-  take_picture();
-
-  // Wait for result
-  WaitForPicture:
-  {
-    SkipCondition Lookup(time, 1) - WaitForPicture.WAITING.START > TimeOut;
-    StartCondition Lookup(ImageReceived);
-    log_info ("Raw image data received.");
-    GotImage = true;
-  }
-
-  // Report image failure if needed
-  ReportImageFailure:
-  {
-    SkipCondition GotImage;
-    log_error ("Did not receive raw image data.");
-  }
+  SynchronousCommand take_picture();
 }

--- a/src/plans/lander-commands.h
+++ b/src/plans/lander-commands.h
@@ -1,0 +1,58 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+#ifndef Ow_commands_H
+#define Ow_commands_H
+
+// All available PLEXIL commands to the lander.  This is essentially the
+// lander's command interface.
+
+// Note that PLEXIL commands are asynchronous by design.  In general, autonomy
+// plans should not call these directly, but rather user the Library interface
+// that wraps these commands; this is defined in plan-interface.h.
+
+Command tilt_antenna (Real degrees);
+Command pan_antenna (Real degrees);
+Command take_picture();
+
+Command dig_circular (Real x,
+                      Real y,
+                      Real depth,
+                      Real ground_pos,
+                      Boolean parallel); // true means parallel to lander arm
+
+Command dig_linear (Real x,
+                    Real y,
+                    Real depth,
+                    Real length,
+                    Real ground_pos);
+
+// This dumps the scoop at the given location; can be used for removing tailings
+// as well as delivering a sample to the receptacle.
+Command deliver_sample (Real x,
+                        Real y,
+                        Real z);
+
+Command grind (Real x,
+               Real y,
+               Real depth,
+               Real length,
+               Boolean parallel,
+               Real ground_pos);
+
+Command guarded_move (Real x,
+                      Real y,
+                      Real z,
+                      Real dir_x,
+                      Real dir_y,
+                      Real dir_z,
+                      Real search_distance);
+
+// Move from stowed position to a "ready" position
+Command unstow();
+
+// Move from "ready" position to stowed position; requires unstow() first
+Command stow();
+
+#endif

--- a/src/plans/plan-interface.h
+++ b/src/plans/plan-interface.h
@@ -7,60 +7,15 @@
 
 // PLEXIL interface: commands, lookups, library plans
 
-// Lander commands
-
-Command tilt_antenna (Real);
-Command pan_antenna (Real);
-Command take_picture();
-
-// The following commands perform only the path planning for the given activity.
-
-Command dig_circular (Real x,
-                      Real y,
-                      Real depth,
-                      Real ground_pos,
-                      Boolean parallel); // true means parallel to lander arm
-
-Command dig_linear (Real x,
-                    Real y,
-                    Real depth,
-                    Real length,
-                    Real ground_pos);
-
-// This dumps the scoop at the given location; can be used for removing tailings
-// as well as delivering a sample to the receptacle.
-Command deliver_sample (Real x,
-                        Real y,
-                        Real z);
-
-Command grind (Real x,
-               Real y,
-               Real depth,
-               Real length,
-               Boolean parallel,
-               Real ground_pos);
-
-Command guarded_move (Real x,
-                      Real y,
-                      Real z,
-                      Real dir_x,
-                      Real dir_y,
-                      Real dir_z,
-                      Real search_distance);
-
-// Move from stowed position to a "ready" position
-Command unstow();
-
-// Move from "ready" position to stowed position; REQUIRES unstow() first
-Command stow();
+#include "lander-commands.h"
 
 // Utility commands; issue ROS_INFO, ROS_WARN, and ROS_ERROR, respectively.
 Command log_info (...);
 Command log_warning (...);
 Command log_error (...);
 
-// PLEXIL library versions of lander operations.  These are preferable to the
-// raw commands above, and include the final publish_trajectory.
+
+// PLEXIL library for lander operations.
 
 LibraryAction Stow ();
 LibraryAction Unstow ();
@@ -89,20 +44,29 @@ LibraryAction DeliverSample (In Real X,
                              In Real Y,
                              In Real Z);
 
-// Does nothing
-LibraryAction Stub (In String desc);
 
-
-// Lookups
-
-// Can be used for fine-grain process control, but generally not needed.
-Boolean Lookup Running (String operation_name);
-Boolean Lookup Finished (String operation_name);
+// Lander queries
 
 Boolean Lookup HardTorqueLimitReached (String joint_name);
 Boolean Lookup SoftTorqueLimitReached (String joint_name);
+Boolean Lookup ImageReceived;
+
+// Relevant with GuardedMove only:
 Boolean Lookup GroundFound;
 Real    Lookup GroundPosition;
-Boolean Lookup ImageReceived;
+
+
+// Misc
+
+// Query whether a given operation has started, or is finished after having been
+// started.  These use the operation names as defined in OwInterface.cpp, and
+// offer fine-grain process control.  They are not required for general use.
+Boolean Lookup Running (String operation_name);
+Boolean Lookup Finished (String operation_name);
+
+// Does nothing, useful as placeholder for real plan.
+LibraryAction Stub (In String description);
+
+
 
 #endif

--- a/src/plans/plan-interface.h
+++ b/src/plans/plan-interface.h
@@ -49,7 +49,6 @@ LibraryAction DeliverSample (In Real X,
 
 Boolean Lookup HardTorqueLimitReached (String joint_name);
 Boolean Lookup SoftTorqueLimitReached (String joint_name);
-Boolean Lookup ImageReceived;
 
 // Relevant with GuardedMove only:
 Boolean Lookup GroundFound;
@@ -66,7 +65,5 @@ Boolean Lookup Finished (String operation_name);
 
 // Does nothing, useful as placeholder for real plan.
 LibraryAction Stub (In String description);
-
-
 
 #endif

--- a/src/plexil-adapter/OwAdapter.cpp
+++ b/src/plexil-adapter/OwAdapter.cpp
@@ -289,7 +289,7 @@ static void pan_antenna (Command* cmd, AdapterExecInterface* intf)
 static void take_picture (Command* cmd, AdapterExecInterface* intf)
 {
   std::unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
-  OwInterface::instance()->takePicture();
+  OwInterface::instance()->takePicture (CommandId);
   send_ack_once(*cr);
 }
 

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -21,7 +21,6 @@
 // ROS
 #include <std_msgs/Float64.h>
 #include <std_msgs/Empty.h>
-#include <sensor_msgs/Image.h>
 
 // C++
 #include <set>
@@ -71,6 +70,7 @@ const string Op_TiltAntenna       = "TiltAntenna";
 const string Op_Grind             = "Grind";
 const string Op_Stow              = "Stow";
 const string Op_Unstow            = "Unstow";
+const string Op_TakePicture       = "TakePicture";
 
 // NOTE: The following map *should* be thread-safe, according to C++11 docs and
 // in particular because map entries are never added or deleted, and the code
@@ -92,7 +92,8 @@ static map<string, int> Running
   { Op_TiltAntenna, IDLE_ID },
   { Op_Grind, IDLE_ID },
   { Op_Stow, IDLE_ID },
-  { Op_Unstow, IDLE_ID }
+  { Op_Unstow, IDLE_ID },
+  { Op_TakePicture, IDLE_ID }
 };
 
 static bool is_lander_operation (const string& name)
@@ -168,7 +169,8 @@ const map<string, map<string, string> > Faults
   { Op_TiltAntenna, AntennaFaults },
   { Op_Grind, ArmFaults },
   { Op_Stow, ArmFaults },
-  { Op_Unstow, ArmFaults }
+  { Op_Unstow, ArmFaults },
+  { Op_TakePicture, AntennaFaults } // for now
 };
 
 static bool faulty (const string& fault)
@@ -371,11 +373,13 @@ void OwInterface::tiltCallback
   publish ("TiltDegrees", m_currentTilt);
 }
 
-static void camera_callback (const sensor_msgs::Image::ConstPtr& msg)
+void OwInterface::cameraCallback (const sensor_msgs::Image::ConstPtr& msg)
 {
-  // Assuming that receipt of this message is success itself.
-  ImageReceived = true;
-  publish ("ImageReceived", ImageReceived);
+  // NOTE: the received image is ignored for now.
+
+  if (operationRunning (Op_TakePicture)) {
+    mark_operation_finished (Op_TakePicture, Running.at (Op_TakePicture));
+  }
 }
 
 
@@ -543,7 +547,8 @@ void OwInterface::initialize()
                  &OwInterface::jointStatesCallback, this));
     m_cameraSubscriber = new ros::Subscriber
       (m_genericNodeHandle ->
-       subscribe("/StereoCamera/left/image_raw", qsize, camera_callback));
+       subscribe("/StereoCamera/left/image_raw", qsize,
+                 &OwInterface::cameraCallback, this));
     m_socSubscriber = new ros::Subscriber
       (m_genericNodeHandle ->
        subscribe("/power_system_node/state_of_charge", qsize, soc_callback));
@@ -675,11 +680,13 @@ void OwInterface::panAntenna (double degrees, int id)
   antenna_op (Op_PanAntenna, degrees, m_antennaPanPublisher, id);
 }
 
-void OwInterface::takePicture ()
+void OwInterface::takePicture (int id)
 {
+  if (! mark_operation_running (Op_TakePicture, id)) return;
   std_msgs::Empty msg;
-  ImageReceived = false;
-  publish ("ImageReceived", ImageReceived);
+  ROS_INFO ("Capturing stereo image using left image trigger.");
+  thread fault_thread (monitor_for_faults, Op_TakePicture);
+  fault_thread.detach();
   m_leftImageTriggerPublisher->publish (msg);
 }
 

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -355,9 +355,7 @@ void OwInterface::managePanTilt (const string& opname,
 }
 
 
-////////////////////////////// Image Support ///////////////////////////////////
-
-static bool   ImageReceived       = false;
+///////////////////////// Antenna/Camera Support ///////////////////////////////
 
 void OwInterface::panCallback
 (const control_msgs::JointControllerState::ConstPtr& msg)
@@ -838,11 +836,6 @@ double OwInterface::getPanVelocity () const
 double OwInterface::getTiltVelocity () const
 {
   return JointTelemetryMap[Joint::antenna_tilt].velocity;
-}
-
-bool OwInterface::imageReceived () const
-{
-  return ImageReceived;
 }
 
 double OwInterface::getVoltage () const

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -684,7 +684,7 @@ void OwInterface::takePicture (int id)
 {
   if (! mark_operation_running (Op_TakePicture, id)) return;
   std_msgs::Empty msg;
-  ROS_INFO ("Capturing stereo image using left image trigger.");
+  ROS_INFO ("  Capturing stereo image using left image trigger.");
   thread fault_thread (monitor_for_faults, Op_TakePicture);
   fault_thread.detach();
   m_leftImageTriggerPublisher->publish (msg);

--- a/src/plexil-adapter/OwInterface.h
+++ b/src/plexil-adapter/OwInterface.h
@@ -64,7 +64,6 @@ class OwInterface
   double getPanDegrees () const;
   double getPanVelocity () const;
   double getTiltVelocity () const;
-  bool   imageReceived () const;
   double getVoltage () const;
   double getRemainingUsefulLife () const;
   bool   groundFound () const;

--- a/src/plexil-adapter/OwInterface.h
+++ b/src/plexil-adapter/OwInterface.h
@@ -14,10 +14,12 @@
 #include <ow_autonomy/GuardedMoveAction.h>
 #include <control_msgs/JointControllerState.h>
 #include <sensor_msgs/JointState.h>
+#include <sensor_msgs/Image.h>
 #include <geometry_msgs/Point.h>
 #include <string>
 
-using GuardedMoveActionClient = actionlib::SimpleActionClient<ow_autonomy::GuardedMoveAction>;
+using GuardedMoveActionClient =
+  actionlib::SimpleActionClient<ow_autonomy::GuardedMoveAction>;
 
 class OwInterface
 {
@@ -38,7 +40,7 @@ class OwInterface
                     double search_distance, int id);
   void tiltAntenna (double degrees, int id);
   void panAntenna (double degrees, int id);
-  void takePicture ();
+  void takePicture (int id);
   void digLinear (double x, double y, double depth, double length,
                   double ground_pos, int id);
   void digCircular (double x, double y, double depth,
@@ -90,8 +92,9 @@ class OwInterface
   bool operationFinished (const std::string& name) const;
 
   void jointStatesCallback (const sensor_msgs::JointState::ConstPtr&);
-  void tiltCallback (const control_msgs::JointControllerState::ConstPtr& msg);
-  void panCallback (const control_msgs::JointControllerState::ConstPtr& msg);
+  void tiltCallback (const control_msgs::JointControllerState::ConstPtr&);
+  void panCallback (const control_msgs::JointControllerState::ConstPtr&);
+  void cameraCallback (const sensor_msgs::Image::ConstPtr&);
   void managePanTilt (const std::string& opname,
                       double position, double velocity,
                       double current, double goal,

--- a/src/plexil-adapter/OwSimProxy.cpp
+++ b/src/plexil-adapter/OwSimProxy.cpp
@@ -76,9 +76,6 @@ bool OwSimProxy::lookup (const std::string& state_name,
     args[0].getValue(s);
     value_out = OwInterface::instance()->softTorqueLimitReached(s);
   }
-  else if (state_name == "ImageReceived") {
-    value_out = OwInterface::instance()->imageReceived();
-  }
   else if (state_name == "Running") {
     string operation;
     args[0].getValue(operation);


### PR DESCRIPTION
The take_picture PLEXIL command is now incorporated into the same framework used by all other lander operations.  It is handled in roughly the same way as antenna pan/tilt.  The PLEXIL code is now much simpler, and the overall implementation more uniform.

As an aside, the declaration file plan-interface.h was refactored and reorganized, creating lander-commands.h.

To test, start any simulator world, and run any plan that takes pictures, e.g. TestAntennaCamera.plx, ReferenceMission1.plx.  There should be no behavior change from the previous version except for a slightly different ROS Info message.