### PR TITLE
Better error reporting in ReferenceMission1 

### DIFF
--- a/ow_plexil/src/plans/IdentifySampleTarget.plp
+++ b/ow_plexil/src/plans/IdentifySampleTarget.plp
@@ -33,7 +33,7 @@ IdentifySampleTarget:
   LibraryCall PanAndShoot(PanAngle = c_pan + delta);
   SynchronousCommand result = identify_sample_location(3, FilterType);
 
-  if (isKnown(result[0] && isKnown(result[1] && isKnown(result[2])){
+  if (isKnown(result[0]) && isKnown(result[1]) && isKnown(result[2])) {
     // Guarded move is an attempt to find the ground position.  The chosen start
     // position is based on the result from identify_sample_location.
     LibraryCall Unstow();

--- a/ow_plexil/src/plans/IdentifySampleTarget.plp
+++ b/ow_plexil/src/plans/IdentifySampleTarget.plp
@@ -24,16 +24,16 @@ IdentifySampleTarget:
   Post Lookup (GroundFound);
 
   // Take pictures in front of the lander for processing in
-  // identify_sample_location.  An alternative would be to create a new
-  // TakePicture command that waits for the pointcloud, or modifying the current
-  // one.
+  // identify_sample_location.  An alternative would be to create a
+  // new TakePicture command that waits for the pointcloud, or
+  // modifying the current one.
   LibraryCall Tilt(Degrees = c_tilt);
   LibraryCall PanAndShoot(PanAngle = c_pan - delta);
   LibraryCall PanAndShoot(PanAngle = c_pan);
   LibraryCall PanAndShoot(PanAngle = c_pan + delta);
   SynchronousCommand result = identify_sample_location(3, FilterType);
 
-  if (isKnown(result[2])){
+  if (isKnown(result[0] && isKnown(result[1] && isKnown(result[2])){
     // Guarded move is an attempt to find the ground position.  The chosen start
     // position is based on the result from identify_sample_location.
     LibraryCall Unstow();
@@ -43,7 +43,7 @@ IdentifySampleTarget:
 
     //check for ground position
     if (Lookup (GroundFound)) GroundPos = Lookup (GroundPosition);
-    else log_warning ("GuardedMove failed to find ground.");
+    else log_error ("IdentifySampleTarget: GuardedMove failed to find ground.");
     endif;
 
     // The chosen X/Y sampling location, as well as choice for Parallel trench
@@ -51,6 +51,7 @@ IdentifySampleTarget:
     Y = result[1];
     Parallel = true;  // arbitrary for now
   }
+  else log_error ("IdentifySampleTarget: failed to find one.");
   endif;
 
 }

--- a/ow_plexil/src/plans/ReferenceMission1.plp
+++ b/ow_plexil/src/plans/ReferenceMission1.plp
@@ -82,7 +82,7 @@ ReferenceMission1: Concurrence
                                       GroundPos = ground_pos,
                                       Parallel = parallel,
                                       FilterType = "Dark");
-    if (Lookup(GroundFound)) {
+    if (isKnown(ground_pos)) {
       LibraryCall DigTrench (X = trench_x, Y = trench_y, GroundPos = ground_pos,
                              Length = trench_length, BiteDepth = 0.05,
                              NumPasses = 2, Parallel = parallel);
@@ -98,7 +98,7 @@ ReferenceMission1: Concurrence
     }
     else
     {
-      log_error ("Failed to find ground, aborting.");
+      log_error ("Mission aborted because a sampling location was not found.");
     }
     endif
     MissionInProgress = false;


### PR DESCRIPTION
This is an improvement to a few error messages in ReferenceMission1 and the checks that trigger them.  Gone is the misleading "failed to find ground" message that would occur when  GuardedMove wasn't even attempted.

Two tests:

1. Run ReferenceMission1 with your current Plexil 4.6 which has a bug that will trigger the revised error messages.

2. Run again after Plexil 4.6 is fixed (pending message from me and your updating your Plexil installation), and you should see the plan run successfully as it did before.
