### PR TITLE
Oceanwater 783 - Library-Level Fault Checks

### DIFF
--- a/ow_plexil/src/plans/Deliver.plp
+++ b/ow_plexil/src/plans/Deliver.plp
@@ -6,13 +6,15 @@
 // delivering the sample to its receptacle (which has specific coordinates) and
 // dumping tailings from trench digging.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 Deliver:
 {
   In Real X;
   In Real Y;
   In Real Z;
+
+  Exit Lookup(ArmFault);
 
   SynchronousCommand deliver (X, Y, Z);
 }

--- a/ow_plexil/src/plans/Deliver.plp
+++ b/ow_plexil/src/plans/Deliver.plp
@@ -14,7 +14,9 @@ Deliver:
   In Real Y;
   In Real Z;
 
-  Exit Lookup(ArmFault);
+  PostCondition !Lookup(ArmFault);
 
-  SynchronousCommand deliver (X, Y, Z);
+  if (!Lookup(ArmFault)) SynchronousCommand deliver (X, Y, Z);
+  else log_error ("Command deliver not sent to lander due to active arm fault.");
+
 }

--- a/ow_plexil/src/plans/DigCircular.plp
+++ b/ow_plexil/src/plans/DigCircular.plp
@@ -14,7 +14,9 @@ DigCircular:
   In Real GroundPos;
   In Boolean Parallel;
 
-  Exit Lookup(ArmFault);
+  PostCondition !Lookup(ArmFault);
 
-  SynchronousCommand dig_circular (X, Y, Depth, GroundPos, Parallel);
+  if (!Lookup(ArmFault)) SynchronousCommand dig_circular (X, Y, Depth, GroundPos, Parallel);
+  else log_error ("Command dig_circular not sent to lander due to active arm fault.");
+
 }

--- a/ow_plexil/src/plans/DigCircular.plp
+++ b/ow_plexil/src/plans/DigCircular.plp
@@ -4,7 +4,7 @@
 
 // Perform one pass of a circular digging action.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 DigCircular:
 {
@@ -13,6 +13,8 @@ DigCircular:
   In Real Depth;
   In Real GroundPos;
   In Boolean Parallel;
+
+  Exit Lookup(ArmFault);
 
   SynchronousCommand dig_circular (X, Y, Depth, GroundPos, Parallel);
 }

--- a/ow_plexil/src/plans/DigLinear.plp
+++ b/ow_plexil/src/plans/DigLinear.plp
@@ -14,7 +14,9 @@ DigLinear:
   In Real Length;
   In Real GroundPos;
 
-  Exit Lookup(ArmFault);
+  PostCondition !Lookup(ArmFault);
 
-  SynchronousCommand dig_linear (X, Y, Depth, Length, GroundPos);
+  if (!Lookup(ArmFault)) SynchronousCommand dig_linear (X, Y, Depth, Length, GroundPos);
+  else log_error ("Command dig_linear not sent to lander due to active arm fault.");
+
 }

--- a/ow_plexil/src/plans/DigLinear.plp
+++ b/ow_plexil/src/plans/DigLinear.plp
@@ -4,7 +4,7 @@
 
 // Perform one pass of a linear digging action.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 DigLinear:
 {
@@ -13,6 +13,8 @@ DigLinear:
   In Real Depth;
   In Real Length;
   In Real GroundPos;
+
+  Exit Lookup(ArmFault);
 
   SynchronousCommand dig_linear (X, Y, Depth, Length, GroundPos);
 }

--- a/ow_plexil/src/plans/Grind.plp
+++ b/ow_plexil/src/plans/Grind.plp
@@ -4,7 +4,7 @@
 
 // Perform one pass with the grinding tool, using the given parameters.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 Grind:
 {
@@ -14,6 +14,8 @@ Grind:
   In Real Length;
   In Real GroundPos;
   In Boolean Parallel;
+
+  Exit Lookup(ArmFault);
 
   SynchronousCommand grind (X, Y, Depth, Length, Parallel, GroundPos);
 }

--- a/ow_plexil/src/plans/Grind.plp
+++ b/ow_plexil/src/plans/Grind.plp
@@ -15,7 +15,10 @@ Grind:
   In Real GroundPos;
   In Boolean Parallel;
 
