### PR TITLE
Support for unified pan/tilt telemetry

### DIFF
--- a/ow_plexil/rqt_plexil_plan_selection/src/rqt_plexil_plan_selection/rqt_plexil_plan_selection.py
+++ b/ow_plexil/rqt_plexil_plan_selection/src/rqt_plexil_plan_selection/rqt_plexil_plan_selection.py
@@ -12,7 +12,8 @@ from qt_gui.plugin import Plugin
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import pyqtSignal
 from python_qt_binding.QtGui import QBrush, QColor, QIcon
-from python_qt_binding.QtWidgets import QWidget, QAbstractItemView, QTableWidgetItem, QAbstractScrollArea, QMessageBox, QApplication
+from python_qt_binding.QtWidgets import QWidget, QAbstractItemView, \
+  QTableWidgetItem, QAbstractScrollArea, QMessageBox, QApplication
 from ow_plexil.srv import PlanSelection
 from std_msgs.msg import String
 import rosservice
@@ -20,7 +21,7 @@ import rosservice
 class PlexilPlanSelectionGUI(Plugin):
 
   #sets up our signal for the sub callback
-  monitor_signal = pyqtSignal(['QString']) 
+  monitor_signal = pyqtSignal(['QString'])
 
   def __init__(self, context):
     '''init initializes the widget and sets up our subscriber, publisher and event handlers'''
@@ -49,18 +50,19 @@ class PlexilPlanSelectionGUI(Plugin):
     self.status_subscriber = rospy.Subscriber('plexil_plan_selection_status', String, self.status_callback)
     #client placeholder
     self.plan_select_client = None
-  
+
     #Qt signal to modify GUI from callback
     self.monitor_signal[str].connect(self.monitor_status)
 
     #populates the plan list, shows different plans based off of what launch file is running
     if rospy.get_param('owlat_flag', False):
       owlat_plan_dir = os.path.join(rospkg.RosPack().get_path('ow_plexil'), 'src', 'plans', 'owlat_plans')
-      self.populate_plan_list(owlat_plan_dir)
+      unified_plan_dir = os.path.join(rospkg.RosPack().get_path('ow_plexil'), 'src', 'plans', 'unified')
+      self.populate_plan_list([owlat_plan_dir, unified_plan_dir])
     else:
       ow_plan_dir = os.path.join(rospkg.RosPack().get_path('ow_plexil'), 'src', 'plans')
-      self.populate_plan_list(ow_plan_dir)
- 
+      self.populate_plan_list([ow_plan_dir, unified_plan_dir])
+
     #sets up tables
     self._widget.sentPlansTable.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
     self._widget.planQueueTable.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
@@ -75,14 +77,13 @@ class PlexilPlanSelectionGUI(Plugin):
     self._widget.sendButton.clicked[bool].connect(self.handle_send_button_clicked)
     self._widget.resetButton.clicked[bool].connect(self.handle_reset_button_clicked)
 
-  def populate_plan_list(self, plan_dir):
-    '''Finds all .ple plexil plans in the plans directory and stores them in the widget list.'''
+  def populate_plan_list(self, plan_dirs):
+    '''Finds all .ple files in the plan directories and stores them in the widget list.'''
     plan_list = []
-    #get all plans with extension .ple
-    for p in os.listdir(plan_dir):
-      if p.endswith(".ple"):
-        plan_list.append(p.rsplit(".")[0])
-    #add to list
+    for plan_dir in plan_dirs:
+      for p in os.listdir(plan_dir):
+        if p.endswith(".ple"):
+          plan_list.append(p.rsplit(".")[0])
     self._widget.planList.addItems(plan_list)
     self._widget.planList.sortItems()
 
@@ -92,7 +93,7 @@ class PlexilPlanSelectionGUI(Plugin):
      Running, Finished or Failed.'''
     num_rows = self._widget.sentPlansTable.rowCount()
     #if completed and previously running we set status as finished
-    if feedback == "COMPLETE": 
+    if feedback == "COMPLETE":
       for i in range(num_rows):
         current_status = self._widget.sentPlansTable.item(i,1).text()
         if current_status == "Running...":
@@ -103,22 +104,22 @@ class PlexilPlanSelectionGUI(Plugin):
       #splitting into plan name and status
       status = feedback.rsplit(":")[0]
       running_plan = feedback.rsplit(":")[1].rsplit(".")[0]
-      #we set status to running or Failed depending on status 
+      #we set status to running or Failed depending on status
       for i in range(num_rows):
         plan_name = self._widget.sentPlansTable.item(i,0).text()
         current_status = self._widget.sentPlansTable.item(i,1).text()
         if plan_name == running_plan and current_status == "Pending...":
           if status == "SUCCESS":
             self._widget.sentPlansTable.item(i, 1).setText("Running...")
-            break 
+            break
           else:
             self._widget.sentPlansTable.item(i, 1).setText("Failed")
             self._widget.sentPlansTable.item(i, 1).setBackground(QColor(230,38,0))
-            break 
+            break
     return
-   
+
   def status_callback(self, msg):
-    '''Callback from status subscriber. Sends the msg to the function monitor_signal for further 
+    '''Callback from status subscriber. Sends the msg to the function monitor_signal for further
      processing in order to prevent threading issues in the GUI.'''
     #have to use a signal here or else GUI wont update
     feedback_string = str(msg.data)
@@ -181,7 +182,7 @@ class PlexilPlanSelectionGUI(Plugin):
 
   def handle_send_button_clicked(self, checked):
     '''When send button is clicked any items in the plan queue table are sent (in order) to the sent plans table.
-     It then publishes a string array of these plans so that the ow_plexil_plan_selection node can run them 
+     It then publishes a string array of these plans so that the ow_plexil_plan_selection node can run them
      sequentially. If the subscriber is not connected a popup box reminding the user to run the ow_plexil node will show up.'''
     if self.check_client_set_up() == False:
       return
@@ -193,7 +194,7 @@ class PlexilPlanSelectionGUI(Plugin):
       plan_name = self._widget.planQueueTable.item(0,0).text()
       plans_sent.append(str(plan_name + ".plx"))
       self._widget.planQueueTable.removeRow(0)
-      
+
       row_position = self._widget.sentPlansTable.rowCount()
       self._widget.sentPlansTable.insertRow(row_position)
       self._widget.sentPlansTable.setItem(row_position, 0, QTableWidgetItem(plan_name))
@@ -205,7 +206,7 @@ class PlexilPlanSelectionGUI(Plugin):
     return
 
   def handle_reset_button_clicked(self, checked):
