### PR TITLE
OCEANWATER-669 Updated OwInterface Pointers to Smart Pointers

### DIFF
--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -462,6 +462,7 @@ OwInterface::OwInterface ()
 {
 }
 
+OwInterface::~OwInterface (){}
 
 void OwInterface::initialize()
 {

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -456,29 +456,12 @@ std::shared_ptr<OwInterface> OwInterface::instance ()
 }
 
 OwInterface::OwInterface ()
-  : m_genericNodeHandle (nullptr),
-    m_antennaTiltPublisher (nullptr),
-    m_antennaPanPublisher (nullptr),
-    m_leftImageTriggerPublisher (nullptr),
-    m_antennaTiltSubscriber (nullptr),
-    m_antennaPanSubscriber (nullptr),
-    m_jointStatesSubscriber (nullptr),
-    m_cameraSubscriber (nullptr),
-    m_socSubscriber (nullptr),
-    m_rulSubscriber (nullptr),
-    m_batteryTempSubscriber (nullptr),
-    m_systemFaultMessagesSubscriber (nullptr),
-    m_armFaultMessagesSubscriber (nullptr),
-    m_powerFaultMessagesSubscriber (nullptr),
-    m_ptFaultMessagesSubscriber (nullptr),
-
-    m_currentPan (0), m_currentTilt (0),
+  : m_currentPan (0), m_currentTilt (0),
     m_goalPan (0), m_goalTilt (0)
     // m_panStart, m_tiltStart are deliberately uninitialized
 {
 }
 
