### PR TITLE
Publish PLEXIL fault states when they change

### DIFF
--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -148,7 +148,9 @@ class OwInterface
   void antennaFaultCallback (const ow_faults::PTFaults::ConstPtr&);
 
   template <typename T1, typename T2>
-    void faultCallback (T1 msg_val, T2&, const std::string& name);
+    void updateFaultStatus (T1 msg_val, T2&,
+                            const std::string& component_name,
+                            const std::string& state_name); // PLEXIL Lookup name
 
   template <typename T>
     bool faultActive (const T& fault_map) const;


### PR DESCRIPTION
This is a simple but significant bug fix.  Before, the fault lookups AntennaFault, PowerFault, ArmFault, and SystemFault were not being published (generating an event that wakes up the executive) when they changed values.  Thus gate conditions (e.g. StartCondition) monitoring these lookups would not be satisfied when expected.

Emily, your branch has the only code in this repository that exhibits the problem.   Merge this branch into your branch to test it.  In particular, those "Start !Lookup(AntennaFault)" cases should work now.

Thomas, please inspect the code change and try a sanity check, such as running ReferenceMission1, while injecting and removing faults in each category.  There is no other meaningful regression test because no existing code exposed the problem.