### PR TITLE
PLEXIL uses LightSetIntensity action

### DIFF
--- a/ow_plexil/src/plans/LightSetIntensity.plp
+++ b/ow_plexil/src/plans/LightSetIntensity.plp
@@ -1,0 +1,9 @@
+#include "lander-commands.h"
+
+LightSetIntensity:
+{
+  In String Side;
+  In Real Intensity;
+
+  SynchronousCommand light_set_intensity (Side, Intensity);
+}

--- a/ow_plexil/src/plans/SetLightIntensity.plp
+++ b/ow_plexil/src/plans/SetLightIntensity.plp
@@ -1,9 +1,0 @@
-#include "lander-commands.h"
-
-SetLightIntensity:
-{
-  In String Side;
-  In Real Intensity;
-
-  SynchronousCommand set_light_intensity (Side, Intensity);
-}

--- a/ow_plexil/src/plans/TestLanderLights.plp
+++ b/ow_plexil/src/plans/TestLanderLights.plp
@@ -12,18 +12,18 @@ TestLanderLights:
   LibraryCall PanTilt (PanDegrees = 0, TiltDegrees = 60.0);
 
   log_info ("Turning lights off...");
-  LibraryCall SetLightIntensity (Side = "left", Intensity = 0.0);
-  LibraryCall SetLightIntensity (Side = "right", Intensity = 0.0);
+  LibraryCall LightSetIntensity (Side = "left", Intensity = 0.0);
+  LibraryCall LightSetIntensity (Side = "right", Intensity = 0.0);
   Wait 2;
 
   log_info ("Setting each to different levels...");
-  LibraryCall SetLightIntensity (Side = "left", Intensity = 0.25);
-  LibraryCall SetLightIntensity (Side = "right", Intensity = 0.75);
+  LibraryCall LightSetIntensity (Side = "left", Intensity = 0.25);
+  LibraryCall LightSetIntensity (Side = "right", Intensity = 0.75);
   Wait 2;
 
   log_info ("Setting both to full intensity...");
-  LibraryCall SetLightIntensity (Side = "left", Intensity = 1.0);
-  LibraryCall SetLightIntensity (Side = "right", Intensity = 1.0);
+  LibraryCall LightSetIntensity (Side = "left", Intensity = 1.0);
+  LibraryCall LightSetIntensity (Side = "right", Intensity = 1.0);
 
   log_info ("Finished TestLanderLights.");
 }

--- a/ow_plexil/src/plans/lander-commands.h
+++ b/ow_plexil/src/plans/lander-commands.h
@@ -70,7 +70,7 @@ Command stow();
 Real [3] Command identify_sample_location(Integer num_images, String filter_type);
 
 // Set spotlight intensity
-Command set_light_intensity (String side,     // "left" or "right"
+Command light_set_intensity (String side,     // "left" or "right"
 			     Real intensity); // 0.0 to 1.0.  0 is off.
 
 #endif

--- a/ow_plexil/src/plans/plan-interface.h
+++ b/ow_plexil/src/plans/plan-interface.h
@@ -18,7 +18,7 @@ Command log_debug (...);
 
 // PLEXIL library for lander operations.
 
-LibraryAction SetLightIntensity (In String Side, In Real Intensity);
+LibraryAction LightSetIntensity (In String Side, In Real Intensity);
 LibraryAction PanTilt  (In Real PanDegrees, In Real TiltDegrees);
 LibraryAction Stow ();
 LibraryAction Unstow ();

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -328,7 +328,7 @@ static void camera_capture (Command* cmd, AdapterExecInterface* intf)
   acknowledge_command_sent(*cr);
 }
 
