### PR TITLE
Plexil interface for ArmMoveJoint and ArmMoveJoints actions

### DIFF
--- a/ow_plexil/src/plans/ArmMoveJoint.plp
+++ b/ow_plexil/src/plans/ArmMoveJoint.plp
@@ -1,0 +1,37 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// A test plan for the ROS action ArmMoveJoint
+// that moves a single arm joint
+
+#include "plan-interface.h"
+
+ArmMoveJoint:
+{
+  In Boolean Relative;
+  In Integer Joint;
+  In Real Angle;
+
+  Boolean FaultDetected = false;
+
+  PostCondition !Lookup(ArmFault);
+
+  if Lookup(ArmFault)
+  {
+    log_error ("Command arm_move_joint not sent to lander due to active arm fault(s).");
+    FaultDetected = true;
+  }
+
+  SendArmMoveJoint:
+  {
+    Start !Lookup(ArmFault);
+
+    if FaultDetected
+    {
+      log_info ("Arm fault(s) resolved, sending arm_move_joint command to lander...");
+    }
+    
+    SynchronousCommand arm_move_joint (Relative, Joint, Angle);
+  }
+}

--- a/ow_plexil/src/plans/ArmMoveJoint.plp
+++ b/ow_plexil/src/plans/ArmMoveJoint.plp
@@ -2,7 +2,7 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// A test plan for the ROS action ArmMoveJoint
+// A plan for the ROS action ArmMoveJoint
 // that moves a single arm joint
 
 #include "plan-interface.h"

--- a/ow_plexil/src/plans/ArmMoveJoints.plp
+++ b/ow_plexil/src/plans/ArmMoveJoints.plp
@@ -1,0 +1,48 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// A test plan for the ROS action ArmMoveJoints
+// that commands the 6 arm joints both sequentially and in parallel
+
+#include "plan-interface.h"
+
+ArmMoveJoints:
+{
+  In Boolean Relative;
+  In Real Angles[6];
+
+  Boolean FaultDetected = false;
+  
+  PostCondition !Lookup(ArmFault);
+
+  if Lookup(ArmFault)
+  {
+    log_error("Command arm_move_joints not sent to lander due to active arm fault(s).");
+    FaultDetected = true;
+  }
+
+  SendArmMoveJoints:
+  {
+    Start !Lookup(ArmFault);
+
+    if FaultDetected
+    {
+      log_info ("Arm fault(s) resolved, sending arm_move_joints command to lander...");
+    }
+    
+    SynchronousCommand arm_move_joints(Relative, Angles[6]);
+  }
+
+  SendArmMoveJointsParallel: Concurrence
+  {
+    Start !Lookup(ArmFault);
+
+    if FaultDetected
+    {
+      log_info ("Arm fault(s) resolved, sending arm_move_joints command to lander...");
+    }
+    
+    SynchronousCommand arm_move_joints (Relative, Angles[6]);
+  }
+}

--- a/ow_plexil/src/plans/ArmMoveJoints.plp
+++ b/ow_plexil/src/plans/ArmMoveJoints.plp
@@ -31,7 +31,7 @@ ArmMoveJoints:
       log_info ("Arm fault(s) resolved, sending arm_move_joints command to lander...");
     }
     
-    SynchronousCommand arm_move_joints (Relative, Angles[6]);
+    SynchronousCommand arm_move_joints (Relative, Angles);
   }
 
   SendArmMoveJointsParallel: Concurrence
@@ -43,6 +43,6 @@ ArmMoveJoints:
       log_info ("Arm fault(s) resolved, sending arm_move_joints command to lander...");
     }
     
-    SynchronousCommand arm_move_joints (Relative, Angles[6]);
+    SynchronousCommand arm_move_joints (Relative, Angles);
   }
 }

