### PR TITLE
Oceanwater 792 - Permissive Fault Checks

### DIFF
--- a/ow_plexil/src/plans/Deliver.plp
+++ b/ow_plexil/src/plans/Deliver.plp
@@ -6,7 +6,7 @@
 // delivering the sample to its receptacle (which has specific coordinates) and
 // dumping tailings from trench digging.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 Deliver:
 {
@@ -14,5 +14,26 @@ Deliver:
   In Real Y;
   In Real Z;
 
-  SynchronousCommand deliver (X, Y, Z);
+  Boolean FaultDetected = false;
+
+  PostCondition !Lookup(ArmFault);
+
+  if Lookup(ArmFault)
+  { 
+    log_error ("Command deliver not sent to lander due to active arm fault(s).");
+    FaultDetected = true;
+  }
+
+  SendDeliver:
+  {
+    Start !Lookup(ArmFault);
+
+    if FaultDetected
+    {
+      log_info ("Arm fault(s) resolved, sending deliver command to lander...");
+    }
+
+    SynchronousCommand deliver (X, Y, Z);
+  }
+
 }

--- a/ow_plexil/src/plans/DigCircular.plp
+++ b/ow_plexil/src/plans/DigCircular.plp
@@ -4,7 +4,7 @@
 
 // Perform one pass of a circular digging action.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 DigCircular:
 {
@@ -14,5 +14,26 @@ DigCircular:
   In Real GroundPos;
   In Boolean Parallel;
 
-  SynchronousCommand dig_circular (X, Y, Depth, GroundPos, Parallel);
+  Boolean FaultDetected = false;
+
+  PostCondition !Lookup(ArmFault);
+
+  if Lookup(ArmFault)
+  { 
+    log_error ("Command dig_circular not sent to lander due to active arm fault(s).");
+    FaultDetected = true;
+  }
+
+  SendDigCircular:
+  {
+    Start !Lookup(ArmFault);
+
+    if FaultDetected
+    {
+      log_info ("Arm fault(s) resolved, sending dig_circular command to lander...");
+    }
+
+    SynchronousCommand dig_circular (X, Y, Depth, GroundPos, Parallel);
+  }
+
 }

--- a/ow_plexil/src/plans/DigLinear.plp
+++ b/ow_plexil/src/plans/DigLinear.plp
@@ -4,7 +4,7 @@
 
 // Perform one pass of a linear digging action.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 DigLinear:
 {
@@ -14,5 +14,26 @@ DigLinear:
   In Real Length;
   In Real GroundPos;
 
-  SynchronousCommand dig_linear (X, Y, Depth, Length, GroundPos);
+  Boolean FaultDetected = false;
+
+  PostCondition !Lookup(ArmFault);
+
+  if Lookup(ArmFault)
+  { 
+    log_error ("Command dig_linear not sent to lander due to active arm fault(s).");
+    FaultDetected = true;
+  }
+
+  SendDigLinear:
+  {
+    Start !Lookup(ArmFault);
+
+    if FaultDetected
+    {
+      log_info ("Arm fault(s) resolved, sending dig_linear command to lander...");
+    }
+
+    SynchronousCommand dig_linear (X, Y, Depth, Length, GroundPos);
+  }
+
 }

--- a/ow_plexil/src/plans/Grind.plp
+++ b/ow_plexil/src/plans/Grind.plp
@@ -4,7 +4,7 @@
 
 // Perform one pass with the grinding tool, using the given parameters.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 Grind:
 {
@@ -15,5 +15,26 @@ Grind:
   In Real GroundPos;
   In Boolean Parallel;
 
-  SynchronousCommand grind (X, Y, Depth, Length, Parallel, GroundPos);
+  Boolean FaultDetected = false;
+
+  PostCondition !Lookup(ArmFault);
+
+  if Lookup(ArmFault)
+  { 
+    log_error ("Command grind not sent to lander due to active arm fault(s).");
+    FaultDetected = true;
+  }
+
+  SendGrind:
+  {
+    Start !Lookup(ArmFault);
+
+    if FaultDetected
+    {
+      log_info ("Arm fault(s) resolved, sending grind command to lander...");
+    }
+
+    SynchronousCommand grind (X, Y, Depth, Length, Parallel, GroundPos);
+  }
+
 }

--- a/ow_plexil/src/plans/GuardedMove.plp
+++ b/ow_plexil/src/plans/GuardedMove.plp
@@ -5,7 +5,7 @@
 // Perform a guarded move with the given parameters.
 // A guarded move is typically used to find the ground.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 GuardedMove:
 {
@@ -17,6 +17,27 @@ GuardedMove:
   In Real DirZ;
   In Real SearchDistance;
 
-  SynchronousCommand guarded_move (X, Y, Z, DirX, DirY, DirZ, SearchDistance);
-  Wait 5; // Add some delay to make sure the status has been updated
+  Boolean FaultDetected = false;
+
+  PostCondition !Lookup(ArmFault);
+
+  if Lookup(ArmFault)
+  { 
+    log_error ("Command guarded_move not sent to lander due to active arm fault(s).");
+    FaultDetected = true;
+  }
+
+  SendGuardedMove:
+  {
+    Start !Lookup(ArmFault);
+
+    if FaultDetected
+    {
+      log_info ("Arm fault(s) resolved, sending guarded_move command to lander...");
+    }
+
+    SynchronousCommand guarded_move (X, Y, Z, DirX, DirY, DirZ, SearchDistance);
+    Wait 5; // Add some delay to make sure the status has been updated
+  }
+  
 }

