### PR TITLE
Oceanwater 656 power fixes

### DIFF
--- a/src/plans/MonitorPower.plp
+++ b/src/plans/MonitorPower.plp
@@ -2,11 +2,9 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// A very basic power monitor that simply prints power status every 30 seconds.
+// A very simple power monitor that prints power status at a regular interval.
 
-Real Lookup Voltage;
-Real Lookup RemainingUsefulLife;
-Command log_info (...);
+#include "plan-interface.h"
 
 MonitorPower:
 {
@@ -17,5 +15,6 @@ MonitorPower:
 
   log_info ("Battery: state of charge: ", Lookup(Voltage));
   log_info ("Battery: remaining useful life: ", Lookup(RemainingUsefulLife));
-  Wait 120;
+  log_info ("Battery: temperature: ", Lookup(BatteryTemperature));
+  Wait 60;
 }

--- a/src/plans/plan-interface.h
+++ b/src/plans/plan-interface.h
@@ -47,6 +47,9 @@ LibraryAction DeliverSample (In Real X,
 
 // Lander queries
 
+Real Lookup Voltage;
+Real Lookup RemainingUsefulLife;
+Real Lookup BatteryTemperature;
 Boolean Lookup HardTorqueLimitReached (String joint_name);
 Boolean Lookup SoftTorqueLimitReached (String joint_name);
 

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -19,6 +19,7 @@
 
 // ROS
 #include <std_msgs/Float64.h>
+#include <std_msgs/Int16.h>
 #include <std_msgs/Empty.h>
 
 // C++
@@ -416,7 +417,7 @@ static void soc_callback (const std_msgs::Float64::ConstPtr& msg)
   publish ("Voltage", Voltage);
 }
 