-OwInterface::~OwInterface (){}
 
 void OwInterface::initialize()
 {

--- a/src/plexil-adapter/OwInterface.cpp
+++ b/src/plexil-adapter/OwInterface.cpp
@@ -446,12 +446,12 @@ static void default_action_done_cb
 
 /////////////////////////// OwInterface members ////////////////////////////////
 
-OwInterface* OwInterface::m_instance = nullptr;
+std::shared_ptr<OwInterface> OwInterface::m_instance = nullptr;
 
-OwInterface* OwInterface::instance ()
+std::shared_ptr<OwInterface> OwInterface::instance ()
 {
   // Very simple singleton
-  if (m_instance == nullptr) m_instance = new OwInterface();
+  if (m_instance == nullptr) m_instance = std::make_shared<OwInterface>();
   return m_instance;
 }
 
@@ -478,96 +478,83 @@ OwInterface::OwInterface ()
 {
 }
 
-OwInterface::~OwInterface ()
-{
-  if (m_genericNodeHandle) delete m_genericNodeHandle;
-  if (m_antennaTiltPublisher) delete m_antennaTiltPublisher;
-  if (m_leftImageTriggerPublisher) delete m_leftImageTriggerPublisher;
-  if (m_antennaTiltSubscriber) delete m_antennaTiltSubscriber;
-  if (m_antennaPanSubscriber) delete m_antennaPanSubscriber;
-  if (m_jointStatesSubscriber) delete m_jointStatesSubscriber;
-  if (m_cameraSubscriber) delete m_cameraSubscriber;
-  if (m_socSubscriber) delete m_socSubscriber;
-  if (m_rulSubscriber) delete m_rulSubscriber;
-  if (m_batteryTempSubscriber) delete m_batteryTempSubscriber;
-  if (m_instance) delete m_instance;
-}
+OwInterface::~OwInterface (){}
 
 void OwInterface::initialize()
 {
   static bool initialized = false;
 
   if (not initialized) {
-    m_genericNodeHandle = new ros::NodeHandle();
+    m_genericNodeHandle = std::make_unique<ros::NodeHandle>();
 
     // Initialize publishers.  Queue size is a guess at adequacy.  For now,
     // latching in lieu of waiting for publishers.
 
     const int qsize = 3;
     const bool latch = true;
-    m_antennaTiltPublisher = new ros::Publisher
+    m_antennaTiltPublisher = std::make_unique<ros::Publisher>
       (m_genericNodeHandle->advertise<std_msgs::Float64>
        ("/ant_tilt_position_controller/command", qsize, latch));
-    m_antennaPanPublisher = new ros::Publisher
+    m_antennaPanPublisher = std::make_unique<ros::Publisher>
       (m_genericNodeHandle->advertise<std_msgs::Float64>
        ("/ant_pan_position_controller/command", qsize, latch));
-    m_leftImageTriggerPublisher = new ros::Publisher
+    m_leftImageTriggerPublisher = std::make_unique<ros::Publisher>
       (m_genericNodeHandle->advertise<std_msgs::Empty>
        ("/StereoCamera/left/image_trigger", qsize, latch));
 
     // Initialize subscribers
 
-    m_antennaTiltSubscriber = new ros::Subscriber
+    m_antennaTiltSubscriber = std::make_unique<ros::Subscriber>
       (m_genericNodeHandle ->
        subscribe("/ant_tilt_position_controller/state", qsize,
                  &OwInterface::tiltCallback, this));
-    m_antennaPanSubscriber = new ros::Subscriber
+    m_antennaPanSubscriber = std::make_unique<ros::Subscriber>
       (m_genericNodeHandle ->
        subscribe("/ant_pan_position_controller/state", qsize,
                  &OwInterface::panCallback, this));
-    m_jointStatesSubscriber = new ros::Subscriber
+    m_jointStatesSubscriber = std::make_unique<ros::Subscriber>
       (m_genericNodeHandle ->
        subscribe("/joint_states", qsize,
                  &OwInterface::jointStatesCallback, this));
-    m_cameraSubscriber = new ros::Subscriber
+    m_cameraSubscriber = std::make_unique<ros::Subscriber>
       (m_genericNodeHandle ->
        subscribe("/StereoCamera/left/image_raw", qsize,
                  &OwInterface::cameraCallback, this));
-    m_socSubscriber = new ros::Subscriber
+    m_socSubscriber = std::make_unique<ros::Subscriber>
       (m_genericNodeHandle ->
        subscribe("/power_system_node/state_of_charge", qsize, soc_callback));
-    m_batteryTempSubscriber = new ros::Subscriber
+    m_batteryTempSubscriber = std::make_unique<ros::Subscriber>
       (m_genericNodeHandle ->
        subscribe("/power_system_node/battery_temperature", qsize,
                  temperature_callback));
-    m_rulSubscriber = new ros::Subscriber
+    m_rulSubscriber = std::make_unique<ros::Subscriber>
       (m_genericNodeHandle ->
        subscribe("/power_system_node/remaining_useful_life", qsize, rul_callback));
     // subscribers for fault messages
-    m_systemFaultMessagesSubscriber.reset(new ros::Subscriber
+    m_systemFaultMessagesSubscriber = std::make_unique<ros::Subscriber>
       (m_genericNodeHandle ->
        subscribe("/faults/system_faults_status", qsize,
-                &OwInterface::systemFaultMessageCallback, this)));
-    m_armFaultMessagesSubscriber.reset(new ros::Subscriber
+                &OwInterface::systemFaultMessageCallback, this));
+    m_armFaultMessagesSubscriber = std::make_unique<ros::Subscriber>
       (m_genericNodeHandle ->
        subscribe("/faults/arm_faults_status", qsize,
-                &OwInterface::armFaultCallback, this)));
-    m_powerFaultMessagesSubscriber.reset(new ros::Subscriber
+                &OwInterface::armFaultCallback, this));
+    m_powerFaultMessagesSubscriber = std::make_unique<ros::Subscriber>
       (m_genericNodeHandle ->
        subscribe("/faults/power_faults_status", qsize,
-                &OwInterface::powerFaultCallback, this)));
-    m_ptFaultMessagesSubscriber.reset(new ros::Subscriber
+                &OwInterface::powerFaultCallback, this));
+    m_ptFaultMessagesSubscriber = std::make_unique<ros::Subscriber>
       (m_genericNodeHandle ->
        subscribe("/faults/pt_faults_status", qsize,
-                &OwInterface::antennaFaultCallback, this)));
+                &OwInterface::antennaFaultCallback, this));
 