--- a/ow_plexil/src/plans/Pan.plp
+++ b/ow_plexil/src/plans/Pan.plp
@@ -4,10 +4,32 @@
 
 // Pan the antenna to specified degrees.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 Pan:
 {
   In Real Degrees;
-  SynchronousCommand pan_antenna (Degrees);
+
+  Boolean FaultDetected = false;
+
+  PostCondition !Lookup(AntennaFault);
+
+  if Lookup(AntennaFault)
+  { 
+    log_error ("Command pan_antenna not sent to lander due to active antenna fault(s).");
+    FaultDetected = true;
+  }
+
+  SendPan:
+  {
+    Start !Lookup(AntennaFault);
+
+    if FaultDetected
+    {
+      log_info ("Antenna fault(s) resolved, sending pan_antenna command to lander...");
+    }
+
+    SynchronousCommand pan_antenna (Degrees);
+  }
+
 }

--- a/ow_plexil/src/plans/Stow.plp
+++ b/ow_plexil/src/plans/Stow.plp
@@ -5,10 +5,30 @@
 // Stow the arm, which requires an unstow() first.  These commands simply move
 // the arm to specific coordinates.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 Stow:
 {
-  SynchronousCommand unstow();
-  SynchronousCommand stow();
+  Boolean FaultDetected = false;
+
+  PostCondition !Lookup(ArmFault);
+
+  if Lookup(ArmFault)
+  { 
+    log_error ("Command stow not sent to lander due to active arm fault(s).");
+    FaultDetected = true;
+  }
+
+  SendStow:
+  {
+    Start !Lookup(ArmFault);
+
+    if FaultDetected
+    {
+      log_info ("Arm fault(s) resolved, sending stow command to lander...");
+    }
+
+    SynchronousCommand stow();
+  }
+
 }

--- a/ow_plexil/src/plans/Tilt.plp
+++ b/ow_plexil/src/plans/Tilt.plp
@@ -4,10 +4,32 @@
 
 // Tilt antenna to specified degrees.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 Tilt:
 {
   In Real Degrees;
-  SynchronousCommand tilt_antenna (Degrees);
+
+  Boolean FaultDetected = false;
+
+  PostCondition !Lookup(AntennaFault);
+
+  if Lookup(AntennaFault)
+  { 
+    log_error ("Command tilt_antenna not sent to lander due to active antenna fault(s).");
+    FaultDetected = true;
+  }
+
+  SendTilt:
+  {
+    Start !Lookup(AntennaFault);
+
+    if FaultDetected
+    {
+      log_info ("Antenna fault(s) resolved, sending tilt_antenna command to lander...");
+    }
+
+    SynchronousCommand tilt_antenna (Degrees);
+  }
+
 }

--- a/ow_plexil/src/plans/Unstow.plp
+++ b/ow_plexil/src/plans/Unstow.plp
@@ -9,16 +9,24 @@
 
 Unstow:
 {
+  Boolean FaultDetected = false;
+
   PostCondition !Lookup(ArmFault);
 
-  if Lookup(ArmFault) 
+  if Lookup(ArmFault)
+  { 
     log_error ("Command unstow not sent to lander due to active arm fault(s).");
+    FaultDetected = true;
+  }
 
-  CommandLander:
+  SendUnstow:
   {
     Start !Lookup(ArmFault);
 
-    log_info ("Arm fault(s) resolved, sending unstow command to lander...");
+    if FaultDetected
+    {
+      log_info ("Arm fault(s) resolved, sending unstow command to lander...");
+    }
 
     SynchronousCommand unstow();
   }

--- a/ow_plexil/src/plans/Unstow.plp
+++ b/ow_plexil/src/plans/Unstow.plp
@@ -5,9 +5,22 @@
 // Unstow the arm, which is moving it to a specified "ready" position from
 // wherever its current location.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 Unstow:
 {
-  SynchronousCommand unstow();
+  PostCondition !Lookup(ArmFault);
+
+  if Lookup(ArmFault) 
+    log_error ("Command unstow not sent to lander due to active arm fault(s).");
+
+  CommandLander:
+  {
+    Start !Lookup(ArmFault);
+
+    log_info ("Arm fault(s) resolved, sending unstow command to lander...");
+
+    SynchronousCommand unstow();
+  }
+
 }


### PR DESCRIPTION
This is an alternative solution to OCEANWATER 783 that does not cause certain plans to fail immediately. Instead, the library-level nodes wait for there to be no faults before sending the associated command to the lander, and print messages or errors to communicate what is happening to the user.

Unstow.plp has been tested and the rest follow the same pattern. They compile, but I have not run them all.