### PR TITLE
Oceanwater 1009 implement telemetry system faults status

### DIFF
--- a/ow_plexil/CMakeLists.txt
+++ b/ow_plexil/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   actionlib_msgs
   geometry_msgs
   ow_lander
-  ow_faults_detection
+  owl_msgs
   rqt_gui_py
   message_generation
   std_msgs
@@ -50,7 +50,7 @@ generate_messages(
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS roscpp roslib rospy ow_lander actionlib_msgs geometry_msgs ow_faults_detection
+  CATKIN_DEPENDS roscpp roslib rospy ow_lander actionlib_msgs geometry_msgs owl_msgs
   CFG_EXTRAS ow_plexil-extras.cmake
 )
 

--- a/ow_plexil/CMakeLists.txt
+++ b/ow_plexil/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   actionlib_msgs
   geometry_msgs
   ow_lander
-  owl_msgs
+  ow_faults_detection
   rqt_gui_py
   message_generation
   std_msgs
@@ -50,7 +50,7 @@ generate_messages(
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS roscpp roslib rospy ow_lander actionlib_msgs geometry_msgs owl_msgs
+  CATKIN_DEPENDS roscpp roslib rospy ow_lander actionlib_msgs geometry_msgs ow_faults_detection
   CFG_EXTRAS ow_plexil-extras.cmake
 )
 

--- a/ow_plexil/CMakeLists.txt
+++ b/ow_plexil/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   ow_lander
   ow_faults_detection
+  owl_msgs
   rqt_gui_py
   message_generation
   std_msgs
@@ -50,7 +51,7 @@ generate_messages(
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS roscpp roslib rospy ow_lander actionlib_msgs geometry_msgs ow_faults_detection
+  CATKIN_DEPENDS roscpp roslib rospy ow_lander actionlib_msgs geometry_msgs ow_faults_detection owl_msgs
   CFG_EXTRAS ow_plexil-extras.cmake
 )
 

--- a/ow_plexil/package.xml
+++ b/ow_plexil/package.xml
@@ -12,6 +12,7 @@
   <depend>roslib</depend>
   <depend>ow_lander</depend>
   <depend>ow_faults_detection</depend>
+  <depend>owl_msgs</depend>
   <depend>actionlib_msgs</depend>
   <depend>actionlib</depend>
   <depend>std_msgs</depend>

--- a/ow_plexil/package.xml
+++ b/ow_plexil/package.xml
@@ -11,7 +11,7 @@
   <depend>rospy</depend>
   <depend>roslib</depend>
   <depend>ow_lander</depend>
-  <depend>ow_faults_detection</depend>
+  <depend>owl_msgs</depend>
   <depend>actionlib_msgs</depend>
   <depend>actionlib</depend>
   <depend>std_msgs</depend>

--- a/ow_plexil/package.xml
+++ b/ow_plexil/package.xml
@@ -11,7 +11,7 @@
   <depend>rospy</depend>
   <depend>roslib</depend>
   <depend>ow_lander</depend>
-  <depend>owl_msgs</depend>
+  <depend>ow_faults_detection</depend>
   <depend>actionlib_msgs</depend>
   <depend>actionlib</depend>
   <depend>std_msgs</depend>

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -285,25 +285,25 @@ void OwInterface::updateFaultStatus (T1 msg_val, T2& fmap,
 ///////////////////////// Subscriber Callbacks ///////////////////////////////
 
 void OwInterface::systemFaultMessageCallback
-(const  owl_msgs::SystemFaultsStatus::ConstPtr& msg)
+(const  ow_faults_detection::SystemFaults::ConstPtr& msg)
 {
   updateFaultStatus (msg->value, m_systemErrors, "SYSTEM", "SystemFault");
 }
 
 void OwInterface::armFaultCallback
-(const owl_msgs::ArmFaults::ConstPtr& msg)
+(const ow_faults_detection::ArmFaults::ConstPtr& msg)
 {
   updateFaultStatus (msg->value, m_armErrors, "ARM", "ArmFault");
 }
 
 void OwInterface::powerFaultCallback
-(const owl_msgs::PowerFaults::ConstPtr& msg)
+(const ow_faults_detection::PowerFaults::ConstPtr& msg)
 {
   updateFaultStatus (msg->value, m_powerErrors, "POWER", "PowerFault");
 }
 
 void OwInterface::antennaFaultCallback
-(const owl_msgs::PTFaults::ConstPtr& msg)
+(const ow_faults_detection::PTFaults::ConstPtr& msg)
 {
   updateFaultStatus (msg->value, m_panTiltErrors, "ANTENNA", "AntennaFault");
 }

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -291,19 +291,19 @@ void OwInterface::systemFaultMessageCallback
 }
 
 void OwInterface::armFaultCallback