-    m_guardedMoveClient.reset(new GuardedMoveActionClient(Op_GuardedMove, true));
-    m_unstowClient.reset(new UnstowActionClient(Op_Unstow, true));
-    m_stowClient.reset(new StowActionClient(Op_Stow, true));
-    m_grindClient.reset(new GrindActionClient(Op_Grind, true));
-    m_digCircularClient.reset(new DigCircularActionClient(Op_DigCircular, true));
-    m_digLinearClient.reset(new DigLinearActionClient(Op_DigLinear, true));
-    m_deliverClient.reset(new DeliverActionClient(Op_Deliver, true));
+    m_guardedMoveClient = std::make_unique<GuardedMoveActionClient>(Op_GuardedMove, true);
+    m_unstowClient = std::make_unique<UnstowActionClient>(Op_Unstow, true);
+    m_stowClient = std::make_unique<StowActionClient>(Op_Stow, true);
+    m_grindClient = std::make_unique<GrindActionClient>(Op_Grind, true);
+    m_digCircularClient = std::make_unique<DigCircularActionClient>(Op_DigCircular, true);
+    m_digLinearClient = std::make_unique<DigLinearActionClient>(Op_DigLinear, true);
+    m_deliverClient = std::make_unique<DeliverActionClient>(Op_Deliver, true);
 
     if (! m_unstowClient->waitForServer(ros::Duration(ActionServerTimeout))) {
       ROS_ERROR ("Unstow action server did not connect!");
@@ -596,7 +583,7 @@ void OwInterface::setCommandStatusCallback (void (*callback) (int, bool))
 }
 
 static void antenna_op (const string& opname, double degrees,
-                        ros::Publisher* pub, int id)
+                        std::unique_ptr<ros::Publisher>& pub, int id)
 {
   if (! mark_operation_running (opname, id)) {
     return;

--- a/src/plexil-adapter/OwInterface.h
+++ b/src/plexil-adapter/OwInterface.h
@@ -66,9 +66,6 @@ class OwInterface
  public:
   static std::shared_ptr<OwInterface> instance();
   OwInterface ();
-  ~OwInterface ();
-  OwInterface (const OwInterface&) = delete;
-  OwInterface& operator= (const OwInterface&) = delete;
   void initialize ();
 
   // Operational interface

--- a/src/plexil-adapter/OwInterface.h
+++ b/src/plexil-adapter/OwInterface.h
@@ -9,6 +9,7 @@
 // ever be needed in the current autonomy scheme, which has one autonomy
 // executive per lander.
 
+#include <memory>
 #include <ros/ros.h>
 
 // ROS Actions
@@ -63,7 +64,7 @@ using FaultMap64 = std::map<std::string,std::pair<uint64_t, bool>>;
 class OwInterface
 {
  public:
-  static OwInterface* instance();
+  static std::shared_ptr<OwInterface> instance();
   OwInterface ();
   ~OwInterface ();
   OwInterface (const OwInterface&) = delete;
@@ -184,22 +185,22 @@ class OwInterface
     {"JOINT_LIMIT_ERROR", std::make_pair(2, false)}
   };
 
-  static OwInterface* m_instance;
-  ros::NodeHandle* m_genericNodeHandle;
+  static std::shared_ptr<OwInterface> m_instance;
+  std::unique_ptr<ros::NodeHandle> m_genericNodeHandle;
 
   // Publishers and subscribers
 
-  ros::Publisher*  m_antennaTiltPublisher;
-  ros::Publisher*  m_antennaPanPublisher;
-  ros::Publisher*  m_leftImageTriggerPublisher;
+  std::unique_ptr<ros::Publisher> m_antennaTiltPublisher;
+  std::unique_ptr<ros::Publisher> m_antennaPanPublisher;
+  std::unique_ptr<ros::Publisher> m_leftImageTriggerPublisher;
 
-  ros::Subscriber* m_antennaPanSubscriber;
-  ros::Subscriber* m_antennaTiltSubscriber;
-  ros::Subscriber* m_jointStatesSubscriber;
-  ros::Subscriber* m_cameraSubscriber;
-  ros::Subscriber* m_socSubscriber;
-  ros::Subscriber* m_rulSubscriber;
-  ros::Subscriber* m_batteryTempSubscriber;
+  std::unique_ptr<ros::Subscriber> m_antennaPanSubscriber;
+  std::unique_ptr<ros::Subscriber> m_antennaTiltSubscriber;
+  std::unique_ptr<ros::Subscriber> m_jointStatesSubscriber;
+  std::unique_ptr<ros::Subscriber> m_cameraSubscriber;
+  std::unique_ptr<ros::Subscriber> m_socSubscriber;
+  std::unique_ptr<ros::Subscriber> m_rulSubscriber;
+  std::unique_ptr<ros::Subscriber> m_batteryTempSubscriber;
   std::unique_ptr<ros::Subscriber> m_systemFaultMessagesSubscriber;
   std::unique_ptr<ros::Subscriber> m_armFaultMessagesSubscriber;
   std::unique_ptr<ros::Subscriber> m_powerFaultMessagesSubscriber;

--- a/src/plexil-adapter/OwInterface.h
+++ b/src/plexil-adapter/OwInterface.h
@@ -66,6 +66,9 @@ class OwInterface
  public:
   static std::shared_ptr<OwInterface> instance();
   OwInterface ();
+  ~OwInterface ();
+  OwInterface (const OwInterface&) = delete;
+	OwInterface& operator= (const OwInterface&) = delete;
   void initialize ();
 
   // Operational interface


### PR DESCRIPTION
**Overview:**
 Replaced reset calls with std::make_unique and replaced all raw pointers with unique_ptr in the OwInterface class. Also got rid of now redundant deletes in the destructor.
 
 **Testing:**
 Run any Plexil plan with the simulator. 
 
**Note:**
Had to use one shared_ptr within the instance method instead of a unique_ptr as a unique_ptr would go out of scope and cause compile errors. 
 
 

