### PR TITLE
OCEANWATER-764 Ignore White space in Terminal Plan Selection

### DIFF
--- a/ow_plexil/src/plexil-adapter/TerminalPlanSelection.cpp
+++ b/ow_plexil/src/plexil-adapter/TerminalPlanSelection.cpp
@@ -43,7 +43,8 @@ void TerminalPlanSelection::start(bool initial_plan)
   while (ros::ok()) {
     if(m_plan_running == false){ // checks to see if previous plan finished
       std::cout << "\nEnter any additional plan to be run (or use the GUI): " << std::endl;
-      std::getline(std::cin, input); 
+      std::cin >> input;
+      std::cin.ignore();
       // if input is not empty we send the plan to the plan selection node for execution
       if(input != ""){
         ow_plexil::PlanSelection instruction;


### PR DESCRIPTION
Minor fix so that all white space in the terminal plan selection surrounding a plan is ignored. Is more user friendly and makes copy and pasting easier.

To test just run any plan like ```TakePicture.plx``` with and without white space surrounding it. If it runs regardless of any white space it is working!