### PR TITLE
Fixed Pan and Tilt marking as complete before the goal position was r…

### DIFF
--- a/ow_plexil/src/plans/TestAntennaMovement.plp
+++ b/ow_plexil/src/plans/TestAntennaMovement.plp
@@ -1,0 +1,42 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// Simple plan to test Pan and Tilt functions
+
+#include "plan-interface.h"
+
+LibraryAction TestPanTilt (In Real Goal, In Real Action, InOut Integer TestSuccess);
+
+TestAntennaMovement: CheckedSequence
+{
+  Integer TestCount = 0;
+
+  //initial location
+  LibraryCall Pan(Degrees = 0);
+  LibraryCall Tilt(Degrees = 0);
+
+  //Pan tests
+  LibraryCall TestPanTilt(Goal = 180, Action = "Pan", TestSuccess = TestCount); 
+  LibraryCall TestPanTilt(Goal = -180, Action = "Pan", TestSuccess = TestCount); 
+  LibraryCall TestPanTilt(Goal = 350, Action = "Pan", TestSuccess = TestCount); 
+  LibraryCall TestPanTilt(Goal = -350, Action = "Pan", TestSuccess = TestCount); 
+  LibraryCall TestPanTilt(Goal = -45, Action = "Pan", TestSuccess = TestCount); 
+  LibraryCall TestPanTilt(Goal = 10, Action = "Pan", TestSuccess = TestCount); 
+
+  //Tilt tests
+  LibraryCall TestPanTilt(Goal = 10, Action = "Tilt", TestSuccess = TestCount); 
+  LibraryCall TestPanTilt(Goal = 20, Action = "Tilt", TestSuccess = TestCount); 
+  LibraryCall TestPanTilt(Goal = -10, Action = "Tilt", TestSuccess = TestCount); 
+  LibraryCall TestPanTilt(Goal = 0, Action = "Tilt", TestSuccess = TestCount); 
+  LibraryCall TestPanTilt(Goal = 45, Action = "Tilt", TestSuccess = TestCount); 
+
+  //Checks if all tests have succeeded
+  if(TestCount == 11){
+    log_info("TestAntennaMovement: SUCCEEDED, 11/11 Tests Succeeded");
+  } 
+  else{
+    log_error("TestAntennaMovement: FAILED, ", TestCount, "/11 Tests Succeeded");
+  }
+ 
+}

--- a/ow_plexil/src/plans/TestAntennaMovement.plp
+++ b/ow_plexil/src/plans/TestAntennaMovement.plp
@@ -13,8 +13,8 @@ TestAntennaMovement: CheckedSequence
   Integer TestCount = 0;
 
   //initial location
-  LibraryCall Pan(Degrees = 0);
   LibraryCall Tilt(Degrees = 0);
+  LibraryCall Pan(Degrees = 0);
 
   //Pan tests
   LibraryCall TestPanTilt(Goal = 180, Action = "Pan", TestSuccess = TestCount); 

--- a/ow_plexil/src/plans/TestPanTilt.plp
+++ b/ow_plexil/src/plans/TestPanTilt.plp
@@ -29,7 +29,7 @@ TestPanTilt: Sequence
     }
 
     //Normalize between -360 and 360
