### PR TITLE
Fault Handling Pattern 1

### DIFF
--- a/ow_plexil/src/plans/FaultHandlingPattern1.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern1.plp
@@ -23,13 +23,7 @@ FaultHandlingPattern1:
     Repeat true;
     Start !Lookup(AntennaFault);
 
-    NewAngle = Lookup(PanDegrees) + 15;
-
-    if NewAngle > 360
-    {
-      NewAngle = NewAngle mod 360;
-    }
-    endif;
+    NewAngle = (Lookup(PanDegrees) + 15) mod 360;
 
     SynchronousCommand pan_antenna (NewAngle);
   }

--- a/ow_plexil/src/plans/FaultHandlingPattern1.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern1.plp
@@ -7,16 +7,15 @@
 
 #include "plan-interface.h"
 
-LibraryAction InitializeAntennaAndArm (InOut Boolean initialize);
+LibraryAction InitializeAntennaAndArm ();
 
 FaultHandlingPattern1:
 {
-  Boolean Initialize = true;
   Real NewAngle = 0;
 
   log_info ("Starting FaultHandlingPattern1 plan...");
 
-  LibraryCall InitializeAntennaAndArm (initialize = Initialize);
+  LibraryCall InitializeAntennaAndArm ();
 
   Pattern1Image:
   {

--- a/ow_plexil/src/plans/FaultHandlingPattern1.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern1.plp
@@ -3,33 +3,29 @@
 // this repository.
 
 // Pan in 15 degree increments as long as no antenna fault is present
-// If an antenna fault is present, wait for resolution
-// No timeout implemented
+// If an antenna fault is occurs, pause until the fault is removed
 
 #include "plan-interface.h"
 
-LibraryAction InitializeLander (InOut Boolean initialize);
+LibraryAction InitializeAntennaAndArm (InOut Boolean initialize);
 
 FaultHandlingPattern1:
 {
   Boolean Initialize = true;
   Real NewAngle = 0;
-  Real NumPreviousRevolutions = 0;
 
-  LibraryCall InitializeLander (initialize = Initialize);
+  LibraryCall InitializeAntennaAndArm (initialize = Initialize);
 
   Pattern1Image:
   {
     Repeat true;
-    Start !Lookup(AntennaFault) && !Initialize;
+    Start !Lookup(AntennaFault);
 
-    log_info ("Running Pattern1Image...");
     NewAngle = Lookup(PanDegrees) + 15;
 
     if NewAngle > 360
     {
-      NumPreviousRevolutions = NewAngle/360;
-      NewAngle = (NumPreviousRevolutions - round(NumPreviousRevolutions))*360;
+      NewAngle = NewAngle mod 360;
     }
     endif;
 

--- a/ow_plexil/src/plans/FaultHandlingPattern1.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern1.plp
@@ -14,6 +14,8 @@ FaultHandlingPattern1:
   Boolean Initialize = true;
   Real NewAngle = 0;
 
+  log_info ("Starting FaultHandlingPattern1 plan...");
+
   LibraryCall InitializeAntennaAndArm (initialize = Initialize);
 
   Pattern1Image:
@@ -32,6 +34,6 @@ FaultHandlingPattern1:
     SynchronousCommand pan_antenna (NewAngle);
   }
 
-
+  log_info ("FaultHandlingPattern1 plan complete.");
 }
 

--- a/ow_plexil/src/plans/FaultHandlingPattern1.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern1.plp
@@ -2,8 +2,8 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Pan in 15 degree increments as long as no antenna fault is present
-// If an antenna fault is occurs, pause until the fault is removed
+// Pan in 15 degree increments as long as no antenna fault is present.
+// If an antenna fault is occurs, pause until the fault is removed.
 
 #include "plan-interface.h"
 

--- a/ow_plexil/src/plans/FaultHandlingPattern1.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern1.plp
@@ -1,0 +1,41 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// Pan in 15 degree increments as long as no antenna fault is present
+// If an antenna fault is present, wait for resolution
+// No timeout implemented
+
+#include "plan-interface.h"
+
+LibraryAction InitializeLander (InOut Boolean initialize);
+
+FaultHandlingPattern1:
+{
+  Boolean Initialize = true;
+  Real NewAngle = 0;
+  Real NumPreviousRevolutions = 0;
+
+  LibraryCall InitializeLander (initialize = Initialize);
+
+  Pattern1Image:
+  {
+    Repeat true;
+    Start !Lookup(AntennaFault) && !Initialize;
+
+    log_info ("Running Pattern1Image...");
+    NewAngle = Lookup(PanDegrees) + 15;
+
+    if NewAngle > 360
+    {
+      NumPreviousRevolutions = NewAngle/360;
+      NewAngle = (NumPreviousRevolutions - round(NumPreviousRevolutions))*360;
+    }
+    endif;
+
+    SynchronousCommand pan_antenna (NewAngle);
+  }
+
+
+}
+

--- a/ow_plexil/src/plans/InitializeAntennaAndArm.plp
+++ b/ow_plexil/src/plans/InitializeAntennaAndArm.plp
@@ -8,7 +8,6 @@
 
 InitializeAntennaAndArm:
 {
-  InOut Boolean initialize;
 
   log_info ("Initializing lander antenna and arm...");
 
@@ -20,8 +19,6 @@ InitializeAntennaAndArm:
   SynchronousCommand stow();
 
   log_info ("Initialization complete.");
-  initialize = false;
 
-  Wait 5; // To buffer before a plan begins after initialization
 }
 

--- a/ow_plexil/src/plans/InitializeAntennaAndArm.plp
+++ b/ow_plexil/src/plans/InitializeAntennaAndArm.plp
@@ -6,20 +6,22 @@
 
 #include "plan-interface.h"
 
-InitializeLander:
+InitializeAntennaAndArm:
 {
   InOut Boolean initialize;
 
-  log_info ("Initializing lander...");
+  log_info ("Initializing lander antenna and arm...");
 
-  log_info ("Resetting pan angle to 0...");
-  SynchronousCommand pan_antenna (0);
   log_info ("Resetting tilt angle to 0...");
   SynchronousCommand tilt_antenna (0);
-  log_info ("If arm unstowed, restowing the arm...");
+  log_info ("Resetting pan angle to 0...");
+  SynchronousCommand pan_antenna (0);
+  log_info ("Stowing the arm...");
   SynchronousCommand stow();
 
   log_info ("Initialization complete.");
   initialize = false;
+
+  Wait 5; // To buffer before a plan begins after initialization
 }
 

--- a/ow_plexil/src/plans/InitializeLander.plp
+++ b/ow_plexil/src/plans/InitializeLander.plp
@@ -1,0 +1,25 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// Reset pan and tilt angles to 0 and stow the arm (if not already there)
+
+#include "plan-interface.h"
+
+InitializeLander:
+{
+  InOut Boolean initialize;
+
+  log_info ("Initializing lander...");
+
+  log_info ("Resetting pan angle to 0...");
+  SynchronousCommand pan_antenna (0);
+  log_info ("Resetting tilt angle to 0...");
+  SynchronousCommand tilt_antenna (0);
+  log_info ("If arm unstowed, restowing the arm...");
+  SynchronousCommand stow();
+
+  log_info ("Initialization complete.");
+  initialize = false;
+}
+


### PR DESCRIPTION
This plan (FaultHandlingPattern1.plp) repeatedly executes a 15 degree pan action unless an antenna fault is injected. If an antenna fault is injected, the action repetition stops and the plan waits for it to be resolved indefinitely. If you remove the fault, the original action will resume repetition. 

This plan also calls an initialization node, InitializeLander.plp, which resets pan and tilt to 0 and stows the arm. This should allow for the plan to be run multiple times without restarting the simulator. Additionally, there is logic in the Image node to prevent pan degree boundary (> 360) errors which occur when you let the pan action occur for long enough. 

To test fault handling, observe that panning is occurring, and inject an antenna fault. You should see the pan stop, and it should remain halted until you remove the fault. When you remove it, panning should resume.

To test panning boundary issue, allow the antenna to rotate past 360 degrees. It should not stop.