-  Exit Lookup(ArmFault);
+  PostCondition !Lookup(ArmFault);
 
-  SynchronousCommand grind (X, Y, Depth, Length, Parallel, GroundPos);
+  if (!Lookup(ArmFault)) SynchronousCommand grind (X, Y, Depth, Length, Parallel, GroundPos);
+  else log_error ("Command grind not sent to lander due to active arm fault.");
+
+
 }

--- a/ow_plexil/src/plans/GuardedMove.plp
+++ b/ow_plexil/src/plans/GuardedMove.plp
@@ -17,8 +17,14 @@ GuardedMove:
   In Real DirZ;
   In Real SearchDistance;
 
-  Exit Lookup(ArmFault);
+  PostCondition !Lookup(ArmFault);
 
-  SynchronousCommand guarded_move (X, Y, Z, DirX, DirY, DirZ, SearchDistance);
-  Wait 5; // Add some delay to make sure the status has been updated
+  if (!Lookup(ArmFault))
+  { 
+    SynchronousCommand guarded_move (X, Y, Z, DirX, DirY, DirZ, SearchDistance);
+    Wait 5; // Add some delay to make sure the status has been updated
+  }
+  else log_error ("Command guarded_move not sent to lander due to active arm fault.");
+
+  
 }

--- a/ow_plexil/src/plans/GuardedMove.plp
+++ b/ow_plexil/src/plans/GuardedMove.plp
@@ -5,7 +5,7 @@
 // Perform a guarded move with the given parameters.
 // A guarded move is typically used to find the ground.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 GuardedMove:
 {
@@ -16,6 +16,8 @@ GuardedMove:
   In Real DirY;
   In Real DirZ;
   In Real SearchDistance;
+
+  Exit Lookup(ArmFault);
 
   SynchronousCommand guarded_move (X, Y, Z, DirX, DirY, DirZ, SearchDistance);
   Wait 5; // Add some delay to make sure the status has been updated

--- a/ow_plexil/src/plans/Pan.plp
+++ b/ow_plexil/src/plans/Pan.plp
@@ -4,10 +4,13 @@
 
 // Pan the antenna to specified degrees.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 Pan:
 {
   In Real Degrees;
+
+  Exit Lookup(AntennaFault);
+
   SynchronousCommand pan_antenna (Degrees);
 }

--- a/ow_plexil/src/plans/Pan.plp
+++ b/ow_plexil/src/plans/Pan.plp
@@ -10,7 +10,10 @@ Pan:
 {
   In Real Degrees;
 
-  Exit Lookup(AntennaFault);
+  PostCondition !Lookup(AntennaFault);
 
-  SynchronousCommand pan_antenna (Degrees);
+  if (!Lookup(AntennaFault)) SynchronousCommand pan_antenna (Degrees);
+  else log_error ("Command pan_antenna not sent to lander due to active antenna fault.");
+
+  
 }

--- a/ow_plexil/src/plans/Stow.plp
+++ b/ow_plexil/src/plans/Stow.plp
@@ -5,10 +5,12 @@
 // Stow the arm, which requires an unstow() first.  These commands simply move
 // the arm to specific coordinates.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 Stow:
 {
+  Exit Lookup(ArmFault);
+
   SynchronousCommand unstow();
   SynchronousCommand stow();
 }

--- a/ow_plexil/src/plans/Stow.plp
+++ b/ow_plexil/src/plans/Stow.plp
@@ -9,8 +9,13 @@
 
 Stow:
 {
-  Exit Lookup(ArmFault);
+  PostCondition !Lookup(ArmFault);
 
-  SynchronousCommand unstow();
-  SynchronousCommand stow();
+  if (!Lookup(ArmFault))
+  {
+    SynchronousCommand unstow();
+    SynchronousCommand stow();
+  }
+  else log_error ("Command stow not sent to lander due to active arm fault.");
+
 }

--- a/ow_plexil/src/plans/Tilt.plp
+++ b/ow_plexil/src/plans/Tilt.plp
@@ -4,10 +4,13 @@
 
 // Tilt antenna to specified degrees.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 Tilt:
 {
   In Real Degrees;
+
+  Exit Lookup(AntennaFault);
+
   SynchronousCommand tilt_antenna (Degrees);
 }

--- a/ow_plexil/src/plans/Tilt.plp
+++ b/ow_plexil/src/plans/Tilt.plp
@@ -10,7 +10,9 @@ Tilt:
 {
   In Real Degrees;
 
-  Exit Lookup(AntennaFault);
+  PostCondition !Lookup(AntennaFault);
 
-  SynchronousCommand tilt_antenna (Degrees);
+  if (!Lookup(AntennaFault)) SynchronousCommand tilt_antenna (Degrees);
+  else log_error ("Command tilt_antenna not sent to lander due to active antenna fault.");
+
 }

--- a/ow_plexil/src/plans/Unstow.plp
+++ b/ow_plexil/src/plans/Unstow.plp
@@ -7,19 +7,11 @@
 
 #include "plan-interface.h"
 
-Unstow: UncheckedSequence
+Unstow:
 {
-  //PreCondition !Lookup(ArmFault);
   PostCondition !Lookup(ArmFault);
 
-  if !Lookup(ArmFault)
-  {
-    SynchronousCommand unstow();
-  }
-  else
-  {
-    log_error ("Command unstow not sent to lander due to active arm fault.");
-  }
-  endif;
+  if (!Lookup(ArmFault)) SynchronousCommand unstow();
+  else log_error ("Command unstow not sent to lander due to active arm fault.");
 
 }

--- a/ow_plexil/src/plans/Unstow.plp
+++ b/ow_plexil/src/plans/Unstow.plp
@@ -9,18 +9,17 @@
 
 Unstow: UncheckedSequence
 {
+  //PreCondition !Lookup(ArmFault);
   PostCondition !Lookup(ArmFault);
 
-  Attempt:
+  if !Lookup(ArmFault)
   {
-    PreCondition !Lookup(ArmFault);
-
     SynchronousCommand unstow();
   }
-
-  if Attempt.outcome == FAILURE
+  else
   {
     log_error ("Command unstow not sent to lander due to active arm fault.");
   }
+  endif;
 
 }

--- a/ow_plexil/src/plans/Unstow.plp
+++ b/ow_plexil/src/plans/Unstow.plp
@@ -7,21 +7,15 @@
 
 #include "plan-interface.h"
 
-Unstow:
+Unstow: UncheckedSequence
 {
-
-  log_info ("testing");
 
   Attempt:
   {
     PreCondition !Lookup(ArmFault);
 
-    log_info ("testing 2");
-
     SynchronousCommand unstow();
   }
-
-  log_info ("Attempt outcome: ", Attempt.outcome);
 
   if Attempt.outcome == FAILURE
   {

--- a/ow_plexil/src/plans/Unstow.plp
+++ b/ow_plexil/src/plans/Unstow.plp
@@ -9,6 +9,7 @@
 
 Unstow: UncheckedSequence
 {
+  PostCondition !Lookup(ArmFault);
 
   Attempt:
   {

--- a/ow_plexil/src/plans/Unstow.plp
+++ b/ow_plexil/src/plans/Unstow.plp
@@ -9,7 +9,23 @@
 
 Unstow:
 {
-  Exit Lookup(ArmFault);
 
-  SynchronousCommand unstow();
+  log_info ("testing");
+
+  Attempt:
+  {
+    PreCondition !Lookup(ArmFault);
+
+    log_info ("testing 2");
+
+    SynchronousCommand unstow();
+  }
+
+  log_info ("Attempt outcome: ", Attempt.outcome);
+
+  if Attempt.outcome == FAILURE
+  {
+    log_error ("Command unstow not sent to lander due to active arm fault.");
+  }
+
 }

--- a/ow_plexil/src/plans/Unstow.plp
+++ b/ow_plexil/src/plans/Unstow.plp
@@ -5,9 +5,11 @@
 // Unstow the arm, which is moving it to a specified "ready" position from
 // wherever its current location.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 Unstow:
 {
+  Exit Lookup(ArmFault);
+
   SynchronousCommand unstow();
 }


### PR DESCRIPTION
Low level library plans now check for relevant faults before commanding the lander, and if a fault does prevent commanding, an error message is logged.

To test, inject a relevant fault before running Unstow.plx (for example), then run it and observe the error message print. Next, try running the .plx without the error and you should see the command run normally.