### PR TITLE
Oceanwater 788 - Explicit Unstow/Stow Plans

### DIFF
--- a/ow_plexil/src/plans/Continuous.plp
+++ b/ow_plexil/src/plans/Continuous.plp
@@ -23,7 +23,8 @@ Continuous:
     Arm:
     {
       Repeat true;
-      LibraryCall Stow();  // Stow does Unstow first
+      LibraryCall Unstow();
+      LibraryCall Stow();
     }
   }    
 }

--- a/ow_plexil/src/plans/Demo.plp
+++ b/ow_plexil/src/plans/Demo.plp
@@ -34,6 +34,7 @@ Demo:
   else log_error ("Failed to find ground, skipping grind and dig.");
   endif
   log_info ("Stowing arm...");
+  LibraryCall Unstow(); // For safety in stowing
   LibraryCall Stow();
   log_info ("Autonomy demo finished.");
 }

--- a/ow_plexil/src/plans/EuropaMission.plp
+++ b/ow_plexil/src/plans/EuropaMission.plp
@@ -168,6 +168,7 @@ EuropaMission: Concurrence
       if (! Lookup(GroundFound)) {
         // Note that the default value of GroundFound is false, so
         log_error ("Failed to find ground. Stowing arm and stopping.");
+        LibraryCall Unstow(); // For safety in stowing
         LibraryCall Stow();
         MissionInProgress = false;
       }
@@ -225,6 +226,7 @@ EuropaMission: Concurrence
     {
       SkipCondition
         (DidCrash && !Lookup(IsBootOK(Lookup(CheckpointWhen("ArmStowed")))));
+      LibraryCall Unstow(); // For safety in stowing
       LibraryCall Stow();
       set_checkpoint("ArmStowed");
       SynchronousCommand flush_checkpoints();

--- a/ow_plexil/src/plans/InitializeAntennaAndArm.plp
+++ b/ow_plexil/src/plans/InitializeAntennaAndArm.plp
@@ -30,6 +30,7 @@ InitializeAntennaAndArm:
   {
     Start !Lookup(ArmFault);
     log_info ("Stowing the arm...");
+    LibraryCall Unstow();
     LibraryCall Stow();
   }
 

--- a/ow_plexil/src/plans/ReferenceMission1.plp
+++ b/ow_plexil/src/plans/ReferenceMission1.plp
@@ -91,6 +91,7 @@ ReferenceMission1: Concurrence
       LibraryCall CollectSample (X = trench_x, Y = trench_y,
                                  GroundPos = ground_pos, Depth = 0.11,
                                  Length = trench_length, Parallel = parallel);
+      LibraryCall Unstow(); // For safety in stowing
       LibraryCall Stow();
       LibraryCall StartSampleAnalysis;
       Wait 2;  // Wait for (stubbed) sample analysis to finish.

--- a/ow_plexil/src/plans/ReferenceMission2.plp
+++ b/ow_plexil/src/plans/ReferenceMission2.plp
@@ -159,6 +159,7 @@ ReferenceMission2: Concurrence
       {
         Start BatteryOK && NoFaults;
         log_info ("** Stowing Arm **");
+        LibraryCall Unstow(); // For safety in stowing
         LibraryCall Stow;
       }
       Analyze:
@@ -174,6 +175,7 @@ ReferenceMission2: Concurrence
      {
        Start BatteryOK && NoFaults;
        log_info ("** Stowing Arm **");
+       LibraryCall Unstow(); // For safety in stowing
        LibraryCall Stow;
      }
     }

--- a/ow_plexil/src/plans/Stow.plp
+++ b/ow_plexil/src/plans/Stow.plp
@@ -9,6 +9,5 @@
 
 Stow:
 {
-  SynchronousCommand unstow();
   SynchronousCommand stow();
 }

--- a/ow_plexil/src/plans/TestActions.plp
+++ b/ow_plexil/src/plans/TestActions.plp
@@ -33,6 +33,7 @@ TestActions:
   // Receptacle coordinates
   LibraryCall Deliver (X = 0.55, Y = -0.3, Z = 0.84);
 
+  LibraryCall Unstow(); // For safety in stowing
   LibraryCall Stow();
 
   log_info ("Action test finished.");


### PR DESCRIPTION
Unstow removed from stow and added elsewhere for safety where stow was previously called alone.

Things to confirm:
- Everything should build obviously!
- Is everywhere I have added an unstow necessary?
- Did I miss any plans where there is a stow that might need an unstow for safety?