### PR TITLE
PLEXIL interface to lander lights

### DIFF
--- a/ow_plexil/src/plans/SetLightIntensity.plp
+++ b/ow_plexil/src/plans/SetLightIntensity.plp
@@ -1,0 +1,9 @@
+#include "lander-commands.h"
+
+SetLightIntensity:
+{
+  In String Side;
+  In Real Intensity;
+
+  SynchronousCommand set_light_intensity (Side, Intensity);
+}

--- a/ow_plexil/src/plans/TestLanderLights.plp
+++ b/ow_plexil/src/plans/TestLanderLights.plp
@@ -2,6 +2,24 @@
 
 TestLanderLights:
 {
-  set_light_intensity ("left", 0.0);
-  //  set_light_intensity ("right", 1.0);
+  log_info ("Starting TestLanderLights...");
+
+  // Tilt the antenna so that the lights aim on the lander body.
+  LibraryCall Tilt (Degrees = 60.0);
+
+  log_info ("Turning lights off...");
+  LibraryCall SetLightIntensity (Side = "left", Intensity = 0.0);
+  LibraryCall SetLightIntensity (Side = "right", Intensity = 0.0);
+  Wait 2;
+
+  log_info ("Setting each to different levels...");
+  LibraryCall SetLightIntensity (Side = "left", Intensity = 0.25);
+  LibraryCall SetLightIntensity (Side = "right", Intensity = 0.75);
+  Wait 2;
+
+  log_info ("Setting both to full intensity...");
+  LibraryCall SetLightIntensity (Side = "left", Intensity = 1.0);
+  LibraryCall SetLightIntensity (Side = "right", Intensity = 1.0);
+
+  log_info ("Finished TestLanderLights.");
 }

--- a/ow_plexil/src/plans/TestLanderLights.plp
+++ b/ow_plexil/src/plans/TestLanderLights.plp
@@ -1,0 +1,7 @@
+#include "plan-interface.h"
+
+TestLanderLights:
+{
+  set_light_intensity ("left", 0.0);
+  //  set_light_intensity ("right", 1.0);
+}

--- a/ow_plexil/src/plans/lander-commands.h
+++ b/ow_plexil/src/plans/lander-commands.h
@@ -8,9 +8,11 @@
 // All available PLEXIL commands to the lander.  This is essentially the
 // lander's command interface.
 
-// Note that PLEXIL commands are asynchronous by design.  In general, autonomy
-// plans should not call these directly, but rather user the Library interface
-// that wraps these commands; this is defined in plan-interface.h.
+// Note that in PLEXIL, commands are asynchronous by design.
+// Typically, OceanWATERS plans should not call the following commands
+// directly, but instead use the Library interface (defined in
+// plan-interface.h) that wraps these commands in a way that they
+// called synchronously.
 
 Command tilt_antenna (Real degrees);
 Command pan_antenna (Real degrees);
@@ -55,8 +57,13 @@ Command unstow();
 // Move from "ready" position to stowed position; requires unstow() first
 Command stow();
 
-//processes number of images already taken with the stereo camera to find the 3d point to sample
-//filter_type can either be Dark or Brown, (Dark chooses dark spots, brown chooses brown spots).
+// Processes number of images already taken with the stereo camera to
+// find the 3d point to sample.  filter_type can either be "Dark" or
+// "Brown".  (Dark chooses dark spots, brown chooses brown spots).
 Real [3] Command identify_sample_location(Integer num_images, String filter_type);
+
+// Set spotlight intensity
+Command set_light_intensity (String side,     // "left" or "right"
+			     Real intensity); // 0.0 to 1.0.  0 is off.
 
 #endif

--- a/ow_plexil/src/plans/plan-interface.h
+++ b/ow_plexil/src/plans/plan-interface.h
@@ -17,6 +17,8 @@ Command log_error (...);
 
 // PLEXIL library for lander operations.
 
+LibraryAction SetLightIntensity (In String Side,
+				 In Real Intensity);
 LibraryAction Tilt (In Real Degrees);
 LibraryAction Pan  (In Real Degrees);
 LibraryAction Stow ();

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -263,12 +263,14 @@ static void set_light_intensity (Command* cmd, AdapterExecInterface* intf)
   const vector<Value>& args = cmd->getArgValues();
   args[0].getValue (side);
   args[1].getValue (intensity);
