### PR TITLE
OCEANWATER-756_Rename_PlexilPlanSelection_python_class_for_GUI

### DIFF
--- a/ow_plexil/plugin.xml
+++ b/ow_plexil/plugin.xml
@@ -1,5 +1,5 @@
 <library path="src">
-  <class name="PLEXIL Plan Selection" type="rqt_plexil_plan_selection.rqt_plexil_plan_selection.PlexilPlanSelection" 
+  <class name="PLEXIL Plan Selection" type="rqt_plexil_plan_selection.rqt_plexil_plan_selection.PlexilPlanSelectionGUI" 
   base_class_type="rqt_gui_py::Plugin">
     <description>
       A simple GUI that selects PLEXIL plans to be run by the ow_plexil node.

--- a/ow_plexil/rqt_plexil_plan_selection/scripts/rqt_plexil_plan_selection.py
+++ b/ow_plexil/rqt_plexil_plan_selection/scripts/rqt_plexil_plan_selection.py
@@ -5,7 +5,7 @@
 
 import sys
 
-from rqt_plexil_plan_selection.rqt_plexil_plan_selection import PlexilPlanSelection
+from rqt_plexil_plan_selection.rqt_plexil_plan_selection import PlexilPlanSelectionGUI
 from rqt_gui.main import Main
 
 plugin = 'rqt_plexil_plan_selection'

--- a/ow_plexil/rqt_plexil_plan_selection/src/rqt_plexil_plan_selection/rqt_plexil_plan_selection.py
+++ b/ow_plexil/rqt_plexil_plan_selection/src/rqt_plexil_plan_selection/rqt_plexil_plan_selection.py
@@ -17,15 +17,15 @@ from ow_plexil.srv import PlanSelection
 from std_msgs.msg import String
 import rosservice
 
-class PlexilPlanSelection(Plugin):
+class PlexilPlanSelectionGUI(Plugin):
 
   #sets up our signal for the sub callback
   monitor_signal = pyqtSignal(['QString']) 
 
   def __init__(self, context):
     '''init initializes the widget and sets up our subscriber, publisher and event handlers'''
-    super(PlexilPlanSelection, self).__init__(context)
-    self.setObjectName('PlexilPlanSelection')
+    super(PlexilPlanSelectionGUI, self).__init__(context)
+    self.setObjectName('PlexilPlanSelectionGUI')
 
     # Process standalone plugin command-line arguments
     parser = ArgumentParser()


### PR DESCRIPTION
Renamed python GUI class PlexilPlanSelection to PlexilPlanSelectionGUI to prevent confusion with the C++ class also present in ow_plexil.

To test try to use the GUI, if it starts up fine then it works as intended!