-(const ow_faults_detection::ArmFaults::ConstPtr& msg)
+(const owl_msgs::ArmFaults::ConstPtr& msg)
 {
   updateFaultStatus (msg->value, m_armErrors, "ARM", "ArmFault");
 }
 
 void OwInterface::powerFaultCallback
-(const ow_faults_detection::PowerFaults::ConstPtr& msg)
+(const owl_msgs::PowerFaults::ConstPtr& msg)
 {
   updateFaultStatus (msg->value, m_powerErrors, "POWER", "PowerFault");
 }
 
 void OwInterface::antennaFaultCallback
-(const ow_faults_detection::PTFaults::ConstPtr& msg)
+(const owl_msgs::PTFaults::ConstPtr& msg)
 {
   updateFaultStatus (msg->value, m_panTiltErrors, "ANTENNA", "AntennaFault");
 }

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -285,7 +285,7 @@ void OwInterface::updateFaultStatus (T1 msg_val, T2& fmap,
 ///////////////////////// Subscriber Callbacks ///////////////////////////////
 
 void OwInterface::systemFaultMessageCallback
-(const  owl_msgs::SystemFaults::ConstPtr& msg)
+(const  owl_msgs::SystemFaultsStatus::ConstPtr& msg)
 {
   updateFaultStatus (msg->value, m_systemErrors, "SYSTEM", "SystemFault");
 }

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -285,7 +285,7 @@ void OwInterface::updateFaultStatus (T1 msg_val, T2& fmap,
 ///////////////////////// Subscriber Callbacks ///////////////////////////////
 
 void OwInterface::systemFaultMessageCallback
-(const  ow_faults_detection::SystemFaults::ConstPtr& msg)
+(const  owl_msgs::SystemFaults::ConstPtr& msg)
 {
   updateFaultStatus (msg->value, m_systemErrors, "SYSTEM", "SystemFault");
 }
@@ -621,7 +621,7 @@ void OwInterface::initialize()
     // subscribers for fault messages
     m_systemFaultMessagesSubscriber = make_unique<ros::Subscriber>
       (m_genericNodeHandle ->
-       subscribe("/faults/system_faults_status", qsize,
+       subscribe("/system_faults_status", qsize,
                 &OwInterface::systemFaultMessageCallback, this));
     m_armFaultMessagesSubscriber = make_unique<ros::Subscriber>
       (m_genericNodeHandle ->

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -285,7 +285,7 @@ void OwInterface::updateFaultStatus (T1 msg_val, T2& fmap,
 ///////////////////////// Subscriber Callbacks ///////////////////////////////
 
 void OwInterface::systemFaultMessageCallback
-(const  ow_faults_detection::SystemFaults::ConstPtr& msg)
+(const  owl_msgs::SystemFaultsStatus::ConstPtr& msg)
 {
   updateFaultStatus (msg->value, m_systemErrors, "SYSTEM", "SystemFault");
 }

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -34,7 +34,7 @@
 #include <geometry_msgs/Point.h>
 #include <string>
 
-#include <owl_msgs/SystemFaults.h>
+#include <owl_msgs/SystemFaultsStatus.h>
 #include <owl_msgs/ArmFaults.h>
 #include <owl_msgs/PowerFaults.h>
 #include <owl_msgs/PTFaults.h>
@@ -155,7 +155,7 @@ class OwInterface : public PlexilInterface
   void managePanTilt (const std::string& opname,
                       double current, double goal,
                       const ros::Time& start);
-  void systemFaultMessageCallback (const owl_msgs::SystemFaults::ConstPtr&);
+  void systemFaultMessageCallback (const owl_msgs::SystemFaultsStatus::ConstPtr&);
   void armFaultCallback (const owl_msgs::ArmFaults::ConstPtr&);
   void powerFaultCallback (const owl_msgs::PowerFaults::ConstPtr&);
   void antennaFaultCallback (const owl_msgs::PTFaults::ConstPtr&);

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -183,10 +183,10 @@ class OwInterface : public PlexilInterface
     {"TASK_GOAL_ERROR", std::make_pair(8,false)},
     {"CAMERA_GOAL_ERROR", std::make_pair(16,false)},
     {"CAMERA_EXECUTION_ERROR", std::make_pair(32,false)},
-    {"PAN_TILT_GOAL_ERROR", std::make_pair(64,false)}
-    {"PAN_TILT_EXECUTION_ERROR", std::make_pair(128,false)}
-    {"LANDER_EXECUTION_ERROR", std::make_pair(256,false)}
-    {"POWER_EXECUTION_ERROR", std::make_pair(512,false)},
+    {"PAN_TILT_GOAL_ERROR", std::make_pair(64,false)},
+    {"PAN_TILT_EXECUTION_ERROR", std::make_pair(128,false)},
+    {"LANDER_EXECUTION_ERROR", std::make_pair(256,false)},
+    {"POWER_EXECUTION_ERROR", std::make_pair(512,false)}
   };
 
   FaultMap32 m_armErrors = {

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -176,7 +176,7 @@ class OwInterface : public PlexilInterface
 
   FaultMap64 m_systemErrors =
   {
-    {"NO_FAULT", std::make_pair(0,false)},
+    {"NONE", std::make_pair(0,false)},
     {"SYSTEM", std::make_pair(1,false)},
     {"ARM_GOAL_ERROR", std::make_pair(2,false)},
     {"ARM_EXECUTION_ERROR", std::make_pair(4,false)},

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -174,9 +174,7 @@ class OwInterface : public PlexilInterface
 
   // System level faults:
 
-  FaultMap64 m_systemErrors =
-  {
-    {"NONE", std::make_pair(0,false)},
+  FaultMap64 m_systemErrors = {
     {"SYSTEM", std::make_pair(1,false)},
     {"ARM_GOAL_ERROR", std::make_pair(2,false)},
     {"ARM_EXECUTION_ERROR", std::make_pair(4,false)},

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -34,7 +34,7 @@
 #include <geometry_msgs/Point.h>
 #include <string>
 
-#include <ow_faults_detection/SystemFaults.h>
+#include <owl_msgs/SystemFaultsStatus.h>
 #include <ow_faults_detection/ArmFaults.h>
 #include <ow_faults_detection/PowerFaults.h>
 #include <ow_faults_detection/PTFaults.h>
@@ -155,7 +155,7 @@ class OwInterface : public PlexilInterface
   void managePanTilt (const std::string& opname,
                       double current, double goal,
                       const ros::Time& start);
-  void systemFaultMessageCallback (const ow_faults_detection::SystemFaults::ConstPtr&);
+  void systemFaultMessageCallback (const owl_msgs::SystemFaultsStatus::ConstPtr&);
   void armFaultCallback (const ow_faults_detection::ArmFaults::ConstPtr&);
   void powerFaultCallback (const ow_faults_detection::PowerFaults::ConstPtr&);
   void antennaFaultCallback (const ow_faults_detection::PTFaults::ConstPtr&);

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -35,9 +35,9 @@
 #include <string>
 
 #include <owl_msgs/SystemFaults.h>
-#include <ow_faults_detection/ArmFaults.h>
-#include <ow_faults_detection/PowerFaults.h>
-#include <ow_faults_detection/PTFaults.h>
+#include <owl_msgs/ArmFaults.h>
+#include <owl_msgs/PowerFaults.h>
+#include <owl_msgs/PTFaults.h>
 
 #include "PlexilInterface.h"
 
@@ -156,9 +156,9 @@ class OwInterface : public PlexilInterface
                       double current, double goal,
                       const ros::Time& start);
   void systemFaultMessageCallback (const owl_msgs::SystemFaults::ConstPtr&);
-  void armFaultCallback (const ow_faults_detection::ArmFaults::ConstPtr&);
-  void powerFaultCallback (const ow_faults_detection::PowerFaults::ConstPtr&);
-  void antennaFaultCallback (const ow_faults_detection::PTFaults::ConstPtr&);
+  void armFaultCallback (const owl_msgs::ArmFaults::ConstPtr&);
+  void powerFaultCallback (const owl_msgs::PowerFaults::ConstPtr&);
+  void antennaFaultCallback (const owl_msgs::PTFaults::ConstPtr&);
   void antennaOp (const std::string& opname, double degrees,
                   std::unique_ptr<ros::Publisher>&, int id);
   void actionGoalStatusCallback (const actionlib_msgs::GoalStatusArray::ConstPtr&,

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -34,10 +34,10 @@
 #include <geometry_msgs/Point.h>
 #include <string>
 
-#include <owl_msgs/SystemFaultsStatus.h>
-#include <owl_msgs/ArmFaults.h>
-#include <owl_msgs/PowerFaults.h>
-#include <owl_msgs/PTFaults.h>
+#include <ow_faults_detection/SystemFaults.h>
+#include <ow_faults_detection/ArmFaults.h>
+#include <ow_faults_detection/PowerFaults.h>
+#include <ow_faults_detection/PTFaults.h>
 
 #include "PlexilInterface.h"
 
@@ -155,10 +155,10 @@ class OwInterface : public PlexilInterface
   void managePanTilt (const std::string& opname,
                       double current, double goal,
                       const ros::Time& start);
-  void systemFaultMessageCallback (const owl_msgs::SystemFaultsStatus::ConstPtr&);
-  void armFaultCallback (const owl_msgs::ArmFaults::ConstPtr&);
-  void powerFaultCallback (const owl_msgs::PowerFaults::ConstPtr&);
-  void antennaFaultCallback (const owl_msgs::PTFaults::ConstPtr&);
+  void systemFaultMessageCallback (const ow_faults_detection::SystemFaults::ConstPtr&);
+  void armFaultCallback (const ow_faults_detection::ArmFaults::ConstPtr&);
+  void powerFaultCallback (const ow_faults_detection::PowerFaults::ConstPtr&);
+  void antennaFaultCallback (const ow_faults_detection::PTFaults::ConstPtr&);
   void antennaOp (const std::string& opname, double degrees,
                   std::unique_ptr<ros::Publisher>&, int id);
   void actionGoalStatusCallback (const actionlib_msgs::GoalStatusArray::ConstPtr&,

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -175,16 +175,26 @@ class OwInterface : public PlexilInterface
   // System level faults:
 
   FaultMap64 m_systemErrors = {
-    {"SYSTEM", std::make_pair(1,false)},
-    {"ARM_GOAL_ERROR", std::make_pair(2,false)},
-    {"ARM_EXECUTION_ERROR", std::make_pair(4,false)},
-    {"TASK_GOAL_ERROR", std::make_pair(8,false)},
-    {"CAMERA_GOAL_ERROR", std::make_pair(16,false)},
-    {"CAMERA_EXECUTION_ERROR", std::make_pair(32,false)},
-    {"PAN_TILT_GOAL_ERROR", std::make_pair(64,false)},
-    {"PAN_TILT_EXECUTION_ERROR", std::make_pair(128,false)},
-    {"LANDER_EXECUTION_ERROR", std::make_pair(256,false)},
-    {"POWER_EXECUTION_ERROR", std::make_pair(512,false)}
+    {"SYSTEM", std::make_pair(
+        owl_msgs::SystemFaultsStatus::SYSTEM,false)},
+    {"ARM_GOAL_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::ARM_GOAL_ERROR,false)},
+    {"ARM_EXECUTION_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::ARM_EXECUTION_ERROR,false)},
+    {"TASK_GOAL_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::TASK_GOAL_ERROR,false)},
+    {"CAMERA_GOAL_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::CAMERA_GOAL_ERROR,false)},
+    {"CAMERA_EXECUTION_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::CAMERA_EXECUTION_ERROR,false)},
+    {"PAN_TILT_GOAL_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::PAN_TILT_GOAL_ERROR,false)},
+    {"PAN_TILT_EXECUTION_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::PAN_TILT_EXECUTION_ERROR,false)},
+    {"LANDER_EXECUTION_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::LANDER_EXECUTION_ERROR,false)},
+    {"POWER_EXECUTION_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::POWER_EXECUTION_ERROR,false)}
   };
 
   FaultMap32 m_armErrors = {

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -34,7 +34,7 @@
 #include <geometry_msgs/Point.h>
 #include <string>
 
-#include <ow_faults_detection/SystemFaults.h>
+#include <owl_msgs/SystemFaults.h>
 #include <ow_faults_detection/ArmFaults.h>
 #include <ow_faults_detection/PowerFaults.h>
 #include <ow_faults_detection/PTFaults.h>
@@ -155,7 +155,7 @@ class OwInterface : public PlexilInterface
   void managePanTilt (const std::string& opname,
                       double current, double goal,
                       const ros::Time& start);
-  void systemFaultMessageCallback (const ow_faults_detection::SystemFaults::ConstPtr&);
+  void systemFaultMessageCallback (const owl_msgs::SystemFaults::ConstPtr&);
   void armFaultCallback (const ow_faults_detection::ArmFaults::ConstPtr&);
   void powerFaultCallback (const ow_faults_detection::PowerFaults::ConstPtr&);
   void antennaFaultCallback (const ow_faults_detection::PTFaults::ConstPtr&);
@@ -176,9 +176,17 @@ class OwInterface : public PlexilInterface
 
   FaultMap64 m_systemErrors =
   {
+    {"NO_FAULT", std::make_pair(0,false)},
+    {"SYSTEM", std::make_pair(1,false)},
+    {"ARM_GOAL_ERROR", std::make_pair(2,false)},
     {"ARM_EXECUTION_ERROR", std::make_pair(4,false)},
+    {"TASK_GOAL_ERROR", std::make_pair(8,false)},
+    {"CAMERA_GOAL_ERROR", std::make_pair(16,false)},
+    {"CAMERA_EXECUTION_ERROR", std::make_pair(32,false)},
+    {"PAN_TILT_GOAL_ERROR", std::make_pair(64,false)}
+    {"PAN_TILT_EXECUTION_ERROR", std::make_pair(128,false)}
+    {"LANDER_EXECUTION_ERROR", std::make_pair(256,false)}
     {"POWER_EXECUTION_ERROR", std::make_pair(512,false)},
-    {"PT_EXECUTION_ERROR", std::make_pair(128,false)}
   };
 
   FaultMap32 m_armErrors = {


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-934](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-934) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1009](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1009) |
| Github :octocat:  | [OCEANWATER-1009_implement_telemetry_system_faults_status](https://github.com/nasa/ow_simulator/tree/OCEANWATER-1009_implement_telemetry_system_faults_status) |

First of a group of Telemetry Unification tickets (listed below) targeting fault related messages in accordance with OceanWATERS/OWLAT Unification Plan. Mostly artifact renaming and updating message definitions.

**This issue has a corresponding and required branch on [ow_simulator](https://github.com/nasa/ow_simulator/tree/OCEANWATER-1009_implement_telemetry_system_faults_status).**

## Summary of Changes
* Update references to `SystemFaults` to match Unified Telemetry spec of `SystemFaultsStatus`
* Update namespaces and includes to reference `owl_msgs` which now houses SystemFaultsStatus (`instead of ow_faults_detection`)

[For more details, see the associated pull request on ow_simulator.](https://github.com/nasa/ow_simulator/pull/278)


## Test
Test with linked PR above.