--- a/ow_plexil/src/plans/ArmMoveJoints.plp
+++ b/ow_plexil/src/plans/ArmMoveJoints.plp
@@ -18,7 +18,7 @@ ArmMoveJoints:
 
   if Lookup(ArmFault)
   {
-    log_error("Command arm_move_joints not sent to lander due to active arm fault(s).");
+    log_error ("Command arm_move_joints not sent to lander due to active arm fault(s).");
     FaultDetected = true;
   }
 
@@ -31,7 +31,7 @@ ArmMoveJoints:
       log_info ("Arm fault(s) resolved, sending arm_move_joints command to lander...");
     }
     
-    SynchronousCommand arm_move_joints(Relative, Angles[6]);
+    SynchronousCommand arm_move_joints (Relative, Angles[6]);
   }
 
   SendArmMoveJointsParallel: Concurrence

--- a/ow_plexil/src/plans/ArmMoveJoints.plp
+++ b/ow_plexil/src/plans/ArmMoveJoints.plp
@@ -2,7 +2,7 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// A test plan for the ROS action ArmMoveJoints
+// A plan for the ROS action ArmMoveJoints
 // that commands the 6 arm joints both sequentially and in parallel
 
 #include "plan-interface.h"

--- a/ow_plexil/src/plans/ArmMoveJoints.plp
+++ b/ow_plexil/src/plans/ArmMoveJoints.plp
@@ -33,16 +33,4 @@ ArmMoveJoints:
     
     SynchronousCommand arm_move_joints (Relative, Angles);
   }
-
-  SendArmMoveJointsParallel: Concurrence
-  {
-    Start !Lookup(ArmFault);
-
-    if FaultDetected
-    {
-      log_info ("Arm fault(s) resolved, sending arm_move_joints command to lander...");
-    }
-    
-    SynchronousCommand arm_move_joints (Relative, Angles);
-  }
 }

--- a/ow_plexil/src/plans/TestArmMoveJoint.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoint.plp
@@ -48,21 +48,15 @@ TestArmMoveJoint:
 
     LibraryCall Stow();
 
-    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
-
     LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.1);
-
-    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
 
     LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.2);
 
-    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
-
     LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.3);
 
-    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
+    log_info ("Second and final test finished, stowing...");
 
-    log_info ("Second and final test finished.");
+    LibraryCall Stow();
   }
 
   log_info ("TestArmMoveJoint plan finished.");

--- a/ow_plexil/src/plans/TestArmMoveJoint.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoint.plp
@@ -1,0 +1,28 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// A test plan for the ROS action ArmMoveJoint
+// that moves the individual arm joints
+
+#include "plan-interface.h"
+
+TestArmMoveJoint:
+{
+  log_info ("Starting ArmMoveJoint demo...");
+
+  // Moves the individuals joints to a certain angle (in radians)
+  LibraryCall ArmMoveJoint (Relative=true, Joint=1, Angle=0.0);
+  
+  LibraryCall ArmMoveJoint (Relative=true, Joint=2, Angle=-0.5);
+
+  LibraryCall ArmMoveJoint (Relative=true, Joint=3, Angle=0.0);
+
+  LibraryCall ArmMoveJoint (Relative=true, Joint=4, Angle=2.0);
+
+  LibraryCall ArmMoveJoint (Relative=true, Joint=5, Angle=0.0);
+
+  LibraryCall ArmMoveJoint (Relative=true, Joint=6, Angle=0.0);
+
+  log_info ("ArmMoveJoint demo finished.");
+}

--- a/ow_plexil/src/plans/TestArmMoveJoint.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoint.plp
@@ -26,7 +26,7 @@ TestArmMoveJoint:
 
     LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0);
 
-    LibraryCall ArmMoveJoint (Relative=true, Joint=1, Angle=0.5);
+    LibraryCall ArmMoveJoint (Relative=true, Joint=1, Angle=0.2);
 
     LibraryCall ArmMoveJoint (Relative=true, Joint=2, Angle=0.0);
 