-  if (side == "left" || side == "right") {
-    ROS_ERROR ("set_light_intensity: side should be 'left' or 'right'");
+  if (side != "left" && side != "right") {
+    ROS_ERROR ("set_light_intensity: side was %s, should be 'left' or 'right'",
+	       side.c_str());
     valid_args = false;
   }
-  if (intensity >= 0.0 && intensity <= 1.0) {
-    ROS_ERROR ("set_light_intensity: intensity should be in range [0.0 1.0]");
+  if (intensity < 0.0 || intensity > 1.0) {
+    ROS_ERROR ("set_light_intensity: intensity was %f, "
+	       "should be in range [0.0 1.0]", intensity);
     valid_args = false;
   }
   if (valid_args) {

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -265,12 +265,12 @@ static void set_light_intensity (Command* cmd, AdapterExecInterface* intf)
   args[1].getValue (intensity);
   if (side != "left" && side != "right") {
     ROS_ERROR ("set_light_intensity: side was %s, should be 'left' or 'right'",
-	       side.c_str());
+               side.c_str());
     valid_args = false;
   }
   if (intensity < 0.0 || intensity > 1.0) {
     ROS_ERROR ("set_light_intensity: intensity was %f, "
-	       "should be in range [0.0 1.0]", intensity);
+               "should be in range [0.0 1.0]", intensity);
     valid_args = false;
   }
   if (valid_args) {
@@ -330,7 +330,7 @@ bool OwAdapter::initialize()
                                           identify_sample_location);
   g_configuration->registerCommandHandler("take_picture", take_picture);
   g_configuration->registerCommandHandler("set_light_intensity",
-					  set_light_intensity);
+                                          set_light_intensity);
   OwInterface::instance()->setCommandStatusCallback (command_status_callback);
   debugMsg("OwAdapter", " initialized.");
   return true;

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -140,7 +140,7 @@ static void stow (Command* cmd, AdapterExecInterface* intf)
 {
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwInterface::instance()->stow (CommandId);
-  send_ack_once(*cr);
+  acknowledge_command_sent(*cr);
 
 }
 
@@ -148,7 +148,7 @@ static void unstow (Command* cmd, AdapterExecInterface* intf)
 {
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwInterface::instance()->unstow (CommandId);
-  send_ack_once(*cr);
+  acknowledge_command_sent(*cr);
 }
 
 static void guarded_move (Command* cmd, AdapterExecInterface* intf)
@@ -165,7 +165,7 @@ static void guarded_move (Command* cmd, AdapterExecInterface* intf)
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwInterface::instance()->guardedMove (x, y, z, dir_x, dir_y, dir_z,
                                         search_distance, CommandId);
-  send_ack_once(*cr);
+  acknowledge_command_sent(*cr);
 }
 
 static void grind (Command* cmd, AdapterExecInterface* intf)
@@ -182,7 +182,7 @@ static void grind (Command* cmd, AdapterExecInterface* intf)
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwInterface::instance()->grind(x, y, depth, length, parallel, ground_pos,
                                  CommandId);
-  send_ack_once(*cr);
+  acknowledge_command_sent(*cr);
 }
 
 static void dig_circular (Command* cmd, AdapterExecInterface* intf)
@@ -198,7 +198,7 @@ static void dig_circular (Command* cmd, AdapterExecInterface* intf)
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwInterface::instance()->digCircular(x, y, depth, ground_position, parallel,
                                        CommandId);
-  send_ack_once(*cr);
+  acknowledge_command_sent(*cr);
 }
 
 static void dig_linear (Command* cmd, AdapterExecInterface* intf)
@@ -213,7 +213,7 @@ static void dig_linear (Command* cmd, AdapterExecInterface* intf)
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwInterface::instance()->digLinear(x, y, depth, length, ground_position,
                                      CommandId);
-  send_ack_once(*cr);
+  acknowledge_command_sent(*cr);
 }
 
 static void deliver (Command* cmd, AdapterExecInterface* intf)
@@ -225,7 +225,7 @@ static void deliver (Command* cmd, AdapterExecInterface* intf)
   args[2].getValue(z);
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwInterface::instance()->deliver (x, y, z, CommandId);
-  send_ack_once(*cr);
+  acknowledge_command_sent(*cr);
 }
 
 static void tilt_antenna (Command* cmd, AdapterExecInterface* intf)
@@ -235,7 +235,7 @@ static void tilt_antenna (Command* cmd, AdapterExecInterface* intf)
   args[0].getValue (degrees);
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwInterface::instance()->tiltAntenna (degrees, CommandId);
-  send_ack_once(*cr);
+  acknowledge_command_sent(*cr);
 }
 
 static void pan_antenna (Command* cmd, AdapterExecInterface* intf)
