### PR TITLE
pan_tilt_faults telemetry unification

### DIFF
--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -240,7 +240,7 @@ void OwInterface::powerFaultCallback
 }
 
 void OwInterface::antennaFaultCallback
-(const ow_faults_detection::PTFaults::ConstPtr& msg)
+(const owl_msgs::PanTiltFaultsStatus::ConstPtr& msg)
 {
   updateFaultStatus (msg->value, m_panTiltErrors, "ANTENNA", "AntennaFault");
 }
@@ -560,7 +560,7 @@ void OwInterface::initialize()
     m_subscribers.push_back
       (make_unique<ros::Subscriber>
        (m_genericNodeHandle ->
-        subscribe("/faults/pt_faults_status", QSize,
+        subscribe("/pan_tilt_faults_status", QSize,
                   &OwInterface::antennaFaultCallback, this)));
 
     // Connect action clients to servers and add subscribers for

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -40,7 +40,7 @@
 #include <owl_msgs/SystemFaultsStatus.h>
 #include <owl_msgs/ArmFaultsStatus.h>
 #include <ow_faults_detection/PowerFaults.h>
-#include <ow_faults_detection/PTFaults.h>
+#include <owl_msgs/PanTiltFaultsStatus.h>
 
 #include "PlexilInterface.h"
 
@@ -169,7 +169,7 @@ class OwInterface : public PlexilInterface
   void systemFaultMessageCallback (const owl_msgs::SystemFaultsStatus::ConstPtr&);
   void armFaultCallback (const owl_msgs::ArmFaultsStatus::ConstPtr&);
   void powerFaultCallback (const ow_faults_detection::PowerFaults::ConstPtr&);
-  void antennaFaultCallback (const ow_faults_detection::PTFaults::ConstPtr&);
+  void antennaFaultCallback (const owl_msgs::PanTiltFaultsStatus::ConstPtr&);
   void antennaOp (const std::string& opname, double degrees,
                   std::unique_ptr<ros::Publisher>&, int id);
   void actionGoalStatusCallback (const actionlib_msgs::GoalStatusArray::ConstPtr&,
@@ -233,9 +233,11 @@ class OwInterface : public PlexilInterface
     {"HARDWARE_ERROR", std::make_pair(1, false)}
   };
 
-  FaultMap32 m_panTiltErrors = {
-    {"HARDWARE_ERROR", std::make_pair(1, false)},
-    {"JOINT_LIMIT_ERROR", std::make_pair(2, false)}
+  FaultMap64 m_panTiltErrors = {
+    {"PAN_JOINT_LOCKED", std::make_pair(
+      owl_msgs::PanTiltFaultsStatus::PAN_JOINT_LOCKED, false)},
+    {"TILT_JOINT_LOCKED", std::make_pair(
+      owl_msgs::PanTiltFaultsStatus::TILT_JOINT_LOCKED, false)}
   };
 
   std::unique_ptr<ros::NodeHandle> m_genericNodeHandle;


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-934](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-934) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1011](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1011) |
| Github :octocat:  | [OCEANWATER-1011_implement_telemetry_pan_tilt_faults_status](https://github.com/nasa/ow_autonomy/tree/OCEANWATER-1011_implement_telemetry_pan_tilt_faults_status) |

Mostly artifact renaming and updating message definitions.

**This issue has a corresponding and required branch on [ow_simulator](https://github.com/nasa/ow_simulator/tree/OCEANWATER-1011_implement_telemetry_pan_tilt_faults_status).**

## Summary of Changes
* Update references to `PTFaults` to match Unified Telemetry spec of `PanTiltFaultsStatus`
* Update namespaces and includes to reference `owl_msgs` which now houses PanTiltFaultsStatus (`instead of ow_faults_detection`)

[For more details, see the associated pull request on ow_simulator.](https://github.com/nasa/ow_simulator/pull/297)


## Test
Test with linked PR above.