### PR TITLE
Power fault telemetry unification

### DIFF
--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -234,7 +234,7 @@ void OwInterface::armFaultCallback
 }
 
 void OwInterface::powerFaultCallback
-(const ow_faults_detection::PowerFaults::ConstPtr& msg)
+(const owl_msgs::PowerFaultsStatus::ConstPtr& msg)
 {
   updateFaultStatus (msg->value, m_powerErrors, "POWER", "PowerFault");
 }

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -39,7 +39,7 @@
 
 #include <owl_msgs/SystemFaultsStatus.h>
 #include <owl_msgs/ArmFaultsStatus.h>
-#include <ow_faults_detection/PowerFaults.h>
+#include <owl_msgs/PowerFaultsStatus.h>
 #include <ow_faults_detection/PTFaults.h>
 
 #include "PlexilInterface.h"
@@ -168,7 +168,7 @@ class OwInterface : public PlexilInterface
   void jointStatesCallback (const sensor_msgs::JointState::ConstPtr&);
   void systemFaultMessageCallback (const owl_msgs::SystemFaultsStatus::ConstPtr&);
   void armFaultCallback (const owl_msgs::ArmFaultsStatus::ConstPtr&);
-  void powerFaultCallback (const ow_faults_detection::PowerFaults::ConstPtr&);
+  void powerFaultCallback (const owl_msgs::PowerFaultsStatus::ConstPtr&);
   void antennaFaultCallback (const ow_faults_detection::PTFaults::ConstPtr&);
   void antennaOp (const std::string& opname, double degrees,
                   std::unique_ptr<ros::Publisher>&, int id);
@@ -230,7 +230,12 @@ class OwInterface : public PlexilInterface
   };
 
   FaultMap32 m_powerErrors = {
-    {"HARDWARE_ERROR", std::make_pair(1, false)}
+    {"LOW_STATE_OF_CHARGE", std::make_pair(
+        owl_msgs::PowerFaultsStatus::LOW_STATE_OF_CHARGE, false)},
+    {"INSTANTANEOUS_CAPACITY_LOSS", std::make_pair(
+        owl_msgs::PowerFaultsStatus::INSTANTANEOUS_CAPACITY_LOSS, false)},
+    {"THERMAL_FAULT", std::make_pair(
+        owl_msgs::PowerFaultsStatus::THERMAL_FAULT, false)}
   };
 
   FaultMap32 m_panTiltErrors = {


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-934](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-934) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1014](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1014) |
| Github :octocat:  | [OCEANWATER-1014_implement_telemetry_power_faults_status](https://github.com/nasa/ow_autonomy/tree/OCEANWATER-1014_implement_telemetry_power_faults_status) |

Mostly artifact renaming and updating message definitions.

**This issue has a corresponding and required branch on [ow_simulator](https://github.com/nasa/ow_simulator/tree/OCEANWATER-1014_implement_telemetry_power_faults_status).**

## Summary of Changes
* Update references to `PowerFaults` to match Unified Telemetry spec of `PowerFaultsStatus`
* Update namespaces and includes to reference `owl_msgs` which now houses PowerFaultsStatus (`instead of ow_faults_detection`)

[For more details, see the associated pull request on ow_simulator.](https://github.com/nasa/ow_simulator/pull/299)


## Test
Test with linked PR above.