@@ -245,14 +245,40 @@ static void pan_antenna (Command* cmd, AdapterExecInterface* intf)
   args[0].getValue (degrees);
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwInterface::instance()->panAntenna (degrees, CommandId);
-  send_ack_once(*cr);
+  acknowledge_command_sent(*cr);
 }
 
 static void take_picture (Command* cmd, AdapterExecInterface* intf)
 {
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwInterface::instance()->takePicture (CommandId);
-  send_ack_once(*cr);
+  acknowledge_command_sent(*cr);
+}
+
+static void set_light_intensity (Command* cmd, AdapterExecInterface* intf)
+{
+  bool valid_args = true;
+  string side;
+  double intensity;
+  const vector<Value>& args = cmd->getArgValues();
+  args[0].getValue (side);
+  args[1].getValue (intensity);
+  if (side == "left" || side == "right") {
+    ROS_ERROR ("set_light_intensity: side should be 'left' or 'right'");
+    valid_args = false;
+  }
+  if (intensity >= 0.0 && intensity <= 1.0) {
+    ROS_ERROR ("set_light_intensity: intensity should be in range [0.0 1.0]");
+    valid_args = false;
+  }
+  if (valid_args) {
+    unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
+    OwInterface::instance()->setLightIntensity (side, intensity, CommandId);
+    acknowledge_command_sent(*cr);
+  }
+  else {
+    acknowledge_command_denied (cmd, intf);
+  }
 }
 
 static void identify_sample_location (Command* cmd, AdapterExecInterface* intf)
@@ -276,7 +302,7 @@ static void identify_sample_location (Command* cmd, AdapterExecInterface* intf)
   // Contstruct a Value type vector for plexil before returning the result
   Value value_point_vector = Value(point_vector);
   intf->handleCommandReturn(cmd, value_point_vector);