--- a/ow_plexil/src/plans/TestArmMoveJoint.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoint.plp
@@ -21,9 +21,11 @@ TestArmMoveJoint:
   TestArmMoveJointSeq:
   {
     log_info ("Starting first ArmMoveJoint test...");
-  
-    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=-1.0);
-  
+
+    LibraryCall Stow();
+
+    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0);
+
     LibraryCall ArmMoveJoint (Relative=true, Joint=1, Angle=0.5);
 
     LibraryCall ArmMoveJoint (Relative=true, Joint=2, Angle=0.0);
@@ -33,19 +35,18 @@ TestArmMoveJoint:
     LibraryCall ArmMoveJoint (Relative=true, Joint=4, Angle=0.0);
 
     LibraryCall ArmMoveJoint (Relative=true, Joint=5, Angle=0.0);
-  
-    log_info ("First test finished.");
+
+    log_info ("First test finished, stowing...");
+
+    LibraryCall Stow();
   }
 
-
-  
-  // Moves a particular joint to a sequence of successive angles, 
-  // making this sequence of plan re-runnable by moving joint 
-  // back to angle 0.0 before it moves to another angle
-  // each time
+  // Moves a single joint to a sequence of successive angles.
   TestArmMoveJointSuc:
-  {  
+  {
     log_info ("Starting second and final ArmMoveJoint test...");
+
+    LibraryCall Stow();
 
     LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
 
@@ -63,8 +64,6 @@ TestArmMoveJoint:
 
     log_info ("Second and final test finished.");
   }
-
-
 
   log_info ("TestArmMoveJoint plan finished.");
 }

--- a/ow_plexil/src/plans/TestArmMoveJoint.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoint.plp
@@ -5,24 +5,86 @@
 // A test plan for the ROS action ArmMoveJoint
 // that moves the individual arm joints
 
+// For reference: joint shou yaw (joint 0) limits are from -1.8 to 1.8
+// joint shou pitch (joint 1) is from 0.05 to 2.2
+// joint grinder is from -3.14 to 3.14 (although not relevant in this case)
+
 #include "plan-interface.h"
 
 TestArmMoveJoint:
 {
-  log_info ("Starting ArmMoveJoint demo...");
+  log_info ("Starting TestArmMoveJoint plan...);
+
+
 
   // Moves the individuals joints to a certain angle (in radians)
-  LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
+  TestArmMoveJointSeq:
+  {
+    log_info ("Starting first ArmMoveJoint test...");
   
-  LibraryCall ArmMoveJoint (Relative=true, Joint=1, Angle=-0.5);
+    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=-1.0);
+  
+    LibraryCall ArmMoveJoint (Relative=true, Joint=1, Angle=0.5);
 
-  LibraryCall ArmMoveJoint (Relative=true, Joint=2, Angle=0.0);
+    LibraryCall ArmMoveJoint (Relative=true, Joint=2, Angle=0.0);
 
-  LibraryCall ArmMoveJoint (Relative=true, Joint=3, Angle=2.0);
+    LibraryCall ArmMoveJoint (Relative=true, Joint=3 Angle=0.03);
 
-  LibraryCall ArmMoveJoint (Relative=true, Joint=4, Angle=0.0);
+    LibraryCall ArmMoveJoint (Relative=true, Joint=4 Angle=0.0);
 
-  LibraryCall ArmMoveJoint (Relative=true, Joint=5, Angle=0.0);
+    LibraryCall ArmMoveJoint (Relative=true, Joint=5 Angle=0.0);
+  
+    log_info ("First test finished.");
+  }
 
-  log_info ("ArmMoveJoint demo finished.");
+
+  
+  // Moves a particular joint to a sequence of successive angles, 
+  // making this sequence of plan re-runnable by moving joint 
+  // back to angle 0.0 before it moves to another angle
+  // each time
+  TestArmMoveJointSuc:
+  {  
+    log_info ("Starting second ArmMoveJoint test...");
+
+    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
+
+    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.1);
+
+    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
+
+    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.2);
+
+    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
+
+    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.3);
+
+    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
+
+    log_info ("Second test finished.");
+  }
+  
+  
+  // Concurrence is added to all six joints commanded
+  TestArmMoveJointConc: Concurrence
+  {
+    log_info ("Starting final ArmMoveJoint test...");
+  
+    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=-1.0);
+  
+    LibraryCall ArmMoveJoint (Relative=true, Joint=1, Angle=0.5);
+
+    LibraryCall ArmMoveJoint (Relative=true, Joint=2, Angle=0.0);
+
+    LibraryCall ArmMoveJoint (Relative=true, Joint=3, Angle=0.03);
+
+    LibraryCall ArmMoveJoint (Relative=true, Joint=4, Angle=0.0);
+
+    LibraryCall ArmMoveJoint (Relative=true, Joint=5, Angle=0.0);
+  
+    log_info ("Final test finished.");
+  }
+
+
+  log_info ("TestArmMoveJoint plan finished.");
 }