-static void rul_callback (const std_msgs::Float64::ConstPtr& msg)
+static void rul_callback (const std_msgs::Int16::ConstPtr& msg)
 {
   RemainingUsefulLife = msg->data;
   publish ("RemainingUsefulLife", RemainingUsefulLife);
@@ -587,13 +588,13 @@ void OwInterface::initialize()
     m_socSubscriber = new ros::Subscriber
       (m_genericNodeHandle ->
        subscribe("/power_system_node/state_of_charge", qsize, soc_callback));
-    m_rulSubscriber = new ros::Subscriber
-      (m_genericNodeHandle ->
-       subscribe("/power_system_node/remaining_useful_life", qsize, rul_callback));
     m_batteryTempSubscriber = new ros::Subscriber
       (m_genericNodeHandle ->
        subscribe("/power_system_node/battery_temperature", qsize,
                  temperature_callback));
+    m_rulSubscriber = new ros::Subscriber
+      (m_genericNodeHandle ->
+       subscribe("/power_system_node/remaining_useful_life", qsize, rul_callback));
     m_guardedMoveSubscriber = new ros::Subscriber
       (m_genericNodeHandle ->
        subscribe("/guarded_move_result", qsize, guarded_move_callback));

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -408,6 +408,7 @@ void OwInterface::cameraCallback (const sensor_msgs::Image::ConstPtr& msg)
 
 static double Voltage             = 4.15;  // faked
 static double RemainingUsefulLife = 28460; // faked
+static double BatteryTemperature  = 0;  // temp
 
 static void soc_callback (const std_msgs::Float64::ConstPtr& msg)
 {
@@ -419,6 +420,12 @@ static void rul_callback (const std_msgs::Float64::ConstPtr& msg)
 {
   RemainingUsefulLife = msg->data;
   publish ("RemainingUsefulLife", RemainingUsefulLife);
+}
+
+static void temperature_callback (const std_msgs::Float64::ConstPtr& msg)
+{
+  BatteryTemperature = msg->data;
+  publish ("BatteryTemperature", BatteryTemperature);
 }
 
 
@@ -508,6 +515,7 @@ OwInterface::OwInterface ()
     m_cameraSubscriber (nullptr),
     m_socSubscriber (nullptr),
     m_rulSubscriber (nullptr),
+    m_batteryTempSubscriber (nullptr),
     m_guardedMoveSubscriber (nullptr),
     m_systemFaultMessagesSubscriber (nullptr),
     m_armFaultMessagesSubscriber (nullptr),
@@ -531,11 +539,8 @@ OwInterface::~OwInterface ()
   if (m_cameraSubscriber) delete m_cameraSubscriber;
   if (m_socSubscriber) delete m_socSubscriber;
   if (m_rulSubscriber) delete m_rulSubscriber;
+  if (m_batteryTempSubscriber) delete m_batteryTempSubscriber;
   if (m_guardedMoveSubscriber) delete m_guardedMoveSubscriber;
-  // if (m_systemFaultMessagesSubscriber) delete m_systemFaultMessagesSubscriber;
-  // if (m_armFaultMessagesSubscriber) delete m_armFaultMessagesSubscriber;
-  // if (m_powerFaultMessagesSubscriber) delete m_powerFaultMessagesSubscriber;
-  // if (m_ptFaultMessagesSubscriber) delete m_ptFaultMessagesSubscriber;
   if (m_instance) delete m_instance;
 }
 
@@ -585,6 +590,10 @@ void OwInterface::initialize()
     m_rulSubscriber = new ros::Subscriber
       (m_genericNodeHandle ->
        subscribe("/power_system_node/remaining_useful_life", qsize, rul_callback));
+    m_batteryTempSubscriber = new ros::Subscriber
+      (m_genericNodeHandle ->
+       subscribe("/power_system_node/battery_temperature", qsize,
+                 temperature_callback));
     m_guardedMoveSubscriber = new ros::Subscriber
       (m_genericNodeHandle ->
        subscribe("/guarded_move_result", qsize, guarded_move_callback));
@@ -895,6 +904,11 @@ double OwInterface::getVoltage () const
 double OwInterface::getRemainingUsefulLife () const
 {
   return RemainingUsefulLife;
+}
+
+double OwInterface::getBatteryTemperature () const
+{
+  return BatteryTemperature;
 }
 
 bool OwInterface::operationRunning (const string& name) const

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -406,9 +406,9 @@ void OwInterface::cameraCallback (const sensor_msgs::Image::ConstPtr& msg)
 
 ///////////////////////// Power support /////////////////////////////////////
 
-static double Voltage             = 4.15;  // faked
-static double RemainingUsefulLife = 28460; // faked
-static double BatteryTemperature  = 0;  // temp
+static double Voltage             = NAN;
+static double RemainingUsefulLife = NAN;
+static double BatteryTemperature  = NAN;
 
 static void soc_callback (const std_msgs::Float64::ConstPtr& msg)
 {

--- a/src/plexil-adapter/OwInterface.h
+++ b/src/plexil-adapter/OwInterface.h
@@ -72,6 +72,7 @@ class OwInterface
   double getTiltVelocity () const;
   double getVoltage () const;
   double getRemainingUsefulLife () const;
+  double getBatteryTemperature () const;
   bool   groundFound () const;
   double groundPosition () const;
 
@@ -86,7 +87,7 @@ class OwInterface
 
 
  private:
-                                           
+
   // Temporary, support for public version above
   void guardedMoveActionDemo1 (const geometry_msgs::Point& start,
                                const geometry_msgs::Point& normal,
@@ -107,19 +108,19 @@ class OwInterface
   void armFaultCallback (const ow_faults::ArmFaults::ConstPtr&);
   void powerFaultCallback (const ow_faults::PowerFaults::ConstPtr&);
   void antennaFaultCallback (const ow_faults::PTFaults::ConstPtr&);
-  
+
   template <typename T>
-  bool checkFaultMessages(std::string fault_component, 
-                                        T msg_val, 
-                                        std::string key, 
-                                        T value, 
+  bool checkFaultMessages(std::string fault_component,
+                                        T msg_val,
+                                        std::string key,
+                                        T value,
                                         bool b );
 
 //////////////////// FAULTS FOR SYSTEM LEVEL ////////////////////////
 // structure of all maps for faults is the following:
 // key = (string) fault name
 // value = (pair) ( (int) numberical fault value, booleon of if fault exists)
-  std::map<std::string,std::pair<uint64_t, bool>> systemErrors = 
+  std::map<std::string,std::pair<uint64_t, bool>> systemErrors =
   {
     {"ARM_EXECUTION_ERROR", std::make_pair(4,false)},
     {"POWER_EXECUTION_ERROR", std::make_pair(512,false)},
@@ -161,6 +162,7 @@ class OwInterface
   ros::Subscriber* m_cameraSubscriber;
   ros::Subscriber* m_socSubscriber;
   ros::Subscriber* m_rulSubscriber;
+  ros::Subscriber* m_batteryTempSubscriber;
   ros::Subscriber* m_guardedMoveSubscriber;
 
   std::unique_ptr<ros::Subscriber> m_systemFaultMessagesSubscriber;

--- a/src/plexil-adapter/OwSimProxy.cpp
+++ b/src/plexil-adapter/OwSimProxy.cpp
@@ -87,6 +87,9 @@ bool OwSimProxy::lookup (const std::string& state_name,
   else if (state_name == "RemainingUsefulLife") {
     value_out = OwInterface::instance()->getRemainingUsefulLife();
   }
+  else if (state_name == "BatteryTemperature") {
+    value_out = OwInterface::instance()->getBatteryTemperature();
+  }
   else if (state_name == "GroundFound") {
     value_out = OwInterface::instance()->groundFound();
   }


### PR DESCRIPTION
To summarize the Jira issue, this branch:
 - fixes RUL subscription (needed to use Int16 type)
 - initializes battery telemetry variables with NAN
 - adds battery temperature monitoring

To test, start any simulator world, then the reference mission plan:
roslaunch ow_autonomy autonomy_node.launch plan:=ReferenceMission1.plx

You should see periodic and sensible messages for each of the three telemetries, e.g:
[ INFO] : PLEXIL: Battery: state of charge: 0.882266318002357
[ INFO] : PLEXIL: Battery: remaining useful life: 2611
[ INFO] : PLEXIL: Battery: temperature: 20.0993274719806