-  send_ack_once(*cr);
+  acknowledge_command_sent(*cr);
 }
 
 OwAdapter::OwAdapter(AdapterExecInterface& execInterface,
@@ -301,6 +327,8 @@ bool OwAdapter::initialize()
   g_configuration->registerCommandHandler("identify_sample_location",
                                           identify_sample_location);
   g_configuration->registerCommandHandler("take_picture", take_picture);
+  g_configuration->registerCommandHandler("set_light_intensity",
+					  set_light_intensity);
   OwInterface::instance()->setCommandStatusCallback (command_status_callback);
   debugMsg("OwAdapter", " initialized.");
   return true;

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -598,7 +598,7 @@ void OwInterface::deliverAction (double x, double y, double z, int id)
   goal.delivery.z = z;
 
   ROS_INFO ("Starting Deliver(x=%.2f, y=%.2f, z=%.2f)", x, y, z);
-  
+
   runAction<actionlib::SimpleActionClient<DeliverAction>,
             DeliverGoal,
             DeliverResultConstPtr,
@@ -634,7 +634,7 @@ void OwInterface::digLinearAction (double x, double y,
   ROS_INFO ("Starting DigLinear"
 	    "(x=%.2f, y=%.2f, depth=%.2f, length=%.2f, ground_pos=%.2f)",
 	    x, y, depth, length, ground_pos);
-  
+
   runAction<actionlib::SimpleActionClient<DigLinearAction>,
             DigLinearGoal,
             DigLinearResultConstPtr,
@@ -668,7 +668,7 @@ void OwInterface::digCircularAction (double x, double y, double depth,
   ROS_INFO ("Starting DigCircular"
 	    "(x=%.2f, y=%.2f, depth=%.2f, parallel=%s, ground_pos=%.2f)",
 	    x, y, depth, (parallel ? "true" : "false"), ground_pos);
-  
+
   runAction<actionlib::SimpleActionClient<DigCircularAction>,
             DigCircularGoal,
             DigCircularResultConstPtr,
@@ -747,7 +747,7 @@ void OwInterface::grindAction (double x, double y, double depth, double length,
   ROS_INFO ("Starting Grind"
 	    "(x=%.2f, y=%.2f, depth=%.2f, length=%.2f, parallel=%s, ground_pos=%.2f)",
 	    x, y, depth, length, (parallel ? "true" : "false"), ground_pos);
-  
+
   runAction<actionlib::SimpleActionClient<GrindAction>,
             GrindGoal,
             GrindResultConstPtr,
@@ -785,7 +785,7 @@ void OwInterface::guardedMoveAction (double x, double y, double z,
 	    "(x=%.2f, y=%.2f, z=%.2f, dir_x=%.2f, dir_y=%.2f,"
 	    "dir_z=%.2f, search_dist=%.2f)",
 	    x, y, z, dir_x, dir_y, dir_z, search_dist);
-  
+
   runAction<actionlib::SimpleActionClient<GuardedMoveAction>,
             GuardedMoveGoal,
             GuardedMoveResultConstPtr,
@@ -843,6 +843,12 @@ void OwInterface::identifySampleLocationAction (int num_images,
      identify_sample_location_done_cb<IdentifySampleLocation,
                                       ow_plexil::IdentifyLocationResultConstPtr>);
 }
+
+
+void OwInterface::setLightIntensity (const string& side, double intensity, int id)
+{
+}
+
 
 double OwInterface::getTilt () const
 {

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -59,9 +59,9 @@ void OwInterface::callService (ros::ServiceClient client, Service srv,
   // outlives its caller.  Assumes that service is not already running; this is
   // checked upstream.
 
-  ROS_INFO("  Starting ROS service %s", name.c_str());
+  ROS_INFO("Starting ROS service %s", name.c_str());
   if (client.call (srv)) { // blocks
-    ROS_INFO("  %s returned: %d, %s", name.c_str(), srv.response.success,
+    ROS_INFO("%s returned: %d, %s", name.c_str(), srv.response.success,
              srv.response.message.c_str());  // make DEBUG later
   }
   else {
@@ -486,7 +486,7 @@ void OwInterface::initialize()
 
   if (not initialized) {
 
-    for (auto name : LanderOpNames) {
+    for (const string& name : LanderOpNames) {
       registerLanderOperation (name);
     }
 
@@ -899,13 +899,8 @@ void OwInterface::setLightIntensity (const string& side, double intensity, int i
     ow_lander::Light srv;
     srv.request.name = side;
     srv.request.intensity = intensity;
-    //    thread service_thread (&OwInterface::callService<ow_lander::Light>,
-    //                           client, srv, Op_SetLightIntensity, id);
-    thread service_thread ([&] () {
-			     callService<ow_lander::Light> (client, srv,
-							    Op_SetLightIntensity,
-							    id);
-			   });
+    thread service_thread (&OwInterface::callService<ow_lander::Light>,
+			   this, client, srv, Op_SetLightIntensity, id);
     service_thread.detach();
   }
 }

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -53,7 +53,7 @@ static bool within_tolerance (double val1, double val2, double tolerance)
 
 template<typename Service>
 void OwInterface::callService (ros::ServiceClient client, Service srv,
-			       string name, int id)
+                               string name, int id)
 {
   // NOTE: arguments are copies because this function is called in a thread that
   // outlives its caller.  Assumes that service is not already running; this is
@@ -675,8 +675,8 @@ void OwInterface::digLinearAction (double x, double y,
   goal.ground_position = ground_pos;
 
   ROS_INFO ("Starting DigLinear"
-	    "(x=%.2f, y=%.2f, depth=%.2f, length=%.2f, ground_pos=%.2f)",
-	    x, y, depth, length, ground_pos);
+            "(x=%.2f, y=%.2f, depth=%.2f, length=%.2f, ground_pos=%.2f)",
+            x, y, depth, length, ground_pos);
 
   runAction<actionlib::SimpleActionClient<DigLinearAction>,
             DigLinearGoal,
@@ -709,8 +709,8 @@ void OwInterface::digCircularAction (double x, double y, double depth,
   goal.parallel = parallel;
 
   ROS_INFO ("Starting DigCircular"
-	    "(x=%.2f, y=%.2f, depth=%.2f, parallel=%s, ground_pos=%.2f)",
-	    x, y, depth, (parallel ? "true" : "false"), ground_pos);
+            "(x=%.2f, y=%.2f, depth=%.2f, parallel=%s, ground_pos=%.2f)",
+            x, y, depth, (parallel ? "true" : "false"), ground_pos);
 
   runAction<actionlib::SimpleActionClient<DigCircularAction>,
             DigCircularGoal,
@@ -788,8 +788,8 @@ void OwInterface::grindAction (double x, double y, double depth, double length,
   goal.ground_position = ground_pos;
 
   ROS_INFO ("Starting Grind"
-	    "(x=%.2f, y=%.2f, depth=%.2f, length=%.2f, parallel=%s, ground_pos=%.2f)",
-	    x, y, depth, length, (parallel ? "true" : "false"), ground_pos);
+            "(x=%.2f, y=%.2f, depth=%.2f, length=%.2f, parallel=%s, ground_pos=%.2f)",
+            x, y, depth, length, (parallel ? "true" : "false"), ground_pos);
 
   runAction<actionlib::SimpleActionClient<GrindAction>,
             GrindGoal,
@@ -825,9 +825,9 @@ void OwInterface::guardedMoveAction (double x, double y, double z,
   goal.search_distance = search_dist;
 
   ROS_INFO ("Starting GuardedMove"
-	    "(x=%.2f, y=%.2f, z=%.2f, dir_x=%.2f, dir_y=%.2f,"
-	    "dir_z=%.2f, search_dist=%.2f)",
-	    x, y, z, dir_x, dir_y, dir_z, search_dist);
+            "(x=%.2f, y=%.2f, z=%.2f, dir_x=%.2f, dir_y=%.2f,"
+            "dir_z=%.2f, search_dist=%.2f)",
+            x, y, z, dir_x, dir_y, dir_z, search_dist);
 
   runAction<actionlib::SimpleActionClient<GuardedMoveAction>,
             GuardedMoveGoal,
@@ -900,7 +900,7 @@ void OwInterface::setLightIntensity (const string& side, double intensity, int i
     srv.request.name = side;
     srv.request.intensity = intensity;
     thread service_thread (&OwInterface::callService<ow_lander::Light>,
-			   this, client, srv, Op_SetLightIntensity, id);
+                           this, client, srv, Op_SetLightIntensity, id);
     service_thread.detach();
   }
 }

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -88,8 +88,7 @@ class OwInterface : public PlexilInterface
   void stow (int id);
   void unstow (int id);
   void deliver (double x, double y, double z, int id);
-  void takePanorama (double elev_lo, double elev_hi,
-                     double lat_overlap, double vert_overlap);
+  void setLightIntensity (const std::string& side, double intensity, int id);
 
   // State/Lookup interface
   double getTilt () const;

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -73,7 +73,7 @@ class OwInterface : public PlexilInterface
   void guardedMove (double x, double y, double z,
                     double direction_x, double direction_y, double direction_z,
                     double search_distance, int id);
-  std::vector<double> identifySampleLocation (int num_images, 
+  std::vector<double> identifySampleLocation (int num_images,
                                               const std::string& filter_type,
                                               int id);
   void tiltAntenna (double degrees, int id);
@@ -109,6 +109,9 @@ class OwInterface : public PlexilInterface
   bool softTorqueLimitReached (const std::string& joint_name) const;
 
  private:
+  template<typename Service>
+  void callService (ros::ServiceClient, Service, std::string name, int id);
+  
   void unstowAction (int id);
   void stowAction (int id);
   void grindAction (double x, double y, double depth, double length,
@@ -116,7 +119,7 @@ class OwInterface : public PlexilInterface
   void guardedMoveAction (double x, double y, double z,
                           double dir_x, double dir_y, double dir_z,
                           double search_distance, int id);
-  void identifySampleLocationAction (int num_images, 
+  void identifySampleLocationAction (int num_images,
                                      const std::string& filter_type, int id);
   void digCircularAction (double x, double y, double depth,
                           double ground_pos, bool parallel, int id);

--- a/ow_plexil/src/plexil-adapter/adapter_support.h
+++ b/ow_plexil/src/plexil-adapter/adapter_support.h
@@ -52,9 +52,9 @@ new_command_record(PLEXIL::Command*, PLEXIL::AdapterExecInterface*);
 // Registry of all commands currently in execution by testbed.
 extern std::map<int, std::unique_ptr<CommandRecord>> CommandRegistry;
 
-// Acknowledge a command issued by a Plexil plan, in a way that guarantees only
-// one acknowledgment (acks are not idempotent).
-void send_ack_once(CommandRecord&, bool skip=false);
+void acknowledge_command_sent(CommandRecord&, bool skip=false);
+
+void acknowledge_command_denied (PLEXIL::Command*, PLEXIL::AdapterExecInterface*);
 
 // Function to call when a command finishes execution in testbed.
 void command_status_callback (int id, bool success);


### PR DESCRIPTION
The lights can now be commanded from PLEXIL.  You specify the side (right or left) and intensity (0..1).

To test:
 - start any simulator world
 - zoom in so that you can see the lander lights and the top of the lander
 - run the test plan: `roslaunch ow_plexil ow_exec.launch plan:=TestLanderLights.plx`
 - textual output and visual results should be self-explanatory

Note: code contains some related and unrelated minor renamings, refactorings, and comment clarifications.