--- a/ow_plexil/src/plans/TestArmMoveJoint.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoint.plp
@@ -12,17 +12,17 @@ TestArmMoveJoint:
   log_info ("Starting ArmMoveJoint demo...");
 
   // Moves the individuals joints to a certain angle (in radians)
-  LibraryCall ArmMoveJoint (Relative=true, Joint=1, Angle=0.0);
+  LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
   
-  LibraryCall ArmMoveJoint (Relative=true, Joint=2, Angle=-0.5);
+  LibraryCall ArmMoveJoint (Relative=true, Joint=1, Angle=-0.5);
 
-  LibraryCall ArmMoveJoint (Relative=true, Joint=3, Angle=0.0);
+  LibraryCall ArmMoveJoint (Relative=true, Joint=2, Angle=0.0);
 
-  LibraryCall ArmMoveJoint (Relative=true, Joint=4, Angle=2.0);
+  LibraryCall ArmMoveJoint (Relative=true, Joint=3, Angle=2.0);
+
+  LibraryCall ArmMoveJoint (Relative=true, Joint=4, Angle=0.0);
 
   LibraryCall ArmMoveJoint (Relative=true, Joint=5, Angle=0.0);
-
-  LibraryCall ArmMoveJoint (Relative=true, Joint=6, Angle=0.0);
 
   log_info ("ArmMoveJoint demo finished.");
 }

--- a/ow_plexil/src/plans/TestArmMoveJoint.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoint.plp
@@ -13,7 +13,7 @@
 
 TestArmMoveJoint:
 {
-  log_info ("Starting TestArmMoveJoint plan...);
+  log_info ("Starting TestArmMoveJoint plan...");
 
 
 

--- a/ow_plexil/src/plans/TestArmMoveJoint.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoint.plp
@@ -28,11 +28,11 @@ TestArmMoveJoint:
 
     LibraryCall ArmMoveJoint (Relative=true, Joint=2, Angle=0.0);
 
-    LibraryCall ArmMoveJoint (Relative=true, Joint=3 Angle=0.03);
+    LibraryCall ArmMoveJoint (Relative=true, Joint=3, Angle=0.03);
 
-    LibraryCall ArmMoveJoint (Relative=true, Joint=4 Angle=0.0);
+    LibraryCall ArmMoveJoint (Relative=true, Joint=4, Angle=0.0);
 
-    LibraryCall ArmMoveJoint (Relative=true, Joint=5 Angle=0.0);
+    LibraryCall ArmMoveJoint (Relative=true, Joint=5, Angle=0.0);
   
     log_info ("First test finished.");
   }

--- a/ow_plexil/src/plans/TestArmMoveJoint.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoint.plp
@@ -45,7 +45,7 @@ TestArmMoveJoint:
   // each time
   TestArmMoveJointSuc:
   {  
-    log_info ("Starting second ArmMoveJoint test...");
+    log_info ("Starting second and final ArmMoveJoint test...");
 
     LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
 
@@ -61,29 +61,9 @@ TestArmMoveJoint:
 
     LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=0.0);
 
-    log_info ("Second test finished.");
+    log_info ("Second and final test finished.");
   }
