### PR TITLE
OCEANWATER-344 Running Multiple Plexil Plans

### DIFF
--- a/src/plexil-adapter/OwExecutive.cpp
+++ b/src/plexil-adapter/OwExecutive.cpp
@@ -53,8 +53,7 @@ OwExecutive::~OwExecutive()
 //returns true if current plan is finished executing
 bool OwExecutive::getPlanState()
 {
-	bool current_state = PlexilApp->allPlansFinished();
-	return current_state;
+	return PlexilApp->allPlansFinished();
 }
 
 

--- a/src/plexil-adapter/OwExecutive.cpp
+++ b/src/plexil-adapter/OwExecutive.cpp
@@ -36,6 +36,7 @@ static string PlexilDir = "";
 
 // The embedded PLEXIL application
 static PLEXIL::ExecApplication* PlexilApp = NULL;
+static PLEXIL::PlexilExec* PlexilEx = NULL;
 
 OwExecutive* OwExecutive::m_instance = NULL;
 
@@ -49,7 +50,16 @@ OwExecutive* OwExecutive::instance ()
 OwExecutive::~OwExecutive()
 {
   if (m_instance) delete m_instance;
+	delete PlexilEx;
 }
+
+bool OwExecutive::getState()
+{
+  //auto a = PlexilExec::allPlansFinished();
+	auto current_state = PlexilEx->allPlansFinished();
+	std::cout << current_state << std::endl;
+}
+
 
 bool OwExecutive::runPlan (const string& filename)
 {
@@ -79,9 +89,9 @@ bool OwExecutive::runPlan (const string& filename)
 
   try {
 	// updates Exec so that multiple plans can be run even after first plan finishes 
-    PlexilApp->notifyExec();
+  PlexilApp->notifyExec();
 	g_execInterface->handleValueChange(PLEXIL::State::timeState(), 0);
-    PlexilApp->run();
+  PlexilApp->run();
   }
   catch (const Error& e) {
     ostringstream s;
@@ -169,6 +179,7 @@ bool OwExecutive::initialize ()
   try {
     REGISTER_ADAPTER(OwAdapter, "Ow");
     PlexilApp = new PLEXIL::ExecApplication();
+    PlexilEx = PLEXIL::makePlexilExec();
     if (!plexilInitializeInterfaces()) {
       ROS_ERROR("plexilInitializeInterfaces failed");
       return false;

--- a/src/plexil-adapter/OwExecutive.cpp
+++ b/src/plexil-adapter/OwExecutive.cpp
@@ -78,7 +78,9 @@ bool OwExecutive::runPlan (const string& filename)
   }
 
   try {
-    g_execInterface->handleValueChange(PLEXIL::State::timeState(), 0);
+	// updates Exec so that multiple plans can be run even after first plan finishes 
+    PlexilApp->notifyExec();
+	g_execInterface->handleValueChange(PLEXIL::State::timeState(), 0);
     PlexilApp->run();
   }
   catch (const Error& e) {

--- a/src/plexil-adapter/OwExecutive.cpp
+++ b/src/plexil-adapter/OwExecutive.cpp
@@ -16,7 +16,6 @@
 #include "AdapterExecInterface.hh"
 #include "Debug.hh"
 #include "Error.hh"
-#include "PlexilExec.hh"
 #include "ExecApplication.hh"
 #include "InterfaceSchema.hh"
 #include "parsePlan.hh"
@@ -36,7 +35,6 @@ static string PlexilDir = "";
 
 // The embedded PLEXIL application
 static PLEXIL::ExecApplication* PlexilApp = NULL;
-static PLEXIL::PlexilExec* PlexilEx = NULL;
 
 OwExecutive* OwExecutive::m_instance = NULL;
 
@@ -50,14 +48,13 @@ OwExecutive* OwExecutive::instance ()
 OwExecutive::~OwExecutive()
 {
   if (m_instance) delete m_instance;
-	delete PlexilEx;
 }
 
-bool OwExecutive::getState()
+//returns true if current plan is finished executing
+bool OwExecutive::getPlanState()
 {
-  //auto a = PlexilExec::allPlansFinished();
-	auto current_state = PlexilEx->allPlansFinished();
-	std::cout << current_state << std::endl;
+	bool current_state = PlexilApp->allPlansFinished();
+	return current_state;
 }
 
 
@@ -179,7 +176,6 @@ bool OwExecutive::initialize ()
   try {
     REGISTER_ADAPTER(OwAdapter, "Ow");
     PlexilApp = new PLEXIL::ExecApplication();
-    PlexilEx = PLEXIL::makePlexilExec();
     if (!plexilInitializeInterfaces()) {
       ROS_ERROR("plexilInitializeInterfaces failed");
       return false;

--- a/src/plexil-adapter/OwExecutive.cpp
+++ b/src/plexil-adapter/OwExecutive.cpp
@@ -188,7 +188,7 @@ bool OwExecutive::initialize ()
       ROS_ERROR("Stepping exec failed");
       return false;
     }
-		PlexilApp->addLibraryPath (PlexilDir);
+    PlexilApp->addLibraryPath (PlexilDir);
   }
   catch (const Error& e) {
     ostringstream s;

--- a/src/plexil-adapter/OwExecutive.h
+++ b/src/plexil-adapter/OwExecutive.h
@@ -23,7 +23,7 @@ class OwExecutive
   static OwExecutive* instance();
 
   bool initialize ();
-	bool getState();
+	bool getPlanState();
   bool runPlan (const std::string& filename);
 
  private:

--- a/src/plexil-adapter/OwExecutive.h
+++ b/src/plexil-adapter/OwExecutive.h
@@ -23,7 +23,7 @@ class OwExecutive
   static OwExecutive* instance();
 
   bool initialize ();
-	bool getPlanState();
+  bool getPlanState();
   bool runPlan (const std::string& filename);
 
  private:

--- a/src/plexil-adapter/OwExecutive.h
+++ b/src/plexil-adapter/OwExecutive.h
@@ -23,6 +23,7 @@ class OwExecutive
   static OwExecutive* instance();
 
   bool initialize ();
+	bool getState();
   bool runPlan (const std::string& filename);
 
  private:

--- a/src/plexil-adapter/autonomy_node.cpp
+++ b/src/plexil-adapter/autonomy_node.cpp
@@ -44,8 +44,16 @@ int main(int argc, char* argv[])
     return 1;
   }
 
+  ros::Rate rate(1); // 1 Hz seems appropriate, for now.
+  while (ros::ok()) {
+    ros::spinOnce();
+		OwExecutive::instance()->getState();
+    rate.sleep();
+  }
+
 	// loops until terminated by user, prompts them to enter any additional plans and
 	// runs them asynchronously. Error checking for plans already handled in other classes.
+/*
   while (ros::ok()) {	
 		ROS_INFO("Enter additional plans to be asynchronously run: \n\n");
 		std::string input;
@@ -53,7 +61,8 @@ int main(int argc, char* argv[])
 		std::cout << std::endl;
 		ROS_INFO ("Running plan %s", input.c_str());
 		OwExecutive::instance()->runPlan (input.c_str()); // asynchronous
+		OwExecutive::instance()->getState();
 	}
-	
+*/	
   return 0;  // We never actually get here!
 }

--- a/src/plexil-adapter/autonomy_node.cpp
+++ b/src/plexil-adapter/autonomy_node.cpp
@@ -44,14 +44,16 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  // ROS Loop (runs concurrently with plan).  Note that once this loop starts,
-  // this function (and node) is terminated with an interrupt.
-
-  ros::Rate rate(1); // 1 Hz seems appropriate, for now.
-  while (ros::ok()) {
-    ros::spinOnce();
-    rate.sleep();
-  }
-
+	// loops until terminated by user, prompts them to enter any additional plans and
+	// runs them asynchronously. Error checking for plans already handled in other classes.
+  while (ros::ok()) {	
+		ROS_INFO("Enter additional plans to be asynchronously run: \n\n");
+		std::string input;
+		std::getline(std::cin, input); // gets next plan to be run 
+		std::cout << std::endl;
+		ROS_INFO ("Running plan %s", input.c_str());
+		OwExecutive::instance()->runPlan (input.c_str()); // asynchronous
+	}
+	
   return 0;  // We never actually get here!
 }

--- a/src/plexil-adapter/autonomy_node.cpp
+++ b/src/plexil-adapter/autonomy_node.cpp
@@ -45,24 +45,25 @@ int main(int argc, char* argv[])
   }
 
   ros::Rate rate(1); // 1 Hz seems appropriate, for now.
+	std::string input; 
+	// loops until terminated by user, prompts them to enter any additional plans after the
+	// previous plan has been run to completion.
   while (ros::ok()) {
     ros::spinOnce();
-		OwExecutive::instance()->getState();
-    rate.sleep();
+		if(OwExecutive::instance()->getPlanState()){ // checks to see if previous plan finished
+			std::cout << "\nEnter any additional plan to be run: ";
+			std::getline(std::cin, input); 
+			// checks for empty input and trys to run the plan, if the plan has an error
+			// or doesnt exist then error message prints before looping again.
+			if(input != "" && OwExecutive::instance()->runPlan(input.c_str())){
+					ROS_INFO ("Running plan %s", input.c_str());
+    			rate.sleep();
+			}
+		}
+		else{
+    	rate.sleep();
+		}
   }
 
-	// loops until terminated by user, prompts them to enter any additional plans and
-	// runs them asynchronously. Error checking for plans already handled in other classes.
-/*
-  while (ros::ok()) {	
-		ROS_INFO("Enter additional plans to be asynchronously run: \n\n");
-		std::string input;
-		std::getline(std::cin, input); // gets next plan to be run 
-		std::cout << std::endl;
-		ROS_INFO ("Running plan %s", input.c_str());
-		OwExecutive::instance()->runPlan (input.c_str()); // asynchronous
-		OwExecutive::instance()->getState();
-	}
-*/	
   return 0;  // We never actually get here!
 }