-    '''When reset button is clicked all plans in the sent plans table are deleted. It also publishes a string command 
+    '''When reset button is clicked all plans in the sent plans table are deleted. It also publishes a string command
      RESET letting the ow_plexil_plan_selection node know that any plans in its queue should also be deleted.'''
     if self.check_client_set_up() == False:
       return
@@ -244,4 +245,3 @@ class PlexilPlanSelectionGUI(Plugin):
     '''handles shutdown procedures for the plugin, unregisters the publisher and subscriber.'''
     self.status_subscriber.unregister()
     pass
-

--- a/ow_plexil/rqt_plexil_plan_selection/src/rqt_plexil_plan_selection/rqt_plexil_plan_selection.py
+++ b/ow_plexil/rqt_plexil_plan_selection/src/rqt_plexil_plan_selection/rqt_plexil_plan_selection.py
@@ -55,9 +55,10 @@ class PlexilPlanSelectionGUI(Plugin):
     self.monitor_signal[str].connect(self.monitor_status)
 
     #populates the plan list, shows different plans based off of what launch file is running
+    unified_plan_dir = os.path.join(rospkg.RosPack().get_path('ow_plexil'),
+                                    'src', 'plans', 'unified')
     if rospy.get_param('owlat_flag', False):
       owlat_plan_dir = os.path.join(rospkg.RosPack().get_path('ow_plexil'), 'src', 'plans', 'owlat_plans')
-      unified_plan_dir = os.path.join(rospkg.RosPack().get_path('ow_plexil'), 'src', 'plans', 'unified')
       self.populate_plan_list([owlat_plan_dir, unified_plan_dir])
     else:
       ow_plan_dir = os.path.join(rospkg.RosPack().get_path('ow_plexil'), 'src', 'plans')

--- a/ow_plexil/src/plans/CMakeLists.txt
+++ b/ow_plexil/src/plans/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Builds every .plp file in this directory.
 
 if(OWLAT)
-file( GLOB PLEXIL_SRC_PLANS "${CMAKE_CURRENT_SOURCE_DIR}/owlat_plans/*.plp" "${CMAKE_CURRENT_SOURCE_DIR}/*.plp")
+  file( GLOB PLEXIL_SRC_PLANS
+    "${CMAKE_CURRENT_SOURCE_DIR}/owlat_plans/*.plp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/unified/*.plp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.plp")
 set( PLEXIL_CONFIG_FILES "ow-config.xml" "owlat_plans/owlat-config.xml" "plexil-debug.cfg")
 else()
-file( GLOB PLEXIL_SRC_PLANS "${CMAKE_CURRENT_SOURCE_DIR}/*.plp" )
+  file( GLOB PLEXIL_SRC_PLANS
+    "${CMAKE_CURRENT_SOURCE_DIR}/unified/*.plp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.plp" )
 set( PLEXIL_CONFIG_FILES "ow-config.xml" "plexil-debug.cfg")
 endif()
-
 
 set( PLEXIL_PLAN_DIR etc/plexil )
 add_plexil_plans( ${PLEXIL_SRC_PLANS} )

--- a/ow_plexil/src/plans/plan-interface.h
+++ b/ow_plexil/src/plans/plan-interface.h
@@ -81,7 +81,11 @@ Boolean Lookup PowerFault;
 // Relevant with GuardedMove only:
 Boolean Lookup GroundFound;
 Real    Lookup GroundPosition;
+
+// Antenna
+Real    Lookup PanRadians;
 Real    Lookup PanDegrees;
+Real    Lookup TiltRadians;
 Real    Lookup TiltDegrees;
 
 

--- a/ow_plexil/src/plans/unified/README.md
+++ b/ow_plexil/src/plans/unified/README.md
@@ -1,0 +1,2 @@
+This directory contains PLEXIL plans that use the OceanWATERS/OWLAT
+unified interface and are runnable on either testbed.

--- a/ow_plexil/src/plans/unified/TestTelemetry.plp
+++ b/ow_plexil/src/plans/unified/TestTelemetry.plp
@@ -12,8 +12,9 @@ TestTelemetry:
 
   // Note that the current version of OWLAT Sim has neither a pan/tilt
   // command nor pan/tilt telemetry.  Unless values are published to
-  // /pan_tilt_position, these lookups will return the default Lookup
-  // value, which is 0, when this plan is run on OWLAT Sim. 
+  // /pan_tilt_position, these lookups will return the PLEXIL
+  // adapter's default Lookup value, which is 0, when this plan is run
+  // on OWLAT Sim.
   
   log_info ("Pan degees: ", Lookup(PanDegrees));
   log_info ("Pan radians: ", Lookup(PanRadians));

--- a/ow_plexil/src/plans/unified/TestTelemetry.plp
+++ b/ow_plexil/src/plans/unified/TestTelemetry.plp
@@ -1,0 +1,22 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// Read and print telemetry values.
+
+#include "unified-interface.h"
+
+TestTelemetry:
+{
+  // Pan/Tilt telemetry.
+
+  // Note that the current version of OWLAT Sim has neither a pan/tilt
+  // command nor pan/tilt telemetry.  Unless values are published to
+  // /pan_tilt_position, these lookups will return the default Lookup
+  // value, which is 0, when this plan is run on OWLAT Sim. 
+  
+  log_info ("Pan degees: ", Lookup(PanDegrees));
+  log_info ("Pan radians: ", Lookup(PanRadians));
+  log_info ("Tilt degees: ", Lookup(TiltDegrees));
+  log_info ("Tilt radians: ", Lookup(TiltRadians));
+}

--- a/ow_plexil/src/plans/unified/unified-interface.h
+++ b/ow_plexil/src/plans/unified/unified-interface.h
@@ -1,0 +1,19 @@
+#ifndef Unified_Interface_H
+#define Unified_Interface_H
+
+// Utility commands; issue ROS_INFO, ROS_WARN, and ROS_ERROR, respectively.
+Command log_info (...);
+Command log_warning (...);
+Command log_error (...);
+Command log_debug (...);
+
+
+////////////// Telemetry //////////////////
+
+// Antenna
+Real    Lookup PanRadians;
+Real    Lookup PanDegrees;
+Real    Lookup TiltRadians;
+Real    Lookup TiltDegrees;
+
+#endif

--- a/ow_plexil/src/plans/unified/unified-interface.h
+++ b/ow_plexil/src/plans/unified/unified-interface.h
@@ -1,6 +1,9 @@
 #ifndef Unified_Interface_H
 #define Unified_Interface_H
 
+// Unified interface to OceanWATERS and OWLAT.
+// Under construction!
+
 // Utility commands; issue ROS_INFO, ROS_WARN, and ROS_ERROR, respectively.
 Command log_info (...);
 Command log_warning (...);

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -81,8 +81,14 @@ static bool lookup (const string& state_name,
   else STATE_STUB(SampleGood, true)
   else STATE_STUB(CollectAndTransferTimeout, 10)
 
+  else if (state_name == "TiltRadians") {
+    value_out = OwInterface::instance()->getTiltRadians();
+  }
   else if (state_name == "TiltDegrees") {
-    value_out = OwInterface::instance()->getTilt();
+    value_out = OwInterface::instance()->getTiltDegrees();
+  }
+  else if (state_name == "PanRadians") {
+    value_out = OwInterface::instance()->getPanRadians();
   }
   else if (state_name == "PanDegrees") {
     value_out = OwInterface::instance()->getPanDegrees();

--- a/ow_plexil/src/plexil-adapter/OwExecutive.cpp
+++ b/ow_plexil/src/plexil-adapter/OwExecutive.cpp
@@ -43,8 +43,13 @@ OwExecutive* OwExecutive::instance ()
   return &instance;
 }
 
-bool OwExecutive::getPlanState()
+bool OwExecutive::allPlansFinished()
 {
+  // WARNING: The called function returns true iff the PLEXIL
+  // executive has executed at least one plan, and no plans are
+  // currently running.  This is NOT accurate enough for the callers
+  // of this method.  The PLEXIL team has been consulted for a better
+  // approach on 12/16/22.
   return PlexilApp->allPlansFinished();
 }
 

--- a/ow_plexil/src/plexil-adapter/OwExecutive.h
+++ b/ow_plexil/src/plexil-adapter/OwExecutive.h
@@ -23,7 +23,7 @@ class OwExecutive
   static OwExecutive* instance();
 
   bool initialize (const std::string& config_file);
-  bool getPlanState(); // returns true if current plan is finished executing
+  bool allPlansFinished(); // See warning in implementation.
   bool runPlan (const std::string& filename);
 };
 

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -32,16 +32,9 @@ using std::string;
 using std::shared_ptr;
 using std::make_unique;
 
-// C
-#include <cmath>  // for M_PI, fabs, fmod
-
 using namespace ow_lander;
 
 //////////////////// Utilities ////////////////////////
-
-// Degree/Radian
-constexpr double D2R = M_PI / 180.0 ;
-constexpr double R2D = 180.0 / M_PI ;
 
 const double PanTiltToleranceDegrees = 2.865; // 0.05 radians, matching simulator
 const double VelocityTolerance       = 0.01;  // made up, unitless

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -282,12 +282,14 @@ void OwInterface::jointStatesCallback
       double velocity = msg->velocity[i];
       double effort = msg->effort[i];
       if (joint == Joint::antenna_pan) {
-        m_currentPan = position * R2D;
-        publish ("PanDegrees", m_currentPan);
+        m_currentPanRadians = position;
+        publish ("PanRadians", m_currentPanRadians);
+        publish ("PanDegrees", m_currentPanRadians * R2D);
      }
       else if (joint == Joint::antenna_tilt) {
-        m_currentTilt = position * R2D;
-        publish ("TiltDegrees", m_currentTilt);
+        m_currentTiltRadians = position;
+        publish ("TiltRadians", m_currentTiltRadians);
+        publish ("TiltDegrees", m_currentTiltRadians * R2D);
       }
       JointTelemetryMap[joint] = JointTelemetry (position, velocity, effort);
       string plexil_name = JointPropMap[joint].plexilName;
@@ -455,7 +457,10 @@ OwInterface* OwInterface::instance ()
   return &instance;
 }
 
-OwInterface::OwInterface () : m_currentPan (0), m_currentTilt (0) { }
+OwInterface::OwInterface ()
+  : m_currentPanRadians (0),
+    m_currentTiltRadians (0)
+{ }
 
 void OwInterface::initialize()
 {
@@ -1097,14 +1102,24 @@ void OwInterface::lightSetIntensityAction (const string& side, double intensity,
 }
 
 
-double OwInterface::getTilt () const
+double OwInterface::getTiltRadians () const
 {
-  return m_currentTilt;
+  return m_currentTiltRadians;
+}
+
+double OwInterface::getTiltDegrees () const
+{
+  return m_currentTiltRadians * R2D;
+}
+
+double OwInterface::getPanRadians () const
+{
+  return m_currentPanRadians;
 }
 
 double OwInterface::getPanDegrees () const
 {
-  return m_currentPan;
+  return m_currentPanRadians * R2D;
 }
 
 double OwInterface::getPanVelocity () const

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -119,7 +119,9 @@ class OwInterface : public PlexilInterface
   void lightSetIntensity (const std::string& side, double intensity, int id);
 
   // State/Lookup interface
-  double getTilt () const;
+  double getTiltRadians () const;
+  double getTiltDegrees () const;
+  double getPanRadians () const;
   double getPanDegrees () const;
   double getPanVelocity () const;
   double getTiltVelocity () const;
@@ -258,7 +260,7 @@ class OwInterface : public PlexilInterface
   std::unique_ptr<IdentifySampleLocationActionClient> m_identifySampleLocationClient;
 
   // Antenna state
-  double m_currentPan, m_currentTilt;
+  double m_currentPanRadians, m_currentTiltRadians;
 };
 
 #endif

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -230,8 +230,6 @@ class OwInterface : public PlexilInterface
     {"JOINT_LIMIT_ERROR", std::make_pair(2, false)}
   };
 
-  std::unique_ptr<ros::NodeHandle> m_genericNodeHandle;
-
   // Publishers and subscribers
 
   std::unique_ptr<ros::Publisher> m_antennaTiltPublisher;

--- a/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
@@ -59,7 +59,7 @@ static void owlat_arm_move_cartesian (Command* cmd, AdapterExecInterface* intf)
   orientation->getContentsVector(orientation_vector);
   std::unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwlatInterface::instance()->owlatArmMoveCartesian (frame, relative,
-                                                     *position_vector, 
+                                                     *position_vector,
                                                      *orientation_vector,
                                                      CommandId);
   acknowledge_command_sent(*cr);
@@ -87,9 +87,9 @@ static void owlat_arm_move_cartesian_guarded (Command* cmd,
   position->getContentsVector(position_vector);
   orientation->getContentsVector(orientation_vector);
   std::unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
-  OwlatInterface::instance()->owlatArmMoveCartesianGuarded (frame, relative, 
+  OwlatInterface::instance()->owlatArmMoveCartesianGuarded (frame, relative,
                                                             *position_vector,
-                                                            *orientation_vector, 
+                                                            *orientation_vector,
                                                             retracting,
                                                             force_threshold,
                                                             torque_threshold,
@@ -146,8 +146,8 @@ static void owlat_arm_move_joints_guarded (Command* cmd,
   std::unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwlatInterface::instance()->owlatArmMoveJointsGuarded (relative,
                                                          *angles_vector,
-                                                         retracting, 
-                                                         force_threshold, 
+                                                         retracting,
+                                                         force_threshold,
                                                          torque_threshold,
                                                          CommandId);
   acknowledge_command_sent(*cr);
@@ -176,9 +176,9 @@ static void owlat_arm_place_tool (Command* cmd, AdapterExecInterface* intf)
   position->getContentsVector(position_vector);
   normal->getContentsVector(normal_vector);
   std::unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
-  OwlatInterface::instance()->owlatArmPlaceTool (frame, relative, 
+  OwlatInterface::instance()->owlatArmPlaceTool (frame, relative,
                                                  *position_vector,
-                                                 *normal_vector, 
+                                                 *normal_vector,
                                                  distance, overdrive,
                                                  retracting,
                                                  force_threshold,
@@ -322,6 +322,13 @@ static void pspStopReason (const State& state, StateCacheEntry &entry)
   entry.update(OwlatInterface::instance()->getPSPStopReason());
 }
 
+static void panTiltPosition (const State& state, StateCacheEntry &entry)
+{
+  debugMsg("PanTiltPosition ", "lookup called for " << state.name()
+           << " with " << state.parameters().size() << " args");
+  entry.update(OwlatInterface::instance()->getPanTiltPosition());
+}
+
 static void getDefaultLookupHandler (const State& state, StateCacheEntry &entry)
 {
   debugMsg("getDefaultLookupHandler", "lookup called for " << state.name()
@@ -343,7 +350,7 @@ bool OwlatAdapter::initialize()
   CommonAdapter::initialize();
 
   // Commands
-  
+
   g_configuration->registerCommandHandler("owlat_unstow", owlat_unstow);
   g_configuration->registerCommandHandler("owlat_stow", owlat_stow);
   g_configuration->registerCommandHandler("owlat_arm_move_cartesian",
@@ -367,7 +374,7 @@ bool OwlatAdapter::initialize()
   OwlatInterface::instance()->setCommandStatusCallback (command_status_callback);
 
   // Telemetry
-  
+
   g_configuration->registerLookupHandler("ArmJointAngles", armJointAngles);
   g_configuration->registerLookupHandler("ArmJointAccelerations",
                                          armJointAccelerations);
@@ -380,6 +387,7 @@ bool OwlatAdapter::initialize()
   g_configuration->registerLookupHandler("ArmPose", armPose);
   g_configuration->registerLookupHandler("ArmTool", armTool);
   g_configuration->registerLookupHandler("PSPStopReason", pspStopReason);
+  g_configuration->registerLookupHandler("PanTiltPosition", panTiltPosition);
   g_configuration->setDefaultLookupHandler(getDefaultLookupHandler);
 
   debugMsg("OwlatAdapter", " initialized.");

--- a/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
@@ -322,11 +322,32 @@ static void pspStopReason (const State& state, StateCacheEntry &entry)
   entry.update(OwlatInterface::instance()->getPSPStopReason());
 }
 
-static void panTiltPosition (const State& state, StateCacheEntry &entry)
+static void panRadians (const State& state, StateCacheEntry &entry)
 {
-  debugMsg("PanTiltPosition ", "lookup called for " << state.name()
+  debugMsg("PanRadians ", "lookup called for " << state.name()
            << " with " << state.parameters().size() << " args");
-  entry.update(OwlatInterface::instance()->getPanTiltPosition());
+  entry.update(OwlatInterface::instance()->getPanRadians());
+}
+
+static void panDegrees (const State& state, StateCacheEntry &entry)
+{
+  debugMsg("PanDegrees ", "lookup called for " << state.name()
+           << " with " << state.parameters().size() << " args");
+  entry.update(OwlatInterface::instance()->getPanDegrees());
+}
+
+static void tiltRadians (const State& state, StateCacheEntry &entry)
+{
+  debugMsg("TiltRadians ", "lookup called for " << state.name()
+           << " with " << state.parameters().size() << " args");
+  entry.update(OwlatInterface::instance()->getTiltRadians());
+}
+
+static void tiltDegrees (const State& state, StateCacheEntry &entry)
+{
+  debugMsg("TiltDegrees ", "lookup called for " << state.name()
+           << " with " << state.parameters().size() << " args");
+  entry.update(OwlatInterface::instance()->getTiltDegrees());
 }
 
 static void getDefaultLookupHandler (const State& state, StateCacheEntry &entry)
@@ -387,7 +408,10 @@ bool OwlatAdapter::initialize()
   g_configuration->registerLookupHandler("ArmPose", armPose);
   g_configuration->registerLookupHandler("ArmTool", armTool);
   g_configuration->registerLookupHandler("PSPStopReason", pspStopReason);
-  g_configuration->registerLookupHandler("PanTiltPosition", panTiltPosition);
+  g_configuration->registerLookupHandler("PanRadians", panRadians);
+  g_configuration->registerLookupHandler("PanDegrees", panDegrees);
+  g_configuration->registerLookupHandler("TiltRadians", tiltRadians);
+  g_configuration->registerLookupHandler("TiltDegrees", tiltDegrees);
   g_configuration->setDefaultLookupHandler(getDefaultLookupHandler);
 
   debugMsg("OwlatAdapter", " initialized.");

--- a/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
@@ -341,6 +341,9 @@ OwlatAdapter::OwlatAdapter (AdapterExecInterface& execInterface,
 bool OwlatAdapter::initialize()
 {
   CommonAdapter::initialize();
+
+  // Commands
+  
   g_configuration->registerCommandHandler("owlat_unstow", owlat_unstow);
   g_configuration->registerCommandHandler("owlat_stow", owlat_stow);
   g_configuration->registerCommandHandler("owlat_arm_move_cartesian",
@@ -363,6 +366,8 @@ bool OwlatAdapter::initialize()
   g_configuration->registerCommandHandler("owlat_task_scoop", owlat_task_scoop);
   OwlatInterface::instance()->setCommandStatusCallback (command_status_callback);
 
+  // Telemetry
+  
   g_configuration->registerLookupHandler("ArmJointAngles", armJointAngles);
   g_configuration->registerLookupHandler("ArmJointAccelerations",
                                          armJointAccelerations);

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
@@ -741,8 +741,8 @@ void OwlatInterface::armToolCallback
 void OwlatInterface::panTiltCallback
 (const owl_msgs::PanTiltPosition::ConstPtr& msg)
 {
-  m_pan_radians = msg->value.value[0];
-  m_tilt_radians = msg->value.value[1];
+  m_pan_radians = msg->value[0];
+  m_tilt_radians = msg->value[1];
   publish("PanRadians", m_pan_radians);
   publish("TiltRadians", m_tilt_radians);
 }
@@ -792,22 +792,22 @@ Value OwlatInterface::getPSPStopReason() const
   return(Value(PSPStopReasonVar));
 }
 
-Value getPanDegrees() const
-{
-  return m_pan_radians * R2D;
-}
-
-Value getPanRadians() const
+Value OwlatInterface::getPanRadians() const
 {
   return m_pan_radians;
 }
 
-Value getTiltRadians() const
+Value OwlatInterface::getPanDegrees() const
+{
+  return m_pan_radians * R2D;
+}
+
+Value OwlatInterface::getTiltRadians() const
 {
   return m_tilt_radians;
 }
 
-Value getTiltDegrees() const
+Value OwlatInterface::getTiltDegrees() const
 {
   return m_tilt_radians * R2D;
 }

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
@@ -744,7 +744,9 @@ void OwlatInterface::panTiltCallback
   m_pan_radians = msg->value[0];
   m_tilt_radians = msg->value[1];
   publish("PanRadians", m_pan_radians);
+  publish("PanDegrees", m_pan_radians * R2D);
   publish("TiltRadians", m_tilt_radians);
+  publish("TiltDegrees", m_tilt_radians * R2D);
 }
 
 Value OwlatInterface::getArmJointAngles() const

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
@@ -132,7 +132,7 @@ void OwlatInterface::initialize()
       (make_unique<ros::Subscriber>
        (m_genericNodeHandle ->
         subscribe("/owlat_sim/ARM_JOINT_VELOCITIES", qsize,
-                  &OwlatInterface::armJointAnglesCallback, this)));
+                  &OwlatInterface::armJointVelocitiesCallback, this)));
 
 
     m_subscribers.push_back

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
@@ -70,10 +70,10 @@ static vector<string> LanderOpNames = {
 
 // Task PSP Callback
 static double PSPStopReasonVar = 0;
+
 template<int OpIndex, typename T>
-static void task_psp_done_cb
-(const actionlib::SimpleClientGoalState& state,
- const T& result)
+static void task_psp_done_cb (const actionlib::SimpleClientGoalState& state,
+                              const T& result)
 {
   ROS_INFO("PSP Stop Reason: : %d", result->stop_reason.value);
   PSPStopReasonVar = result->stop_reason.value;
@@ -110,45 +110,60 @@ void OwlatInterface::initialize()
     m_arm_tool = 0;
 
     const int qsize = 3;
-    m_armJointAnglesSubscriber = make_unique<ros::Subscriber>
-      (m_genericNodeHandle ->
-       subscribe("/owlat_sim/ARM_JOINT_ANGLES", qsize,
-       &OwlatInterface::armJointAnglesCallback, this));
+    m_subscribers.push_back
+      (make_unique<ros::Subscriber>
+       (m_genericNodeHandle ->
+        subscribe("/owlat_sim/ARM_JOINT_ANGLES", qsize,
+                  &OwlatInterface::armJointAnglesCallback, this)));
 
-    m_armJointAccelerationsSubscriber = make_unique<ros::Subscriber>
-      (m_genericNodeHandle ->
-       subscribe("/owlat_sim/ARM_JOINT_ACCELERATIONS", qsize,
-       &OwlatInterface::armJointAccelerationsCallback, this));
+    m_subscribers.push_back
+      (make_unique<ros::Subscriber>
+       (m_genericNodeHandle ->
+        subscribe("/owlat_sim/ARM_JOINT_ACCELERATIONS", qsize,
+                  &OwlatInterface::armJointAccelerationsCallback, this)));
 
-    m_armJointTorquesSubscriber = make_unique<ros::Subscriber>
-      (m_genericNodeHandle ->
-       subscribe("/owlat_sim/ARM_JOINT_TORQUES", qsize,
-       &OwlatInterface::armJointTorquesCallback, this));
+    m_subscribers.push_back
+      (make_unique<ros::Subscriber>
+       (m_genericNodeHandle ->
+        subscribe("/owlat_sim/ARM_JOINT_TORQUES", qsize,
+                  &OwlatInterface::armJointTorquesCallback, this)));
 
-    m_armJointVelocitiesSubscriber = make_unique<ros::Subscriber>
-      (m_genericNodeHandle ->
-       subscribe("/owlat_sim/ARM_JOINT_VELOCITIES", qsize,
-       &OwlatInterface::armJointAnglesCallback, this));
+    m_subscribers.push_back
+      (make_unique<ros::Subscriber>
+       (m_genericNodeHandle ->
+        subscribe("/owlat_sim/ARM_JOINT_VELOCITIES", qsize,
+                  &OwlatInterface::armJointAnglesCallback, this)));
 
-    m_armFTTorqueSubscriber = make_unique<ros::Subscriber>
-      (m_genericNodeHandle ->
-       subscribe("/owlat_sim/ARM_FT_TORQUE", qsize,
-       &OwlatInterface::armFTTorqueCallback, this));
 
-   m_armFTForceSubscriber = make_unique<ros::Subscriber>
-        (m_genericNodeHandle ->
-         subscribe("/owlat_sim/ARM_FT_FORCE", qsize,
-         &OwlatInterface::armFTForceCallback, this));
+    m_subscribers.push_back
+      (make_unique<ros::Subscriber>
+       (m_genericNodeHandle ->
+        subscribe("/owlat_sim/ARM_FT_TORQUE", qsize,
+                  &OwlatInterface::armFTTorqueCallback, this)));
 
-   m_armPoseSubscriber = make_unique<ros::Subscriber>
-        (m_genericNodeHandle ->
-         subscribe("/owlat_sim/ARM_POSE", qsize,
-         &OwlatInterface::armPoseCallback, this));
+    m_subscribers.push_back
+      (make_unique<ros::Subscriber>
+       (m_genericNodeHandle ->
+        subscribe("/owlat_sim/ARM_FT_FORCE", qsize,
+                  &OwlatInterface::armFTForceCallback, this)));
 
-   m_armToolSubscriber = make_unique<ros::Subscriber>
-        (m_genericNodeHandle ->
-         subscribe("/owlat_sim/ARM_TOOL", qsize,
-         &OwlatInterface::armToolCallback, this));
+    m_subscribers.push_back
+      (make_unique<ros::Subscriber>
+       (m_genericNodeHandle ->
+        subscribe("/owlat_sim/ARM_POSE", qsize,
+                  &OwlatInterface::armPoseCallback, this)));
+
+    m_subscribers.push_back
+      (make_unique<ros::Subscriber>
+       (m_genericNodeHandle ->
+        subscribe("/owlat_sim/ARM_TOOL", qsize,
+                  &OwlatInterface::armToolCallback, this)));
+
+    m_subscribers.push_back
+      (make_unique<ros::Subscriber>
+       (m_genericNodeHandle ->
+        subscribe("/owl_msgs/pan_tilt_position", qsize,
+                  &OwlatInterface::panTiltCallback, this)));
 
     // Initialize pointers
     m_owlatUnstowClient =
@@ -723,48 +738,76 @@ void OwlatInterface::armToolCallback
   publish("ArmTool", m_arm_tool);
 }
 
-Value OwlatInterface::getArmJointAngles()
+void OwlatInterface::panTiltCallback
+(const owl_msgs::PanTiltPosition::ConstPtr& msg)
+{
+  m_pan_radians = msg->value.value[0];
+  m_tilt_radians = msg->value.value[1];
+  publish("PanRadians", m_pan_radians);
+  publish("TiltRadians", m_tilt_radians);
+}
+
+Value OwlatInterface::getArmJointAngles() const
 {
   return(Value(m_arm_joint_angles));
 }
 
-Value OwlatInterface::getArmJointAccelerations()
+Value OwlatInterface::getArmJointAccelerations() const
 {
   return(Value(m_arm_joint_accelerations));
 }
 
-Value OwlatInterface::getArmJointTorques()
+Value OwlatInterface::getArmJointTorques() const
 {
   return(Value(m_arm_joint_torques));
 }
 
-Value OwlatInterface::getArmJointVelocities()
+Value OwlatInterface::getArmJointVelocities() const
 {
   return(Value(m_arm_joint_velocities));
 }
 
-Value OwlatInterface::getArmFTTorque()
+Value OwlatInterface::getArmFTTorque() const
 {
   return(Value(m_arm_ft_torque));
 }
 
-Value OwlatInterface::getArmFTForce()
+Value OwlatInterface::getArmFTForce() const
 {
   return(Value(m_arm_ft_force));
 }
 
-Value OwlatInterface::getArmPose()
+Value OwlatInterface::getArmPose() const
 {
   return(Value(m_arm_pose));
 }
 
-Value OwlatInterface::getArmTool()
+Value OwlatInterface::getArmTool() const
 {
   return(Value(m_arm_tool));
 }
 
-Value OwlatInterface::getPSPStopReason()
+Value OwlatInterface::getPSPStopReason() const
 {
   return(Value(PSPStopReasonVar));
 }
 
+Value getPanDegrees() const
+{
+  return m_pan_radians * R2D;
+}
+
+Value getPanRadians() const
+{
+  return m_pan_radians;
+}
+
+Value getTiltRadians() const
+{
+  return m_tilt_radians;
+}
+
+Value getTiltDegrees() const
+{
+  return m_tilt_radians * R2D;
+}

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.h
@@ -11,6 +11,9 @@
 #include <memory>
 #include <ros/ros.h>
 
+// owl_msgs
+#include <owl_msgs/PanTiltPosition.h>
+
 // ow_plexil
 #include <Value.hh>
 #include "PlexilInterface.h"
@@ -182,6 +185,7 @@ class OwlatInterface : public PlexilInterface
   void armFTForceCallback(const owlat_sim_msgs::ARM_FT_FORCE::ConstPtr& msg);
   void armPoseCallback(const owlat_sim_msgs::ARM_POSE::ConstPtr& msg);
   void armToolCallback(const owlat_sim_msgs::ARM_TOOL::ConstPtr& msg);
+  void panTiltCallback (const owl_msgs::PanTiltPosition::ConstPtr& msg);
 
   // Action Clients
   std::unique_ptr<OwlatUnstowActionClient> m_owlatUnstowClient;
@@ -207,6 +211,8 @@ class OwlatInterface : public PlexilInterface
   std::vector<double> m_arm_ft_force;
   std::vector<double> m_arm_pose;
   double m_arm_tool;
+  double m_pan_radians;
+  double m_tilt_radians;
 };
 
 #endif

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.h
@@ -79,28 +79,28 @@ class OwlatInterface : public PlexilInterface
   // Lander interface
   void owlatUnstow (int id);
   void owlatStow (int id);
-  void owlatArmMoveCartesian (int frame, bool relative, 
-                              const std::vector<double>& position, 
-                              const std::vector<double>& orientation, 
+  void owlatArmMoveCartesian (int frame, bool relative,
+                              const std::vector<double>& position,
+                              const std::vector<double>& orientation,
                               int id);
-  void owlatArmMoveCartesianGuarded (int frame, bool relative, 
-                                     const std::vector<double>& position, 
+  void owlatArmMoveCartesianGuarded (int frame, bool relative,
+                                     const std::vector<double>& position,
                                      const std::vector<double>& orientation,
                                      bool retracting,
                                      double force_threshold,
                                      double torque_threshold,int id);
-  void owlatArmMoveJoint (bool relative, int joint, double angle, 
+  void owlatArmMoveJoint (bool relative, int joint, double angle,
                           int id);
   void owlatArmMoveJoints (bool relative,
                            const std::vector<double>& angles,
-                           int id); 
+                           int id);
   void owlatArmMoveJointsGuarded (bool relative,
-                                  const std::vector<double>& angles, 
+                                  const std::vector<double>& angles,
                                   bool retracting, double force_threshold,
                                   double torque_threshold, int id);
   void owlatArmPlaceTool (int frame,
                           bool relative,
-                          const std::vector<double>& position, 
+                          const std::vector<double>& position,
                           const std::vector<double>& normal,
                           double distance, double overdrive,
                           bool retracting, double force_threshold,
@@ -108,47 +108,51 @@ class OwlatInterface : public PlexilInterface
   void owlatArmSetTool (int tool, int id);
   void owlatArmStop (int id);
   void owlatArmTareFS (int id);
-  void owlatTaskPSP (int frame, bool relative, const std::vector<double>& point, 
+  void owlatTaskPSP (int frame, bool relative, const std::vector<double>& point,
                      const std::vector<double>& normal, double max_depth,
-                     double max_force, int id); 
-  void owlatTaskScoop (int frame, bool relative, const std::vector<double>& point, 
-                       const std::vector<double>& normal, int id); 
+                     double max_force, int id);
+  void owlatTaskScoop (int frame, bool relative, const std::vector<double>& point,
+                       const std::vector<double>& normal, int id);
 
   // Lookups
-  PLEXIL::Value getArmJointAngles();
-  PLEXIL::Value getArmJointAccelerations();
-  PLEXIL::Value getArmJointTorques();
-  PLEXIL::Value getArmJointVelocities();
-  PLEXIL::Value getArmFTTorque();
-  PLEXIL::Value getArmFTForce();
-  PLEXIL::Value getArmPose();
-  PLEXIL::Value getArmTool();
-  PLEXIL::Value getPSPStopReason();
+  PLEXIL::Value getArmJointAngles() const;
+  PLEXIL::Value getArmJointAccelerations() const;
+  PLEXIL::Value getArmJointTorques() const ;
+  PLEXIL::Value getArmJointVelocities() const;
+  PLEXIL::Value getArmFTTorque() const;
+  PLEXIL::Value getArmFTForce() const;
+  PLEXIL::Value getArmPose() const;
+  PLEXIL::Value getArmTool() const;
+  PLEXIL::Value getPSPStopReason() const;
+  PLEXIL::Value getPanDegrees() const;
+  PLEXIL::Value getPanRadians() const;
+  PLEXIL::Value getTiltRadians() const;
+  PLEXIL::Value getTiltDegrees() const;
 
  private:
 
   // Actions
   void owlatUnstowAction (int id);
   void owlatStowAction (int id);
-  void owlatArmMoveCartesianAction (int frame, bool relative, 
-                                    const std::vector<double>& position, 
-                                    const std::vector<double>& orientation, 
+  void owlatArmMoveCartesianAction (int frame, bool relative,
+                                    const std::vector<double>& position,
+                                    const std::vector<double>& orientation,
                                     int id);
-  void owlatArmMoveCartesianGuardedAction (int frame, bool relative, 
-                                           const std::vector<double>& position, 
+  void owlatArmMoveCartesianGuardedAction (int frame, bool relative,
+                                           const std::vector<double>& position,
                                            const std::vector<double>& orientation,
-                                           bool retracting, 
-                                           double force_threshold, 
+                                           bool retracting,
+                                           double force_threshold,
                                            double torque_threshold,int id);
   void owlatArmMoveJointAction (bool relative, int joint,
-                                double angle, int id); 
+                                double angle, int id);
   void owlatArmMoveJointsAction (bool relative, const std::vector<double>& angles,
                                  int id);
   void owlatArmMoveJointsGuardedAction (bool relative,
-                                        const std::vector<double>& angles, 
+                                        const std::vector<double>& angles,
                                         bool retracting, double force_threshold,
                                         double torque_threshold, int id);
-  void owlatArmPlaceToolAction (int frame, bool relative, 
+  void owlatArmPlaceToolAction (int frame, bool relative,
                                 const std::vector<double>& position,
                                 const std::vector<double>& normal,
                                 double distance, double overdrive,
@@ -158,25 +162,12 @@ class OwlatInterface : public PlexilInterface
   void owlatArmStopAction (int id);
   void owlatArmTareFSAction (int id);
   void owlatTaskPSPAction (int frame, bool relative,
-                           const std::vector<double>& point, 
+                           const std::vector<double>& point,
                            const std::vector<double>& normal, double max_depth,
                            double max_force, int id);
   void owlatTaskScoopAction (int frame, bool relative,
-                             const std::vector<double>& point, 
-                             const std::vector<double>& normal, int id); 
-
-  // Node handle
-  std::unique_ptr<ros::NodeHandle> m_genericNodeHandle;
-
-  // Subscribers
-  std::unique_ptr<ros::Subscriber> m_armJointAnglesSubscriber;
-  std::unique_ptr<ros::Subscriber> m_armJointAccelerationsSubscriber;
-  std::unique_ptr<ros::Subscriber> m_armJointTorquesSubscriber;
-  std::unique_ptr<ros::Subscriber> m_armJointVelocitiesSubscriber;
-  std::unique_ptr<ros::Subscriber> m_armFTTorqueSubscriber;
-  std::unique_ptr<ros::Subscriber> m_armFTForceSubscriber;
-  std::unique_ptr<ros::Subscriber> m_armPoseSubscriber;
-  std::unique_ptr<ros::Subscriber> m_armToolSubscriber;
+                             const std::vector<double>& point,
+                             const std::vector<double>& normal, int id);
 
   // Callbacks
   void armJointAnglesCallback

--- a/ow_plexil/src/plexil-adapter/PlexilInterface.h
+++ b/ow_plexil/src/plexil-adapter/PlexilInterface.h
@@ -9,6 +9,11 @@
 // simulators and testbeds.
 
 #include "action_support.h"
+#include <cmath>  // for M_PI, fabs, fmod
+
+// Degree/Radian conversion used in subclasses
+constexpr double D2R = M_PI / 180.0 ;
+constexpr double R2D = 180.0 / M_PI ;
 
 class PlexilInterface
 {
@@ -62,6 +67,13 @@ class PlexilInterface
     bool finished_before_timeout = ac->waitForResult (ros::Duration (0));
     markOperationFinished (opname, id);
   }
+
+  // Node handle reused much.
+  std::unique_ptr<ros::NodeHandle> m_genericNodeHandle;
+
+  // Subscribers: generic container because the subscribers are not
+  // referenced; only their callback functions are of use.
+  std::vector<std::unique_ptr<ros::Subscriber>> m_subscribers;
 
  private:
   // Callback function in PLEXIL adapter for success/failure of given command.

--- a/ow_plexil/src/plexil-adapter/PlexilPlanSelection.cpp
+++ b/ow_plexil/src/plexil-adapter/PlexilPlanSelection.cpp
@@ -27,14 +27,15 @@ void PlexilPlanSelection::initialize(std::string initial_plan)
   if(initial_plan.compare("None") != 0) {
     m_plan_array.push_back(initial_plan);
   }
+  
   //workaround for the allPlansFinished not returning correctly for first plan
   m_first_plan = true;
 
   //initialize service
   m_planSelectionService = std::make_unique<ros::ServiceServer>
-      (m_genericNodeHandle->
-       advertiseService("/plexil_plan_selection",
-       &PlexilPlanSelection::planSelectionServiceCallback, this));
+    (m_genericNodeHandle->
+     advertiseService("/plexil_plan_selection",
+                      &PlexilPlanSelection::planSelectionServiceCallback, this));
 
   //initialize publisher
   m_planSelectionStatusPublisher = std::make_unique<ros::Publisher>
@@ -90,39 +91,39 @@ void PlexilPlanSelection::runCurrentPlan(){
 
   if (OwExecutive::instance()->runPlan(m_plan_array[0].c_str())) {
 
-/* Skipping these checks for now, because they don't work if the plan
-   finishes execution very quickly.  Seeking a solution from the
-   PLEXIL team as of 12/16/22.
+    /* Skipping these checks for now, because they don't work if the plan
+       finishes execution very quickly.  Seeking a solution from the
+       PLEXIL team as of 12/16/22.
 
-    // Workaround for allPlansFinished() not working on first plan.
-    if (m_first_plan) m_first_plan = false;
+       // Workaround for allPlansFinished() not working on first plan.
+       if (m_first_plan) m_first_plan = false;
 
-    // Times out, or the plan is registered as running.
-    int timeout = 0;
-    while(OwExecutive::instance()->allPlansFinished() && 
-          timeout < TIMEOUT * LOOP_RATE) {
-      ros::spinOnce();
-      rate.sleep();
-      timeout+=1;
-      if(timeout % LOOP_RATE == 0){
-        ROS_ERROR("Plan not responding, timing out in %i seconds",
-                  (TIMEOUT - timeout/LOOP_RATE));
-      }
-    }
+       // Times out, or the plan is registered as running.
+       int timeout = 0;
+       while(OwExecutive::instance()->allPlansFinished() && 
+       timeout < TIMEOUT * LOOP_RATE) {
+       ros::spinOnce();
+       rate.sleep();
+       timeout+=1;
+       if(timeout % LOOP_RATE == 0){
+       ROS_ERROR("Plan not responding, timing out in %i seconds",
+       (TIMEOUT - timeout/LOOP_RATE));
+       }
+       }
 
-    // If timed out we set plan as failed for GUI.
-    if(timeout == TIMEOUT * LOOP_RATE){
-      ROS_INFO ("Plan timed out, try again.");
-      status.data = "FAILED:" + m_plan_array[0];
-      m_planSelectionStatusPublisher->publish(status);
-    }
-    //otherwise we set it as running
-    else{
-      status.data = "SUCCESS:" + m_plan_array[0];
-      m_planSelectionStatusPublisher->publish(status);
-    }
-  }
-*/
+       // If timed out we set plan as failed for GUI.
+       if(timeout == TIMEOUT * LOOP_RATE){
+       ROS_INFO ("Plan timed out, try again.");
+       status.data = "FAILED:" + m_plan_array[0];
+       m_planSelectionStatusPublisher->publish(status);
+       }
+       //otherwise we set it as running
+       else{
+       status.data = "SUCCESS:" + m_plan_array[0];
+       m_planSelectionStatusPublisher->publish(status);
+       }
+       }
+    */
     // Workaround for allPlansFinished() not working on first plan.
     if (m_first_plan) m_first_plan = false;
 

--- a/ow_plexil/src/plexil-adapter/PlexilPlanSelection.cpp
+++ b/ow_plexil/src/plexil-adapter/PlexilPlanSelection.cpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <std_msgs/String.h>
 
+const auto LOOP_RATE = 10.0;
+
 void PlexilPlanSelection::initialize(std::string initial_plan)
 {
   ROS_INFO("Starting PLEXIL executive node...");
@@ -23,7 +25,7 @@ void PlexilPlanSelection::initialize(std::string initial_plan)
 
   // if launch argument plan is given we add it
   if(initial_plan.compare("None") != 0) {
-    plan_array.push_back(initial_plan);
+    m_plan_array.push_back(initial_plan);
   }
   //workaround for the allPlansFinished not returning correctly for first plan
   m_first_plan = true;
@@ -44,19 +46,19 @@ void PlexilPlanSelection::initialize(std::string initial_plan)
 
 void PlexilPlanSelection::start()
 {
-  ros::Rate rate(10); // 10 Hz for overall rate we are spinning
+  ros::Rate rate(LOOP_RATE);
   int length = 0;
   while(ros::ok()){
     //if we have plans in our plan array we begin the control loop
-    if(plan_array.size() > 0){
-      length = plan_array.size();
+    if(m_plan_array.size() > 0){
+      length = m_plan_array.size();
       for(int i = 0; i < length; i++){
         //trys to run the current plan
         runCurrentPlan();
         //waits until plan finishes running
         waitForPlan();
-        //checks if plan_array has been cleared
-        if(plan_array.size() == 0){
+        //checks if m_plan_array has been cleared
+        if(m_plan_array.size() == 0){
           break;
         }
       }
@@ -69,7 +71,7 @@ void PlexilPlanSelection::start()
 
 void PlexilPlanSelection::waitForPlan(){
   std_msgs::String status;
-  ros::Rate rate(10); // 10 Hz for overall rate we are spinning
+  ros::Rate rate(LOOP_RATE);
   //wait for current plan to finish before running next plan
   while(!OwExecutive::instance()->allPlansFinished() && m_first_plan == false){
     ros::spinOnce();
@@ -83,9 +85,10 @@ void PlexilPlanSelection::waitForPlan(){
 
 void PlexilPlanSelection::runCurrentPlan(){
   std_msgs::String status;
-  ros::Rate rate(10); // 10 Hz for overall rate we are spinning
+  ros::Rate rate(LOOP_RATE);
+  const auto TIMEOUT = 3;
 
-  if (OwExecutive::instance()->runPlan(plan_array[0].c_str())) {
+  if (OwExecutive::instance()->runPlan(m_plan_array[0].c_str())) {
 
 /* Skipping these checks for now, because they don't work if the plan
    finishes execution very quickly.  Seeking a solution from the
@@ -94,27 +97,28 @@ void PlexilPlanSelection::runCurrentPlan(){
     // Workaround for allPlansFinished() not working on first plan.
     if (m_first_plan) m_first_plan = false;
 
-    // Times out after 3 seconds or the plan is registered as running.
+    // Times out, or the plan is registered as running.
     int timeout = 0;
-    while(OwExecutive::instance()->allPlansFinished() && timeout < 30){
+    while(OwExecutive::instance()->allPlansFinished() && 
+          timeout < TIMEOUT * LOOP_RATE) {
       ros::spinOnce();
       rate.sleep();
       timeout+=1;
-      if(timeout % 10 == 0){
+      if(timeout % LOOP_RATE == 0){
         ROS_ERROR("Plan not responding, timing out in %i seconds",
-                  (3 - timeout/10));
+                  (TIMEOUT - timeout/LOOP_RATE));
       }
     }
 
     // If timed out we set plan as failed for GUI.
-    if(timeout == 30){
+    if(timeout == TIMEOUT * LOOP_RATE){
       ROS_INFO ("Plan timed out, try again.");
-      status.data = "FAILED:" + plan_array[0];
+      status.data = "FAILED:" + m_plan_array[0];
       m_planSelectionStatusPublisher->publish(status);
     }
     //otherwise we set it as running
     else{
-      status.data = "SUCCESS:" + plan_array[0];
+      status.data = "SUCCESS:" + m_plan_array[0];
       m_planSelectionStatusPublisher->publish(status);
     }
   }
@@ -126,31 +130,31 @@ void PlexilPlanSelection::runCurrentPlan(){
     ros::spinOnce();
     rate.sleep();
     
-    status.data = "SUCCESS:" + plan_array[0];
+    status.data = "SUCCESS:" + m_plan_array[0];
     m_planSelectionStatusPublisher->publish(status);
   }
   else {
     // Unable to run the plan for some reason.
-    status.data = "FAILED:" + plan_array[0];
+    status.data = "FAILED:" + m_plan_array[0];
     m_planSelectionStatusPublisher->publish(status);
   }
 
   // Delete the plan we just ran from plan array.
-  plan_array.erase(plan_array.begin());
+  m_plan_array.erase(m_plan_array.begin());
 }
 
 bool PlexilPlanSelection::planSelectionServiceCallback
 (ow_plexil::PlanSelection::Request &req,
  ow_plexil::PlanSelection::Response &res)
 {
-  //if command is ADD we add given plans to the plan_array
+  //if command is ADD we add given plans to the m_plan_array
   if(req.command.compare("ADD") == 0){
-    plan_array.insert(plan_array.end(), req.plans.begin(), req.plans.end());
+    m_plan_array.insert(m_plan_array.end(), req.plans.begin(), req.plans.end());
     res.success = true;
   }
-  //if command is RESET  delete all plans in the plan_array
+  //if command is RESET  delete all plans in the m_plan_array
   else if(req.command.compare("RESET") == 0){
-    plan_array.clear();
+    m_plan_array.clear();
     ROS_INFO ("Plan list cleared, "
               "current plan will finish execution before stopping");
     res.success = true;

--- a/ow_plexil/src/plexil-adapter/PlexilPlanSelection.h
+++ b/ow_plexil/src/plexil-adapter/PlexilPlanSelection.h
@@ -9,28 +9,26 @@
 #include <ow_plexil/PlanSelection.h>
 
 class PlexilPlanSelection{
-  public:
-    PlexilPlanSelection() = default;
-    ~PlexilPlanSelection() = default;
-    void initialize(std::string initial_plan);
-    void start();
+ public:
+  PlexilPlanSelection() = default;
+  ~PlexilPlanSelection() = default;
+  void initialize(std::string initial_plan);
+  void start();
 
+ private:
+  PlexilPlanSelection(const PlexilPlanSelection&) = delete;
+  PlexilPlanSelection& operator = (const PlexilPlanSelection&) = delete;
+  bool planSelectionServiceCallback(ow_plexil::PlanSelection::Request&,
+                                    ow_plexil::PlanSelection::Response&);
+  void runCurrentPlan();
+  void waitForPlan();
 
-  private:
-    PlexilPlanSelection(const PlexilPlanSelection&) = delete;
-    PlexilPlanSelection& operator = (const PlexilPlanSelection&) = delete;
-    bool planSelectionServiceCallback(ow_plexil::PlanSelection::Request&,
-                                      ow_plexil::PlanSelection::Response&);
-    void runCurrentPlan();
-    void waitForPlan();
-
-    std::unique_ptr<ros::NodeHandle> m_genericNodeHandle;
-    std::unique_ptr<ros::ServiceServer> m_planSelectionService;
+  std::unique_ptr<ros::NodeHandle> m_genericNodeHandle;
+  std::unique_ptr<ros::ServiceServer> m_planSelectionService;
   std::unique_ptr<ros::Publisher> m_planSelectionStatusPublisher;
-    // TODO: consider replacing vector with queue:
-    std::vector<std::string> m_plan_array;
-    bool m_first_plan;
- 
+  // TODO: consider replacing vector with queue:
+  std::vector<std::string> m_plan_array;
+  bool m_first_plan;
 };
 
 #endif

--- a/ow_plexil/src/plexil-adapter/PlexilPlanSelection.h
+++ b/ow_plexil/src/plexil-adapter/PlexilPlanSelection.h
@@ -26,8 +26,9 @@ class PlexilPlanSelection{
 
     std::unique_ptr<ros::NodeHandle> m_genericNodeHandle;
     std::unique_ptr<ros::ServiceServer> m_planSelectionService;
-    std::unique_ptr<ros::Publisher> m_planSelectionStatusPublisher;
-    std::vector<std::string> plan_array;
+  std::unique_ptr<ros::Publisher> m_planSelectionStatusPublisher;
+    // TODO: consider replacing vector with queue:
+    std::vector<std::string> m_plan_array;
     bool m_first_plan;
  
 };


### PR DESCRIPTION
### Summary of Changes

- Implemented PLEXIL support for the topic `/owl_msgs/pan_tilt_position` as specified in Google doc.
   - Note that this topic is only used for OWLAT Sim.  OceanWATERS still reads pan and tilt from the `/joint_states` topic, because this is more efficient.  (The unified topic republishes this information and adds some lag).
- PLEXIL now provides both radian and degree versions of pan/tilt lookups.
    - Note that the PLEXIL interface is independent of the ROS interface and still reads pan and tilt individually, which is most useful.

### Unrelated Changes

- Added `plans/unified` as a home for PLEXIL plans that can run on either testbed.
- Discovered and worked around a pre-existing bug in Plexil plan selection: a plan that finishes very quickly will break the interface because of synchronization issues.  More info in the code comments.
- Replaced the individual subscriber members with a container.
 - Factored shared members in OwInterface and OwlatInterface into PlexilInterface.
 - Added `const` to many member functions that are.
 - Formatting: removed trailing whitespace in some files (done automatically by Emacs), shortened some lines.

### Test

Two tests are needed, one using OceanWATERS, and one using OWLAT Sim.  We assume you have OWLAT Sim installed.  First, a clean build that supports OWLAT is needed:

```
$ catkin clean
$ catkin build -DOWLAT=ON
```

Test 1: OceanWATERS
1. Start any simulation world.
2. Launch `ow_exec.launch` and run the plan `TestTelemetry`.  You should see something close to the printout below.  Note that we're reading the pan/tilt positions at startup.  Feel free to move the antenna and run the plan again.
3. To test the changes to the plan selection interface, run any other plan, and then run `TestTelemetry` again.
```
[ INFO]: PLEXIL: Pan degees: -0.000373310720624672
[ INFO]: PLEXIL: Pan radians: -6.51550120789324e-06
[ INFO]: PLEXIL: Tilt degees: -0.665347767210253
[ INFO]: PLEXIL: Tilt radians: -0.0116125092086978
```

Test 2: OWLAT Sim
1. Start `roscore`.
2. Start OWLAT Sim: `launch_owlat Scoop`
3. Launch `owlat_exec.launch`
4. Run the same plan, `TestTelemetry`.  Since nothing is publishing to the topic, you should see the Plexil adapter default values:

```
[ INFO]: PLEXIL: Pan degees: 0
[ INFO]: PLEXIL: Pan radians: 0
[ INFO]: PLEXIL: Tilt degees: 0
[ INFO]: PLEXIL: Tilt radians: 0
```
5. Now, start publishing to the topic manually:
```
$ rostopic pub -r 10 /owl_msgs/pan_tilt_position owl_msgs/PanTiltPosition '{ header: {seq: 10, stamp: {secs: 1, nsecs: 1}, frame_id: "3"}, value: [1.0, 2.0] }'
```
6. Run the `TestTelemetry` plan again, and you should see this:
```
[ INFO]: PLEXIL: Pan degees: 57.2957795130823
[ INFO]: PLEXIL: Pan radians: 1
[ INFO]: PLEXIL: Tilt degees: 114.591559026165
[ INFO]: PLEXIL: Tilt radians: 2
```