-  
-  
-  // Concurrence is added to all six joints commanded
-  TestArmMoveJointConc: Concurrence
-  {
-    log_info ("Starting final ArmMoveJoint test...");
-  
-    LibraryCall ArmMoveJoint (Relative=true, Joint=0, Angle=-1.0);
-  
-    LibraryCall ArmMoveJoint (Relative=true, Joint=1, Angle=0.5);
 
-    LibraryCall ArmMoveJoint (Relative=true, Joint=2, Angle=0.0);
-
-    LibraryCall ArmMoveJoint (Relative=true, Joint=3, Angle=0.03);
-
-    LibraryCall ArmMoveJoint (Relative=true, Joint=4, Angle=0.0);
-
-    LibraryCall ArmMoveJoint (Relative=true, Joint=5, Angle=0.0);
-  
-    log_info ("Final test finished.");
-  }
 
 
   log_info ("TestArmMoveJoint plan finished.");

--- a/ow_plexil/src/plans/TestArmMoveJoints.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoints.plp
@@ -10,20 +10,17 @@
 TestArmMoveJoints:
 {
   // Three sets of angles for each joint
-  Real angles1[6] = #(0.0 -0.5 0.0 2.0 0.0 0.0);
+  Real angles1[6] = #(-1.0 0.5 0.0 0.03 0.0 0.0);
   Real angles2[6] = #(0.0 0.5 0.0 0.0 0.0 0.0);
-  Real angles3[6] = #(0.0 -0.5 0.0 0.0 0.0 0.0);
+  Real angles3[6] = #(0.0 1.0 0.0 0.0 0.0 0.0);
 
-  log_info ("Starting ArmMoveJoints demo...");
+  log_info ("Starting TestArmMoveJoints plan...");
 
-  // Changes position of arm so that it's positioned above the ground
   LibraryCall ArmMoveJoints (Relative=false, Angles=angles1);
 
-  // Moves the arm until it reaches the ground
   LibraryCall ArmMoveJoints (Relative=true, Angles=angles2);
 
-  // Pulls arm above the ground's surface
   LibraryCall ArmMoveJoints (Relative=true, Angles=angles3);
 
-  log_info ("ArmMoveJoints demo finished.");
+  log_info ("TestArmMoveJoints plan finished.");
 }

--- a/ow_plexil/src/plans/TestArmMoveJoints.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoints.plp
@@ -24,5 +24,7 @@ TestArmMoveJoints:
 
   LibraryCall ArmMoveJoints (Relative=true, Angles=angles3);
 
+  LibraryCall Stow();
+
   log_info ("TestArmMoveJoints plan finished.");
 }

--- a/ow_plexil/src/plans/TestArmMoveJoints.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoints.plp
@@ -16,6 +16,8 @@ TestArmMoveJoints:
 
   log_info ("Starting TestArmMoveJoints plan...");
 
+  LibraryCall Stow();
+
   LibraryCall ArmMoveJoints (Relative=false, Angles=angles1);
 
   LibraryCall ArmMoveJoints (Relative=true, Angles=angles2);