--- a/src/plexil-adapter/autonomy_node.cpp
+++ b/src/plexil-adapter/autonomy_node.cpp
@@ -45,39 +45,39 @@ int main(int argc, char* argv[])
   }
 
   ros::Rate rate(1); // 1 Hz seems appropriate, for now.
-	std::string input; 
-	// loops until terminated by user, prompts them to enter any additional plans after the
-	// previous plan has been run to completion.
+  std::string input; 
+  // loops until terminated by user, prompts them to enter any additional plans after the
+  // previous plan has been run to completion.
   while (ros::ok()) {
     ros::spinOnce();
-		if(OwExecutive::instance()->getPlanState()){ // checks to see if previous plan finished
-			std::cout << "\nEnter any additional plan to be run: ";
-			std::getline(std::cin, input); 
-			// checks for empty input and trys to run the plan, if the plan has an error
-			// or doesnt exist then error message prints before looping again.
-			if(input != "" && OwExecutive::instance()->runPlan(input.c_str())){
-					ROS_INFO ("Running plan %s", input.c_str());
-  				ros::Rate rate2(10); // 10 Hz seems appropriate, for now.
-					int timeout = 0;
-					// handles edge case where getPlanState will not register that plan is running
-					// and attempts to run another plan when an ABORT state is recieved. Times out
-					// after 5 seconds or the plan is registered as running.
-					while(OwExecutive::instance()->getPlanState() && timeout < 50){
-						ros::spinOnce();
-						rate2.sleep();
-						timeout+=1;
-						if(timeout % 10 == 0){
-							ROS_INFO ("Plan not responding, timing out in %i seconds", (5 - timeout/10));
-						}
-					}
-					if(timeout == 49){
-						ROS_INFO ("Plan timed out, try again.");
-					}
-			}
-		}
-		else{
-    	rate.sleep();
-		}
+    if(OwExecutive::instance()->getPlanState()){ // checks to see if previous plan finished
+      std::cout << "\nEnter any additional plan to be run: ";
+      std::getline(std::cin, input); 
+      // checks for empty input and trys to run the plan, if the plan has an error
+      // or doesnt exist then error message prints before looping again.
+      if(input != "" && OwExecutive::instance()->runPlan(input.c_str())){
+          ROS_INFO ("Running plan %s", input.c_str());
+          ros::Rate rate2(10); // 10 Hz seems appropriate, for now.
+          int timeout = 0;
+          // handles edge case where getPlanState will not register that plan is running
+          // and attempts to run another plan when an ABORT state is recieved. Times out
+          // after 5 seconds or the plan is registered as running.
+          while(OwExecutive::instance()->getPlanState() && timeout < 50){
+            ros::spinOnce();
+            rate2.sleep();
+            timeout+=1;
+            if(timeout % 10 == 0){
+              ROS_INFO ("Plan not responding, timing out in %i seconds", (5 - timeout/10));
+            }
+          }
+          if(timeout == 49){
+            ROS_INFO ("Plan timed out, try again.");
+          }
+      }
+    }
+    else{
+      rate.sleep();
+    }
   }
 
   return 0;  // We never actually get here!


### PR DESCRIPTION
**Overview:**
Autonomy node (Plexil node) added feature so it can now can run multple Plexil plans asynchronously, user can type name of plexil plan into the terminal (ex: Stow.plx) to run plan.
 
 **Testing:**
 Run any Plexil plan with the simulator and type in any other plexil plans to the terminal for it to run asynchronously.
 
**Note:**
Added a notifyExec() call in the OwExecutive class so that even after a given plan had been run, the Executive would be notified of the new plan. If this is not included you can run plans while the previous plan is running but not after the first plan has finished.
 