-static void set_light_intensity (Command* cmd, AdapterExecInterface* intf)
+static void light_set_intensity (Command* cmd, AdapterExecInterface* intf)
 {
   bool valid_args = true;
   string side;
@@ -337,18 +337,18 @@ static void set_light_intensity (Command* cmd, AdapterExecInterface* intf)
   args[0].getValue (side);
   args[1].getValue (intensity);
   if (side != "left" && side != "right") {
-    ROS_ERROR ("set_light_intensity: side was %s, should be 'left' or 'right'",
+    ROS_ERROR ("light_set_intensity: side was %s, should be 'left' or 'right'",
                side.c_str());
     valid_args = false;
   }
   if (intensity < 0.0 || intensity > 1.0) {
-    ROS_ERROR ("set_light_intensity: intensity was %f, "
+    ROS_ERROR ("light_set_intensity: intensity was %f, "
                "should be in range [0.0 1.0]", intensity);
     valid_args = false;
   }
   if (valid_args) {
     unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
-    OwInterface::instance()->setLightIntensity (side, intensity, CommandId);
+    OwInterface::instance()->lightSetIntensity (side, intensity, CommandId);
     acknowledge_command_sent(*cr);
   }
   else {
@@ -404,8 +404,8 @@ bool OwAdapter::initialize()
   g_configuration->registerCommandHandler("identify_sample_location",
                                           identify_sample_location);
   g_configuration->registerCommandHandler("camera_capture", camera_capture);
-  g_configuration->registerCommandHandler("set_light_intensity",
-                                          set_light_intensity);
+  g_configuration->registerCommandHandler("light_set_intensity",
+                                          light_set_intensity);
   OwInterface::instance()->setCommandStatusCallback (command_status_callback);
   debugMsg("OwAdapter", " initialized.");
   return true;

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -47,44 +47,6 @@ const double PanTiltToleranceDegrees = 2.865; // 0.05 radians, matching simulato
 const double VelocityTolerance       = 0.01;  // made up, unitless
 
 
-/////////////////// ROS Service support //////////////////////
-
-template<typename Service>
-void OwInterface::callService (ros::ServiceClient client, Service srv,
-                               string name, int id)
-{
-  // NOTE: arguments are copies because this function is called in a thread that
-  // outlives its caller.  Assumes that service is not already running; this is
-  // checked upstream.
-
-  ROS_INFO("Starting ROS service %s", name.c_str());
-  if (client.call (srv)) { // blocks
-    ROS_INFO("%s returned: %d, %s", name.c_str(), srv.response.success,
-             srv.response.message.c_str());  // make DEBUG later
-  }
-  else {
-    ROS_ERROR("Failed to call service %s", name.c_str());
-  }
-  markOperationFinished (name, id);
-}
-
-static bool check_service_client (ros::ServiceClient& client,
-                                  const string& name)
-{
-  if (! client.exists()) {
-    ROS_ERROR("Service client for %s does not exist!", name.c_str());
-    return false;
-  }
-
-  if (! client.isValid()) {
-    ROS_ERROR("Service client for %s is invalid!", name.c_str());
-    return false;
-  }
-
-  return true;
-}
-
-
 //////////////////// Lander Operation Support ////////////////////////
 
 const double PointCloudTimeout = 50.0; // 5 second timeout assuming a rate of 10hz

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -27,6 +27,7 @@
 #include <ow_lander/AntennaPanTiltAction.h>
 #include <ow_lander/DiscardAction.h>
 #include <ow_lander/CameraCaptureAction.h>
+#include <ow_lander/LightSetIntensityAction.h>
 #include <ow_plexil/IdentifyLocationAction.h>
 
 #include <control_msgs/JointControllerState.h>
@@ -67,8 +68,13 @@ using DiscardActionClient =
   actionlib::SimpleActionClient<ow_lander::DiscardAction>;
 using CameraCaptureActionClient =
   actionlib::SimpleActionClient<ow_lander::CameraCaptureAction>;
+using LightSetIntensityActionClient =
+  actionlib::SimpleActionClient<ow_lander::LightSetIntensityAction>;
+
+// The only ow_plexil-defined action.
 using IdentifySampleLocationActionClient =
   actionlib::SimpleActionClient<ow_plexil::IdentifyLocationAction>;
+
 
 // Maps from fault name to the pair (fault value, is fault in progress?)
 using FaultMap32 = std::map<std::string,std::pair<uint32_t, bool>>;
@@ -110,7 +116,7 @@ class OwInterface : public PlexilInterface
   void unstow (int id);
   void deliver (int id);
   void discard (double x, double y, double z, int id);
-  void setLightIntensity (const std::string& side, double intensity, int id);
+  void lightSetIntensity (const std::string& side, double intensity, int id);
 
   // State/Lookup interface
   double getTilt () const;
@@ -157,6 +163,7 @@ class OwInterface : public PlexilInterface
   void deliverAction (int id);
   void discardAction (double x, double y, double z, int id);
   void cameraCaptureAction (double exposure_secs, int id);
+  void lightSetIntensityAction (const std::string& side, double intensity, int id);
   void jointStatesCallback (const sensor_msgs::JointState::ConstPtr&);
   void systemFaultMessageCallback (const owl_msgs::SystemFaultsStatus::ConstPtr&);
   void armFaultCallback (const ow_faults_detection::ArmFaults::ConstPtr&);
@@ -229,6 +236,7 @@ class OwInterface : public PlexilInterface
   std::unique_ptr<ros::Publisher> m_leftImageTriggerPublisher;
 
   std::unique_ptr<ros::Subscriber> m_jointStatesSubscriber;
+  std::unique_ptr<ros::Subscriber> m_cameraSubscriber;
   std::unique_ptr<ros::Subscriber> m_pointCloudSubscriber;
   std::unique_ptr<ros::Subscriber> m_socSubscriber;
   std::unique_ptr<ros::Subscriber> m_rulSubscriber;
@@ -248,6 +256,7 @@ class OwInterface : public PlexilInterface
   std::unique_ptr<ros::Subscriber> m_deliverStatusSubscriber;
   std::unique_ptr<ros::Subscriber> m_discardStatusSubscriber;
   std::unique_ptr<ros::Subscriber> m_cameraCaptureStatusSubscriber;
+  std::unique_ptr<ros::Subscriber> m_lightSetIntensityStatusSubscriber;
 
   // Action clients
   std::unique_ptr<GuardedMoveActionClient> m_guardedMoveClient;
@@ -262,6 +271,7 @@ class OwInterface : public PlexilInterface
   std::unique_ptr<PanTiltActionClient> m_panTiltClient;
   std::unique_ptr<DiscardActionClient> m_discardClient;
   std::unique_ptr<CameraCaptureActionClient> m_cameraCaptureClient;
+  std::unique_ptr<LightSetIntensityActionClient> m_lightSetIntensityClient;
 
   std::unique_ptr<IdentifySampleLocationActionClient> m_identifySampleLocationClient;
 

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -139,6 +139,7 @@ class OwInterface : public PlexilInterface
   int actionGoalStatus (const std::string& action_name) const;
 
  private:
+  void addSubscriber (const std::string& topic, const std::string& operation);
   template<typename Service>
   void callService (ros::ServiceClient, Service, std::string name, int id);
 
@@ -235,28 +236,9 @@ class OwInterface : public PlexilInterface
   std::unique_ptr<ros::Publisher> m_antennaPanPublisher;
   std::unique_ptr<ros::Publisher> m_leftImageTriggerPublisher;
 
-  std::unique_ptr<ros::Subscriber> m_jointStatesSubscriber;
-  std::unique_ptr<ros::Subscriber> m_cameraSubscriber;
-  std::unique_ptr<ros::Subscriber> m_pointCloudSubscriber;
-  std::unique_ptr<ros::Subscriber> m_socSubscriber;
-  std::unique_ptr<ros::Subscriber> m_rulSubscriber;
-  std::unique_ptr<ros::Subscriber> m_batteryTempSubscriber;
-  std::unique_ptr<ros::Subscriber> m_systemFaultMessagesSubscriber;
-  std::unique_ptr<ros::Subscriber> m_armFaultMessagesSubscriber;
-  std::unique_ptr<ros::Subscriber> m_powerFaultMessagesSubscriber;
-  std::unique_ptr<ros::Subscriber> m_ptFaultMessagesSubscriber;
-  std::unique_ptr<ros::Subscriber> m_unstowStatusSubscriber;
-  std::unique_ptr<ros::Subscriber> m_stowStatusSubscriber;
-  std::unique_ptr<ros::Subscriber> m_grindStatusSubscriber;
-  std::unique_ptr<ros::Subscriber> m_guardedMoveStatusSubscriber;
-  std::unique_ptr<ros::Subscriber> m_armMoveJointStatusSubscriber;
-  std::unique_ptr<ros::Subscriber> m_armMoveJointsStatusSubscriber;
-  std::unique_ptr<ros::Subscriber> m_digCircularStatusSubscriber;
-  std::unique_ptr<ros::Subscriber> m_digLinearStatusSubscriber;
-  std::unique_ptr<ros::Subscriber> m_deliverStatusSubscriber;
-  std::unique_ptr<ros::Subscriber> m_discardStatusSubscriber;
-  std::unique_ptr<ros::Subscriber> m_cameraCaptureStatusSubscriber;
-  std::unique_ptr<ros::Subscriber> m_lightSetIntensityStatusSubscriber;
+  // Generic container because the subscribers are not referenced;
+  // only their callback functions are of use.
+  std::vector<std::unique_ptr<ros::Subscriber>> m_subscribers;
 
   // Action clients
   std::unique_ptr<GuardedMoveActionClient> m_guardedMoveClient;


### PR DESCRIPTION
Summary:

- PLEXIL now uses the ROS action for LightSetIntensity instead of the service.
- set_light_intensity and SetLightIntensity have been renamed to light_set_intensity and LightSetIntensity, respectively, everywhere.
- Support for ROS services is completely removed.

Unrelated changes:
 - Refactored the initialization of action status subscribers, eliminating the individual member pointers.
 - Minor code reformatting.
 
Test:

- First, ow_plexil should be rebuilt clean, because a plan was renamed.
- Start any simulator world.
- Run the `TestLanderLights` plan, e.g.
`$ roslaunch ow_plexil ow_exec.launch plan:=TestLanderLights.plx`
- Watch both Gazebo and the ow_exec terminal, which explains what you should see in Gazebo as the plan runs.  (It happens fast, don't blink!).
- Run ReferenceMission1 for regression.  It should complete without incident.


Notes:
 - The major code changes are in OwInterface.cpp.  Changes elsewhere are trivial.