### PR TITLE
env: fix #70 improving mechanism for locating .plx files

### DIFF
--- a/ow_plexil/README.md
+++ b/ow_plexil/README.md
@@ -85,6 +85,11 @@ Launch the plan executive
     - for alternate terrains, other launch files are available:
       `atacama_y1a.launch`, `europa_terminator_workspace.launch`,
       `europa_test_dem.launch`.
+    - the environment variable `$PLEXIL_PLAN_DIR` is required to locate the
+      `.plx` files used by the executive. This environment varialbe is exported
+      by the env-hooks which are sourced when sourcing the catkin setup script,
+      and should point to a directory in the catkin develspace where the `.plx`
+      files are deployed.
 
   For OWLAT:
   Start ROS: ``` roscore ```

--- a/ow_plexil/env-hooks/60.ow_plexil.sh
+++ b/ow_plexil/env-hooks/60.ow_plexil.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-export PLEXIL_PLAN_DIR="$(catkin_find --first-only ow_plexil src/plans)"
+export PLEXIL_PLAN_DIR="$(catkin_find --first-only --etc plexil)"

--- a/ow_plexil/src/plexil-adapter/OwExecutive.cpp
+++ b/ow_plexil/src/plexil-adapter/OwExecutive.cpp
@@ -156,11 +156,11 @@ bool OwExecutive::initialize (const string& config_file)
   // Get plan library directory from the environment variable set by the ow_plexil env-hooks
   char *plexil_plan_dir_env = getenv("PLEXIL_PLAN_DIR");
   if(plexil_plan_dir_env == NULL) {
-      ROS_ERROR("Environment variable $PLEXIL_PLAN_DIR is not set.");
-      return false;
+    ROS_ERROR("Environment variable $PLEXIL_PLAN_DIR is not set.");
+    return false;
   }
 
-  PlexilDir = plexil_plan_dir_env+std::string("/");
+  PlexilDir = plexil_plan_dir_env+string("/");
 
   // Throw exceptions, DON'T assert
   Error::doThrowExceptions();

--- a/ow_plexil/src/plexil-adapter/OwExecutive.cpp
+++ b/ow_plexil/src/plexil-adapter/OwExecutive.cpp
@@ -23,6 +23,7 @@ using PLEXIL::Error;
 using PLEXIL::InterfaceSchema;
 
 // C++
+#include <stdlib.h>
 #include <fstream>
 #include <string>
 #include <iostream>
@@ -152,9 +153,14 @@ static void get_plexil_debug_config()
 
 bool OwExecutive::initialize (const string& config_file)
 {
-  // NOTE: this is the best we can do for now.
-  // ROS provides no API to locate the 'devel' directory.
-  PlexilDir = ros::package::getPath("ow_plexil") + "/../../../devel/etc/plexil/";
+  // Get plan library directory from the environment variable set by the ow_plexil env-hooks
+  char *plexil_plan_dir_env = getenv("PLEXIL_PLAN_DIR");
+  if(plexil_plan_dir_env == NULL) {
+      ROS_ERROR("Environment variable $PLEXIL_PLAN_DIR is not set.");
+      return false;
+  }
+
+  PlexilDir = plexil_plan_dir_env+std::string("/");
 
   // Throw exceptions, DON'T assert
   Error::doThrowExceptions();


### PR DESCRIPTION
## Overview

See #70 for additional details.

This could be further improved by standardizing a general use of `$PLEXIL_PLAN_DIR` as `$PLEXIL_PLAN_PATH`, in which case, each package which compiles `.plx` files can append its path to the search path for the plexil plan library. 

## Evaluation

### Context 

- Ubuntu 18.04, ROS Melodic
- OW Repo versions:
  - https://github.com/nasa/GSAP/commit/ea3d4ad1ce5cef2c0e7c1d0d087b0b0aaa142acf gsap/GSAP (v1.1.1-210-gea3d4ad)
  - https://github.com/nasa/irg_open/commit/737c75fa48f7f72bd8aef54b2faa6d41b5dcfd69 irg_open (8.0)
  - https://github.com/nasa/ow_autonomy/commit/23caa34c8c39d8298394d7aed5a564a5d9c0261e ow_autonomy (8.0-252-g23caa34)
  - https://github.com/nasa/ow_europa/commit/8b7c2f841b16c52746b3029240915feb872bb70e ow_europa (8.0-10-g8b7c2f8)
  - https://github.com/nasa/ow_simulator/commit/11acc19600fe6569ff0539468bc67a79e8224119 ow_simulator (v7.0.2-133-g11acc19)
  - plexil 77bbf96645b394b09182ce6b5ebb59b37265641e plexil/plexil (2020-09-02-plexil-4-before-reintegration-750-g77bbf966)

### Affirmative integration test:

```
shell 1 $> roslaunch ow europa_terminator.launch
shell 2 $> roslaunch ow_plexil ow_exec.launch
shell 2 in> ReferenceMission1.plx
```

Visually confirmed `ReferenceMission1` executing as expected.

#### Error condition test:

When `$PLEXIL_PLAN_DIR` is not set, `ow_executive` should fail:

```
shell 1 $> roslaunch ow europa_terminator.launch
shell 2 $> unset PLEXIL_PLAN_DIR
shell 2 $> roslaunch ow_plexil ow_exec.launch
shell 2 in> ReferenceMission1.plx
```

It fails:

```
process[terminal_selection_node-2]: started with pid [21448]
[ERROR] [1633015444.729614303]: Environment variable $PLEXIL_PLAN_DIR is not set.
[ERROR] [1633015444.729646349]: Could not initialize Plexil executive, shutting down.
```

## Contributor License Agreement

This contribution is published under the contribution terms of the NASA Open Source Agreement 1.3.