--- a/ow_plexil/src/plans/TestArmMoveJoints.plp
+++ b/ow_plexil/src/plans/TestArmMoveJoints.plp
@@ -1,0 +1,29 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// A test plan for the ROS action ArmMoveJoints
+// that commands the 6 arm joints both sequentially and in parallel
+
+#include "plan-interface.h"
+
+TestArmMoveJoints:
+{
+  // Three sets of angles for each joint
+  Real angles1[6] = #(0.0 -0.5 0.0 2.0 0.0 0.0);
+  Real angles2[6] = #(0.0 0.5 0.0 0.0 0.0 0.0);
+  Real angles3[6] = #(0.0 -0.5 0.0 0.0 0.0 0.0);
+
+  log_info ("Starting ArmMoveJoints demo...");
+
+  // Changes position of arm so that it's positioned above the ground
+  LibraryCall ArmMoveJoints (Relative=false, Angles=angles1);
+
+  // Moves the arm until it reaches the ground
+  LibraryCall ArmMoveJoints (Relative=true, Angles=angles2);
+
+  // Pulls arm above the ground's surface
+  LibraryCall ArmMoveJoints (Relative=true, Angles=angles3);
+
+  log_info ("ArmMoveJoints demo finished.");
+}

--- a/ow_plexil/src/plans/lander-commands.h
+++ b/ow_plexil/src/plans/lander-commands.h
@@ -18,6 +18,13 @@ Command tilt_antenna (Real degrees);
 Command pan_antenna (Real degrees);
 Command take_picture();
 