-    if(abs(current)+tolerance > 360){
+    if(abs(current) > 360){
       if(current < 0){
         current = (abs(current) % 360)*-1;
       }
@@ -49,7 +49,7 @@ TestPanTilt: Sequence
     endif;
 
     //check if resulting position is within tolerance
-    if(current <= Goal + tolerance && current >= Goal - tolerance){
+    if(abs(current - Goal) <= tolerance){
       log_info(Action, ": SUCCEEDED", " Goal: ", Goal, " Actual: ", current);
       //if we succeed we increment the TestSuccess
       TestSuccess = TestSuccess + 1;

--- a/ow_plexil/src/plans/TestPanTilt.plp
+++ b/ow_plexil/src/plans/TestPanTilt.plp
@@ -2,20 +2,65 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// This is a simplified and stubbed version of a procedure that should
-// "interrogate" the terrain to find a good sampling location.  Instead, we
-// choose an arbitrary location and probe for ground position there.
+// Simple plan to test Pan and Tilt functions
 
 #include "plan-interface.h"
 
 TestPanTilt: Sequence
 {
+
+    log_info("Testing Pan, should succeed on all tests.");
+    LibraryCall Pan(Degrees = 65);
     log_info("Current Pan Degree: ", Lookup(PanDegrees));
     log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
-    LibraryCall Pan(Degrees = 70);
+
+    LibraryCall Pan(Degrees = 0);
     log_info("Current Pan Degree: ", Lookup(PanDegrees));
     log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+
+    LibraryCall Pan(Degrees = 180);
+    log_info("Current Pan Degree: ", Lookup(PanDegrees));
+    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+
+    LibraryCall Pan(Degrees = -180);
+    log_info("Current Pan Degree: ", Lookup(PanDegrees));
+    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+
+    LibraryCall Pan(Degrees = 350);
+    log_info("Current Pan Degree: ", Lookup(PanDegrees));
+    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+
+    LibraryCall Pan(Degrees = -350);
+    log_info("Current Pan Degree: ", Lookup(PanDegrees));
+    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+
+    LibraryCall Pan(Degrees = -360);
+    log_info("Current Pan Degree: ", Lookup(PanDegrees));
+    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+
+    LibraryCall Pan(Degrees = -45);
+    log_info("Current Pan Degree: ", Lookup(PanDegrees));
+    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+
+    LibraryCall Pan(Degrees = 10);
+    log_info("Current Pan Degree: ", Lookup(PanDegrees));
+    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+    log_info("PAN TEST FINISHED");
+
+    
+
+    log_info("Testing Tilt, should move to 45 degrees, back to 0, then attempt 200 before colliding and timing out.");
     LibraryCall Tilt(Degrees = 45);
     log_info("Current Pan Degree: ", Lookup(PanDegrees));
     log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+
+    LibraryCall Tilt(Degrees = 0);
+    log_info("Current Pan Degree: ", Lookup(PanDegrees));
+    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+
+    LibraryCall Tilt(Degrees = 200);
+    log_info("Current Pan Degree: ", Lookup(PanDegrees));
+    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+    log_info("TILT TEST FINISHED");
+    log_info("TestPanTilt Completed");
 }

--- a/ow_plexil/src/plans/TestPanTilt.plp
+++ b/ow_plexil/src/plans/TestPanTilt.plp
@@ -9,58 +9,54 @@
 TestPanTilt: Sequence
 {
 
-    log_info("Testing Pan, should succeed on all tests.");
-    LibraryCall Pan(Degrees = 65);
-    log_info("Current Pan Degree: ", Lookup(PanDegrees));
-    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+    In Real Goal;
+    In String Action;
+    InOut Integer TestSuccess;
+    Real tolerance = 0.4;
+    Real current = 0;
 
-    LibraryCall Pan(Degrees = 0);
-    log_info("Current Pan Degree: ", Lookup(PanDegrees));
-    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+    //output test number
+    log_info("TEST: ", TestSuccess+1);
 
-    LibraryCall Pan(Degrees = 180);
-    log_info("Current Pan Degree: ", Lookup(PanDegrees));
-    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+    //check for which command was passed
+    if(Action == "Pan" || Action == "pan"){
+      LibraryCall Pan(Degrees = Goal); 
+      current = Lookup(PanDegrees);
+    }
+    elseif(Action == "Tilt" || Action == "tilt"){
+      LibraryCall Tilt(Degrees = Goal);
+      current = Lookup(TiltDegrees);
+    }
 
-    LibraryCall Pan(Degrees = -180);
-    log_info("Current Pan Degree: ", Lookup(PanDegrees));
-    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+    //Normalize between -360 and 360
+    if(abs(current)+tolerance > 360){
+      if(current < 0){
+        current = (abs(current) % 360)*-1;
+      }
+      else{
+        current = (abs(current) % 360);
+      }
+    }
+    endif;
 
-    LibraryCall Pan(Degrees = 350);
-    log_info("Current Pan Degree: ", Lookup(PanDegrees));
-    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+    //check for equivalent angles
+    if(current > 0 && Goal < 0){
+      current = current - 360; 
+    }
+    else if(current < 0 && Goal > 0){
+      current = current + 360;
+    }
+    endif;
 
-    LibraryCall Pan(Degrees = -350);
-    log_info("Current Pan Degree: ", Lookup(PanDegrees));
-    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+    //check if resulting position is within tolerance
+    if(current <= Goal + tolerance && current >= Goal - tolerance){
+      log_info(Action, ": SUCCEEDED", " Goal: ", Goal, " Actual: ", current);
+      //if we succeed we increment the TestSuccess
+      TestSuccess = TestSuccess + 1;
+    }
+    else{
+      log_error(Action, ": FAILED", " Goal: ", Goal, " Actual: ", current);
+    }
 
-    LibraryCall Pan(Degrees = -360);
-    log_info("Current Pan Degree: ", Lookup(PanDegrees));
-    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
 
-    LibraryCall Pan(Degrees = -45);
-    log_info("Current Pan Degree: ", Lookup(PanDegrees));
-    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
-
-    LibraryCall Pan(Degrees = 10);
-    log_info("Current Pan Degree: ", Lookup(PanDegrees));
-    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
-    log_info("PAN TEST FINISHED");
-
-    
-
-    log_info("Testing Tilt, should move to 45 degrees, back to 0, then attempt 200 before colliding and timing out.");
-    LibraryCall Tilt(Degrees = 45);
-    log_info("Current Pan Degree: ", Lookup(PanDegrees));
-    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
-
-    LibraryCall Tilt(Degrees = 0);
-    log_info("Current Pan Degree: ", Lookup(PanDegrees));
-    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
-
-    LibraryCall Tilt(Degrees = 200);
-    log_info("Current Pan Degree: ", Lookup(PanDegrees));
-    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
-    log_info("TILT TEST FINISHED");
-    log_info("TestPanTilt Completed");
 }

--- a/ow_plexil/src/plans/TestPanTilt.plp
+++ b/ow_plexil/src/plans/TestPanTilt.plp
@@ -1,0 +1,21 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// This is a simplified and stubbed version of a procedure that should
+// "interrogate" the terrain to find a good sampling location.  Instead, we
+// choose an arbitrary location and probe for ground position there.
+
+#include "plan-interface.h"
+
+TestPanTilt: Sequence
+{
+    log_info("Current Pan Degree: ", Lookup(PanDegrees));
+    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+    LibraryCall Pan(Degrees = 70);
+    log_info("Current Pan Degree: ", Lookup(PanDegrees));
+    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+    LibraryCall Tilt(Degrees = 45);
+    log_info("Current Pan Degree: ", Lookup(PanDegrees));
+    log_info("Current Tilt Degree: ", Lookup(TiltDegrees));
+}

--- a/ow_plexil/src/plans/plan-interface.h
+++ b/ow_plexil/src/plans/plan-interface.h
@@ -70,6 +70,8 @@ Boolean Lookup PowerFault;
 // Relevant with GuardedMove only:
 Boolean Lookup GroundFound;
 Real    Lookup GroundPosition;
+Real    Lookup PanDegrees;
+Real    Lookup TiltDegrees;
 
 
 // Misc

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -291,7 +291,7 @@ void OwInterface::managePanTilt (const string& opname,
 
   //if position is over 360 we want to bring it back within the
   //-360 to 360 range to check if goal position has been reached.
-  if(fabs(current) > 360+DegreeTolerance){
+  if(fabs(current) > 360){
     if(current < 0){
       current = fmod(fabs(current),360.0)*-1;
     }

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -291,12 +291,12 @@ void OwInterface::managePanTilt (const string& opname,
 
   //if position is over 360 we want to bring it back within the
   //-360 to 360 range to check if goal position has been reached.
-  if(abs(current) > 360){
+  if(fabs(current) > 360+DegreeTolerance){
     if(current < 0){
-      current = fmod(abs(current),360.0)*-1;
+      current = fmod(fabs(current),360.0)*-1;
     }
     else{
-      current = fmod(abs(current), 360.0);
+      current = fmod(fabs(current), 360.0);
     }
   }
 

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -138,11 +138,8 @@ class OwInterface
   void deliverAction (double x, double y, double z, int id);
   bool operationRunning (const std::string& name) const;
   void jointStatesCallback (const sensor_msgs::JointState::ConstPtr&);
-  void tiltCallback (const control_msgs::JointControllerState::ConstPtr&);
-  void panCallback (const control_msgs::JointControllerState::ConstPtr&);
   void cameraCallback (const sensor_msgs::Image::ConstPtr&);
   void managePanTilt (const std::string& opname,
-                      double position, double velocity,
                       double current, double goal,
                       const ros::Time& start);
   void systemFaultMessageCallback (const ow_faults::SystemFaults::ConstPtr&);
@@ -194,8 +191,6 @@ class OwInterface
   std::unique_ptr<ros::Publisher> m_antennaPanPublisher;
   std::unique_ptr<ros::Publisher> m_leftImageTriggerPublisher;
 
-  std::unique_ptr<ros::Subscriber> m_antennaPanSubscriber;
-  std::unique_ptr<ros::Subscriber> m_antennaTiltSubscriber;
   std::unique_ptr<ros::Subscriber> m_jointStatesSubscriber;
   std::unique_ptr<ros::Subscriber> m_cameraSubscriber;
   std::unique_ptr<ros::Subscriber> m_socSubscriber;


### PR DESCRIPTION
***Overview***
Fixed Pan and Tilt marking as complete before the goal position was reached, also fixed the lookups for PanDegrees and TiltDegrees to reflect actual position. Due to this change I had to increase the degree tolerance slightly. Also added TestPanTilt plan for testing purposes.

***Testing***
1. Clean ow_plexil
2. Build ow_plexil
3. ```roslaunch ow europa_terminator_workspace.launch```
4. launch ow_plexil and run the test plan ```TestPanTilt.plx```
5. Also can run the first part of ```Demo.plx```

You should see in Rviz and Gazebo that the Pan and Tilt will now get to their goal locations before marking as complete.

***Notes***
I had to increase the timeout as Panning and Tilting now take longer. For reference a Pan to 70 degrees from its starting location takes just under 6 seconds. I also increased the tolerance level from .2 to .4 since the desired position check was not spinning fast enough for the lower tolerance and would sometimes trigger a timeout.