+Command arm_move_joint (Boolean relative,
+                        Integer joint,
+                        Real angle);
+
+Command arm_move_joints (Boolean relative, 
+                         Real angles[6]);
+
 Command dig_circular (Real x,
                       Real y,
                       Real depth,

--- a/ow_plexil/src/plans/plan-interface.h
+++ b/ow_plexil/src/plans/plan-interface.h
@@ -31,6 +31,13 @@ LibraryAction GuardedMove (In Real X,
                            In Real DirZ,
                            In Real SearchDistance);
 
+LibraryAction ArmMoveJoint (In Boolean Relative,
+                            In Integer Joint,
+                            In Real Angle);
+
+LibraryAction ArmMoveJoints (In Boolean Relative,
+                             In Real Angles[6]);
+
 LibraryAction Grind (In Real X,
                      In Real Y,
                      In Real Depth,

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -168,6 +168,37 @@ static void guarded_move (Command* cmd, AdapterExecInterface* intf)
   acknowledge_command_sent(*cr);
 }
 
+static void arm_move_joint (Command *cmd, AdapterExecInterface* intf)
+{
+  bool relative;
+  int joint;
+  double angle; // unit is radians
+  const vector<Value>& args = cmd->getArgValues();
+  args[0].getValue(relative);
+  args[1].getValue(joint);
+  args[2].getValue(angle);
+  std::unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
+  OwInterface::instance()->armMoveJoint (relative, joint, angle,
+                                         CommandId);
+  acknowledge_command_sent(*cr);
+}
+
+static void arm_move_joints (Command *cmd, AdapterExecInterface* intf)
+{
+  bool relative;
+  vector<double> const *angles_vector = nullptr;
+  RealArray const *angles = nullptr;
+  const vector<Value>& args = cmd->getArgValues();
+  args[0].getValue(relative);
+  args[1].getValuePointer(angles);
+  //changes real array into a vector
+  angles->getContentsVector(angles_vector);
+  std::unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
+  OwInterface::instance()->armMoveJoints (relative, *angles_vector,
+                                          CommandId);
+  acknowledge_command_sent(*cr);
+}
+
 static void grind (Command* cmd, AdapterExecInterface* intf)
 {
   double x, y, depth, length, ground_pos;
@@ -328,6 +359,8 @@ bool OwAdapter::initialize()
   g_configuration->registerCommandHandler("unstow", unstow);
   g_configuration->registerCommandHandler("grind", grind);
   g_configuration->registerCommandHandler("guarded_move", guarded_move);
+  g_configuration->registerCommandHandler("arm_move_joint", arm_move_joint);
+  g_configuration->registerCommandHandler("arm_move_joints", arm_move_joints);
   g_configuration->registerCommandHandler("dig_circular", dig_circular);
   g_configuration->registerCommandHandler("dig_linear", dig_linear);
   g_configuration->registerCommandHandler("deliver", deliver);

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -18,6 +18,8 @@
 #include <ow_lander/StowAction.h>
 #include <ow_lander/GrindAction.h>
 #include <ow_lander/GuardedMoveAction.h>
+#include <ow_lander/ArmMoveJointAction.h>
+#include <ow_lander/ArmMoveJointsAction.h>
 #include <ow_lander/DigCircularAction.h>
 #include <ow_lander/DigLinearAction.h>
 #include <ow_lander/DeliverAction.h>
@@ -46,6 +48,10 @@ using GrindActionClient =
   actionlib::SimpleActionClient<ow_lander::GrindAction>;
 using GuardedMoveActionClient =
   actionlib::SimpleActionClient<ow_lander::GuardedMoveAction>;
+using ArmMoveJointActionClient =
+  actionlib::SimpleActionClient<ow_lander::ArmMoveJointAction>;
+using ArmMoveJointsActionClient = 
+  actionlib::SimpleActionClient<ow_lander::ArmMoveJointsAction>;
 using DigCircularActionClient =
   actionlib::SimpleActionClient<ow_lander::DigCircularAction>;
 using DigLinearActionClient =
@@ -76,6 +82,11 @@ class OwInterface : public PlexilInterface
   void guardedMove (double x, double y, double z,
                     double direction_x, double direction_y, double direction_z,
                     double search_distance, int id);
+  void armMoveJoint (bool relative, int joint, double angle,
+                     int id);
+  void armMoveJoints (bool relative,
+                      const std::vector<double>& angles,
+                      int id); 
   std::vector<double> identifySampleLocation (int num_images,
                                               const std::string& filter_type,
                                               int id);
@@ -123,6 +134,10 @@ class OwInterface : public PlexilInterface
   void guardedMoveAction (double x, double y, double z,
                           double dir_x, double dir_y, double dir_z,
                           double search_distance, int id);
+  void armMoveJointAction (bool relative, int joint, 
+                     double angle, int id);
+  void armMoveJointsAction (bool relative, const std::vector<double>& angles,
+                      int id);
   void identifySampleLocationAction (int num_images,
                                      const std::string& filter_type, int id);
   void digCircularAction (double x, double y, double depth,
@@ -202,6 +217,8 @@ class OwInterface : public PlexilInterface
 
   // Action clients
   std::unique_ptr<GuardedMoveActionClient> m_guardedMoveClient;
+  std::unique_ptr<ArmMoveJointActionClient> m_armMoveJointClient;
+  std::unique_ptr<ArmMoveJointsActionClient> m_armMoveJointsClient;
   std::unique_ptr<UnstowActionClient> m_unstowClient;
   std::unique_ptr<StowActionClient> m_stowClient;
   std::unique_ptr<GrindActionClient> m_grindClient;

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -135,9 +135,9 @@ class OwInterface : public PlexilInterface
                           double dir_x, double dir_y, double dir_z,
                           double search_distance, int id);
   void armMoveJointAction (bool relative, int joint, 
-                     double angle, int id);
+                           double angle, int id);
   void armMoveJointsAction (bool relative, const std::vector<double>& angles,
-                      int id);
+                            int id);
   void identifySampleLocationAction (int num_images,
                                      const std::string& filter_type, int id);
   void digCircularAction (double x, double y, double depth,


### PR DESCRIPTION
The new ROS actions ArmMoveJoint and ArmMoveJoints can now be commanded from PLEXIL.

To test:

- Launch any simulator of choice
- Then, on a separate terminal, execute the test plans, whatever order you may choose, for ArmMoveJoint and ArmMoveJoints (respectively) by the commands `roslaunch ow_plexil ow_exec.launch plan:="TestArmMoveJoint.plx"` and `roslaunch ow_plexil ow_exec.launch plan:="TestArmMoveJoints.plx"`