### PR TITLE
PLEXIL interface to joint telemetry

### DIFF
--- a/ow_plexil/src/plans/unified/TestTelemetry.plp
+++ b/ow_plexil/src/plans/unified/TestTelemetry.plp
@@ -22,5 +22,7 @@ TestTelemetry:
   log_info ("Tilt radians: ", Lookup(TiltRadians));
 
   // Arm joint telemetry
-  log_info ("dist pitch velocity: ", Lookup(JointVelocity(DISTAL_PITCH)));
+  log_info ("Distal pitch velocity: ", Lookup(JointVelocity(DISTAL_PITCH)));
+  log_info ("Antenna pan position: ", Lookup(JointPosition(ANTENNA_PAN)));
+  log_info ("Shoulder Yaw effort: ", Lookup(JointEffort(SHOULDER_YAW)));
 }

--- a/ow_plexil/src/plans/unified/TestTelemetry.plp
+++ b/ow_plexil/src/plans/unified/TestTelemetry.plp
@@ -26,5 +26,6 @@ TestTelemetry:
     log_info ("Position of joint ", j, " = ", Lookup(JointPosition(j)));
     log_info ("Velocity of joint ", j, " = ", Lookup(JointVelocity(j)));
     log_info ("Effort of joint ", j, " = ", Lookup(JointEffort(j)));
+    log_info ("Acceleration of joint ", j, " = ", Lookup(JointAcceleration(j)));
   }
 }

--- a/ow_plexil/src/plans/unified/TestTelemetry.plp
+++ b/ow_plexil/src/plans/unified/TestTelemetry.plp
@@ -22,6 +22,12 @@ TestTelemetry:
   log_info ("Tilt radians: ", Lookup(TiltRadians));
 
   // Joint telemetry
+
+  // This is coded for the 9 joints in OceanWATERS (7 arm, 2 antenna),
+  // while OWLAT has a total of 6 joints, all arm.  Nonetheless, this
+  // code will do the "right" thing on each testbed, which includes
+  // producing warnings/errors for invalid indices and options.
+  
   for (Integer j = 0; j < 9; j + 1) {
     log_info ("Position of joint ", j, " = ", Lookup(JointPosition(j)));
     log_info ("Velocity of joint ", j, " = ", Lookup(JointVelocity(j)));

--- a/ow_plexil/src/plans/unified/TestTelemetry.plp
+++ b/ow_plexil/src/plans/unified/TestTelemetry.plp
@@ -21,8 +21,10 @@ TestTelemetry:
   log_info ("Tilt degees: ", Lookup(TiltDegrees));
   log_info ("Tilt radians: ", Lookup(TiltRadians));
 
-  // Arm joint telemetry
-  log_info ("Distal pitch velocity: ", Lookup(JointVelocity(DISTAL_PITCH)));
-  log_info ("Antenna pan position: ", Lookup(JointPosition(ANTENNA_PAN)));
-  log_info ("Shoulder Yaw effort: ", Lookup(JointEffort(SHOULDER_YAW)));
+  // Joint telemetry
+  for (Integer j = 0; j < 9; j + 1) {
+    log_info ("Position of joint ", j, " = ", Lookup(JointPosition(j)));
+    log_info ("Velocity of joint ", j, " = ", Lookup(JointVelocity(j)));
+    log_info ("Effort of joint ", j, " = ", Lookup(JointEffort(j)));
+  }
 }

--- a/ow_plexil/src/plans/unified/TestTelemetry.plp
+++ b/ow_plexil/src/plans/unified/TestTelemetry.plp
@@ -15,9 +15,12 @@ TestTelemetry:
   // /pan_tilt_position, these lookups will return the PLEXIL
   // adapter's default Lookup value, which is 0, when this plan is run
   // on OWLAT Sim.
-  
+
   log_info ("Pan degees: ", Lookup(PanDegrees));
   log_info ("Pan radians: ", Lookup(PanRadians));
   log_info ("Tilt degees: ", Lookup(TiltDegrees));
   log_info ("Tilt radians: ", Lookup(TiltRadians));
+
+  // Arm joint telemetry
+  log_info ("dist pitch velocity: ", Lookup(JointVelocity(DISTAL_PITCH)));
 }

--- a/ow_plexil/src/plans/unified/unified-interface.h
+++ b/ow_plexil/src/plans/unified/unified-interface.h
@@ -4,15 +4,24 @@
 // Unified interface to OceanWATERS and OWLAT.
 // Under construction!
 
-// Utility commands; issue ROS_INFO, ROS_WARN, and ROS_ERROR, respectively.
+// Utility commands.
+// These issue ROS_INFO, ROS_WARN, ROS_ERROR, and ROS_DEBUG, respectively.
 Command log_info (...);
 Command log_warning (...);
 Command log_error (...);
 Command log_debug (...);
 
-// Joint names
+// Joint names, defined by their indices in the /joint_states ROS message.
 
-#define DISTAL_PITCH 0
+#define ANTENNA_PAN    0
+#define ANTENNA_TILT   1
+#define DISTAL_PITCH   2
+#define GRINDER        3
+#define HAND_YAW       4
+#define PROXIMAL_PITCH 5
+#define SCOOP_YAW      6
+#define SHOULDER_PITCH 7
+#define SHOULDER_YAW   8
 
 
 ////////////// Telemetry //////////////////
@@ -24,6 +33,8 @@ Real Lookup TiltRadians;
 Real Lookup TiltDegrees;
 
 // Arm
-Real Lookup JointVelocity (Integer joint_name);
+Real Lookup JointVelocity (Integer joint);
+Real Lookup JointPosition (Integer joint);
+Real Lookup JointEffort   (Integer joint);
 
 #endif

--- a/ow_plexil/src/plans/unified/unified-interface.h
+++ b/ow_plexil/src/plans/unified/unified-interface.h
@@ -10,13 +10,20 @@ Command log_warning (...);
 Command log_error (...);
 Command log_debug (...);
 
+// Joint names
+
+#define DISTAL_PITCH 0
+
 
 ////////////// Telemetry //////////////////
 
 // Antenna
-Real    Lookup PanRadians;
-Real    Lookup PanDegrees;
-Real    Lookup TiltRadians;
-Real    Lookup TiltDegrees;
+Real Lookup PanRadians;
+Real Lookup PanDegrees;
+Real Lookup TiltRadians;
+Real Lookup TiltDegrees;
+
+// Arm
+Real Lookup JointVelocity (Integer joint_name);
 
 #endif

--- a/ow_plexil/src/plans/unified/unified-interface.h
+++ b/ow_plexil/src/plans/unified/unified-interface.h
@@ -33,8 +33,9 @@ Real Lookup TiltRadians;
 Real Lookup TiltDegrees;
 
 // Arm
-Real Lookup JointVelocity (Integer joint);
-Real Lookup JointPosition (Integer joint);
-Real Lookup JointEffort   (Integer joint);
+Real Lookup JointAcceleration (Integer joint);
+Real Lookup JointVelocity     (Integer joint);
+Real Lookup JointPosition     (Integer joint);
+Real Lookup JointEffort       (Integer joint);
 
 #endif

--- a/ow_plexil/src/plexil-adapter/CommonAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/CommonAdapter.cpp
@@ -58,7 +58,8 @@ bool CommonAdapter::initialize()
   setSubscriber (receiveBool);
   setSubscriber (receiveString);
   setSubscriber (receiveDouble);
-  setSubscriber (receiveBoolString);
+  setSubscriber (receiveBoolFromString);
+  setSubscriber (receiveDoubleFromInt);
   setSubscriber (receiveDoubleVector);
   g_adapter = this;
   debugMsg("CommonAdapter", " initialized.");

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -147,6 +147,11 @@ static bool lookup (const string& state_name,
     args[0].getValue(s);
     value_out = OwInterface::instance()->actionGoalStatus(s);
   }
+  else if (state_name == "JointVelocity") {
+    int joint;
+    args[0].getValue(joint);
+    value_out = OwInterface::instance()->jointVelocity(joint);
+  }
   else if (state_name == "AnglesEquivalent") {
     double deg1, deg2, tolerance;
     args[0].getValue(deg1);

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -150,17 +150,20 @@ static bool lookup (const string& state_name,
   else if (state_name == "JointVelocity") {
     int joint;
     args[0].getValue(joint);
-    value_out = OwInterface::instance()->jointVelocity(joint);
+    value_out = OwInterface::instance()->jointTelemetry(joint,
+                                                        TelemetryType::Velocity);
   }
   else if (state_name == "JointEffort") {
     int joint;
     args[0].getValue(joint);
-    value_out = OwInterface::instance()->jointEffort(joint);
+    value_out = OwInterface::instance()->jointTelemetry(joint,
+                                                        TelemetryType::Effort);
   }
   else if (state_name == "JointPosition") {
     int joint;
     args[0].getValue(joint);
-    value_out = OwInterface::instance()->jointPosition(joint);
+    value_out = OwInterface::instance()->jointTelemetry(joint,
+                                                        TelemetryType::Position);
   }
   else if (state_name == "AnglesEquivalent") {
     double deg1, deg2, tolerance;

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -152,6 +152,16 @@ static bool lookup (const string& state_name,
     args[0].getValue(joint);
     value_out = OwInterface::instance()->jointVelocity(joint);
   }
+  else if (state_name == "JointEffort") {
+    int joint;
+    args[0].getValue(joint);
+    value_out = OwInterface::instance()->jointEffort(joint);
+  }
+  else if (state_name == "JointPosition") {
+    int joint;
+    args[0].getValue(joint);
+    value_out = OwInterface::instance()->jointPosition(joint);
+  }
   else if (state_name == "AnglesEquivalent") {
     double deg1, deg2, tolerance;
     args[0].getValue(deg1);

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -150,20 +150,26 @@ static bool lookup (const string& state_name,
   else if (state_name == "JointVelocity") {
     int joint;
     args[0].getValue(joint);
-    value_out = OwInterface::instance()->jointTelemetry(joint,
-                                                        TelemetryType::Velocity);
+    value_out = OwInterface::instance()->
+      jointTelemetry(joint, TelemetryType::Velocity);
   }
   else if (state_name == "JointEffort") {
     int joint;
     args[0].getValue(joint);
-    value_out = OwInterface::instance()->jointTelemetry(joint,
-                                                        TelemetryType::Effort);
+    value_out = OwInterface::instance()->
+      jointTelemetry(joint, TelemetryType::Effort);
   }
   else if (state_name == "JointPosition") {
     int joint;
     args[0].getValue(joint);
-    value_out = OwInterface::instance()->jointTelemetry(joint,
-                                                        TelemetryType::Position);
+    value_out = OwInterface::instance()->
+      jointTelemetry(joint, TelemetryType::Position);
+  }
+  else if (state_name == "JointAcceleration") {
+    int joint;
+    args[0].getValue(joint);
+    value_out = OwInterface::instance()->
+      jointTelemetry(joint, TelemetryType::Acceleration);
   }
   else if (state_name == "AnglesEquivalent") {
     double deg1, deg2, tolerance;

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -1144,13 +1144,17 @@ double OwInterface::jointTelemetry (int joint, TelemetryType type) const
       case TelemetryType::Position: return JointTelemetries[joint].position;
       case TelemetryType::Velocity: return JointTelemetries[joint].velocity;
       case TelemetryType::Effort: return JointTelemetries[joint].effort;
+      case TelemetryType::Acceleration: {
+        ROS_WARN ("jointTelemetry: acceleration not yet implemented.");
+        break;
+      }
     default:
       ROS_ERROR ("jointTelemetry: unsupported telemetry type.");
       break;
     }
   }
   else {
-    ROS_ERROR ("jointVelocity: invalid joint index %d", joint);
+    ROS_ERROR ("jointTelemetry: invalid joint index %d", joint);
   }
   return 0;
 }

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -289,6 +289,10 @@ void OwInterface::jointStatesCallback
       publish (plexil_name + "Position", position);
       publish (plexil_name + "Velocity", velocity);
       publish (plexil_name + "Effort", effort);
+      // New interface
+      publish ("JointPosition", position, i);
+      publish ("JointVelocity", velocity, i);
+      publish ("JointEffort", effort, i);
       handle_joint_fault (joint, i, msg);
     }
     else ROS_ERROR("jointStatesCallback: unsupported joint %s",
@@ -1158,6 +1162,16 @@ int OwInterface::actionGoalStatus (const string& action_name) const
 }
 
 double OwInterface::jointVelocity (int joint) const
+{
+  return 0; // stub
+}
+
+double OwInterface::jointPosition (int joint) const
+{
+  return 0; // stub
+}
+
+double OwInterface::jointEffort (int joint) const
 {
   return 0; // stub
 }

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -292,7 +292,7 @@ void OwInterface::jointStatesCallback
       publish ("TiltRadians", m_currentTiltRadians);
       publish ("TiltDegrees", m_currentTiltRadians * R2D);
     }
-    JointTelemetries[i] = JointTelemetry (position, velocity, effort);
+    JointTelemetries[i] = JointTelemetry {position, velocity, effort};
     publish ("JointPosition", position, i);
     publish ("JointVelocity", velocity, i);
     publish ("JointEffort", effort, i);

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -42,7 +42,7 @@ const double VelocityTolerance       = 0.01;  // made up, unitless
 
 //////////////////// Lander Operation Support ////////////////////////
 
-// Index into /joint_states message and JointTelmetries vector.
+// Index into /joint_states message and JointTelemetries vector.
 const size_t ArmJointStartIndex = 2;
 
 const double PointCloudTimeout = 50.0; // 5 second timeout assuming a rate of 10hz

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -1156,3 +1156,8 @@ int OwInterface::actionGoalStatus (const string& action_name) const
 {
   return ActionGoalStatusMap[action_name];
 }
+
+double OwInterface::jointVelocity (int joint) const
+{
+  return 0; // stub
+}

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -138,6 +138,8 @@ class OwInterface : public PlexilInterface
   bool   hardTorqueLimitReached (const std::string& joint_name) const;
   bool   softTorqueLimitReached (const std::string& joint_name) const;
   double jointVelocity (int joint) const;
+  double jointPosition (int joint) const;
+  double jointEffort (int joint) const;
 
   int actionGoalStatus (const std::string& action_name) const;
 

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -137,6 +137,7 @@ class OwInterface : public PlexilInterface
   bool   anglesEquivalent (double deg1, double deg2, double tolerance);
   bool   hardTorqueLimitReached (const std::string& joint_name) const;
   bool   softTorqueLimitReached (const std::string& joint_name) const;
+  double jointVelocity (int joint) const;
 
   int actionGoalStatus (const std::string& action_name) const;
 

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -9,10 +9,17 @@
 // ever be needed in the current autonomy scheme, which has one autonomy
 // executive per lander.
 
-#include <memory>
-#include <ros/ros.h>
+// ow_plexil
+#include "PlexilInterface.h"
+#include "joint_support.h"
 
-// ROS Actions - OceanWATERS
+// ow_simulator
+#include <owl_msgs/SystemFaultsStatus.h>
+#include <ow_faults_detection/ArmFaults.h>
+#include <ow_faults_detection/PowerFaults.h>
+#include <ow_faults_detection/PTFaults.h>
+
+// ow_simulator (ROS Actions)
 #include <actionlib/client/simple_action_client.h>
 #include <actionlib_msgs/GoalStatusArray.h>
 #include <ow_lander/UnstowAction.h>
@@ -30,19 +37,17 @@
 #include <ow_lander/LightSetIntensityAction.h>
 #include <ow_plexil/IdentifyLocationAction.h>
 
+// ROS
 #include <control_msgs/JointControllerState.h>
 #include <sensor_msgs/JointState.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <geometry_msgs/Point.h>
+#include <ros/ros.h>
+
+// C++
 #include <string>
-
-#include <owl_msgs/SystemFaultsStatus.h>
-#include <ow_faults_detection/ArmFaults.h>
-#include <ow_faults_detection/PowerFaults.h>
-#include <ow_faults_detection/PTFaults.h>
-
-#include "PlexilInterface.h"
+#include <memory>
 
 using UnstowActionClient =
   actionlib::SimpleActionClient<ow_lander::UnstowAction>;
@@ -137,10 +142,7 @@ class OwInterface : public PlexilInterface
   bool   anglesEquivalent (double deg1, double deg2, double tolerance);
   bool   hardTorqueLimitReached (const std::string& joint_name) const;
   bool   softTorqueLimitReached (const std::string& joint_name) const;
-  double jointVelocity (int joint) const;
-  double jointPosition (int joint) const;
-  double jointEffort (int joint) const;
-
+  double jointTelemetry (int joint, TelemetryType type) const;
   int actionGoalStatus (const std::string& action_name) const;
 
  private:

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -12,9 +12,11 @@
 // ow_plexil
 #include "PlexilInterface.h"
 #include "joint_support.h"
+#include <ow_plexil/IdentifyLocationAction.h>
 
 // ow_simulator
 #include <owl_msgs/SystemFaultsStatus.h>
+#include <owl_msgs/ArmJointAccelerations.h>
 #include <ow_faults_detection/ArmFaults.h>
 #include <ow_faults_detection/PowerFaults.h>
 #include <ow_faults_detection/PTFaults.h>
@@ -35,7 +37,6 @@
 #include <ow_lander/DiscardAction.h>
 #include <ow_lander/CameraCaptureAction.h>
 #include <ow_lander/LightSetIntensityAction.h>
-#include <ow_plexil/IdentifyLocationAction.h>
 
 // ROS
 #include <control_msgs/JointControllerState.h>
@@ -173,6 +174,7 @@ class OwInterface : public PlexilInterface
   void cameraCaptureAction (double exposure_secs, int id);
   void lightSetIntensityAction (const std::string& side, double intensity, int id);
   void jointStatesCallback (const sensor_msgs::JointState::ConstPtr&);
+  void armJointAccelerationsCb (const owl_msgs::ArmJointAccelerations::ConstPtr&);
   void systemFaultMessageCallback (const owl_msgs::SystemFaultsStatus::ConstPtr&);
   void armFaultCallback (const ow_faults_detection::ArmFaults::ConstPtr&);
   void powerFaultCallback (const ow_faults_detection::PowerFaults::ConstPtr&);

--- a/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
@@ -8,6 +8,7 @@
 #include "OwlatAdapter.h"
 #include "OwlatInterface.h"
 #include "adapter_support.h"
+#include "joint_support.h"
 #include "subscriber.h"
 using namespace PLEXIL;
 
@@ -361,7 +362,8 @@ static void joint_velocity (const State& state, StateCacheEntry &entry)
            << " with " << args.size() << " args");
   int joint;
   args[0].getValue(joint);
-  entry.update(OwlatInterface::instance()->getJointVelocity(joint));
+  entry.update(OwlatInterface::instance()->
+               getJointTelemetry(joint, TelemetryType::Velocity));
 }
 
 static void joint_position (const State& state, StateCacheEntry &entry)
@@ -371,7 +373,8 @@ static void joint_position (const State& state, StateCacheEntry &entry)
            << " with " << args.size() << " args");
   int joint;
   args[0].getValue(joint);
-  entry.update(OwlatInterface::instance()->getJointPosition(joint));
+  entry.update(OwlatInterface::instance()->
+               getJointTelemetry(joint, TelemetryType::Position));
 }
 
 static void joint_effort (const State& state, StateCacheEntry &entry)
@@ -381,7 +384,19 @@ static void joint_effort (const State& state, StateCacheEntry &entry)
            << " with " << args.size() << " args");
   int joint;
   args[0].getValue(joint);
-  entry.update(OwlatInterface::instance()->getJointEffort(joint));
+  entry.update(OwlatInterface::instance()->
+               getJointTelemetry(joint, TelemetryType::Effort));
+}
+
+static void joint_acceleration (const State& state, StateCacheEntry &entry)
+{
+  const vector<PLEXIL::Value>& args = state.parameters();
+  debugMsg("joint_effort ", "lookup called for " << state.name()
+           << " with " << args.size() << " args");
+  int joint;
+  args[0].getValue(joint);
+  entry.update(OwlatInterface::instance()->
+               getJointTelemetry(joint, TelemetryType::Acceleration));
 }
 
 static void default_lookup_handler (const State& state, StateCacheEntry &entry)
@@ -391,12 +406,6 @@ static void default_lookup_handler (const State& state, StateCacheEntry &entry)
   debugMsg("Invalid State: ", state.name());
   entry.update(Unknown);
 }
-
-/*
-static std::map<string, auto> LookupHandlers {
-  { "JointVelocity", joint_velocity }
-};
-*/
 
 OwlatAdapter::OwlatAdapter (AdapterExecInterface& execInterface,
                             const pugi::xml_node& configXml)
@@ -454,6 +463,7 @@ bool OwlatAdapter::initialize()
   g_configuration->registerLookupHandler("JointVelocity", joint_velocity);
   g_configuration->registerLookupHandler("JointPosition", joint_position);
   g_configuration->registerLookupHandler("JointEffort", joint_effort);
+  g_configuration->registerLookupHandler("JointAcceleration", joint_acceleration);
   g_configuration->setDefaultLookupHandler(default_lookup_handler);
 
   debugMsg("OwlatAdapter", " initialized.");

--- a/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
@@ -364,6 +364,26 @@ static void joint_velocity (const State& state, StateCacheEntry &entry)
   entry.update(OwlatInterface::instance()->getJointVelocity(joint));
 }
 
+static void joint_position (const State& state, StateCacheEntry &entry)
+{
+  const vector<PLEXIL::Value>& args = state.parameters();
+  debugMsg("joint_position ", "lookup called for " << state.name()
+           << " with " << args.size() << " args");
+  int joint;
+  args[0].getValue(joint);
+  entry.update(OwlatInterface::instance()->getJointPosition(joint));
+}
+
+static void joint_effort (const State& state, StateCacheEntry &entry)
+{
+  const vector<PLEXIL::Value>& args = state.parameters();
+  debugMsg("joint_effort ", "lookup called for " << state.name()
+           << " with " << args.size() << " args");
+  int joint;
+  args[0].getValue(joint);
+  entry.update(OwlatInterface::instance()->getJointEffort(joint));
+}
+
 static void default_lookup_handler (const State& state, StateCacheEntry &entry)
 {
   debugMsg("default_lookup_handler", "lookup called for " << state.name()
@@ -432,6 +452,8 @@ bool OwlatAdapter::initialize()
   g_configuration->registerLookupHandler("TiltRadians", tiltRadians);
   g_configuration->registerLookupHandler("TiltDegrees", tiltDegrees);
   g_configuration->registerLookupHandler("JointVelocity", joint_velocity);
+  g_configuration->registerLookupHandler("JointPosition", joint_position);
+  g_configuration->registerLookupHandler("JointEffort", joint_effort);
   g_configuration->setDefaultLookupHandler(default_lookup_handler);
 
   debugMsg("OwlatAdapter", " initialized.");

--- a/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
@@ -470,21 +470,6 @@ bool OwlatAdapter::initialize()
   return true;
 }
 
-/*
-void OwlatAdapter::lookupNow (const State& state, StateCacheEntry& entry)
-{
-  debugMsg("OwlatAdapter:lookupNow", " called on " << state.name() << " with "
-           << state.parameters().size() << " arguments");
-
-  Value retval = Unknown;  // the value of the queried state
-
-  // At the moment there are no lookups defined for OWLAT.
-  ROS_ERROR("PLEXIL Adapter: Invalid lookup name: %s", state.name().c_str());
-
-  entry.update(retval);
-}
-*/
-
 extern "C" {
   void initowlat_adapter() {
     REGISTER_ADAPTER(OwlatAdapter, "owlat_adapter");

--- a/ow_plexil/src/plexil-adapter/OwlatAdapter.h
+++ b/ow_plexil/src/plexil-adapter/OwlatAdapter.h
@@ -19,7 +19,7 @@ public:
   OwlatAdapter& operator= (const OwlatAdapter&) = delete;
 
   virtual bool initialize();
-  virtual void lookupNow (const PLEXIL::State&, PLEXIL::StateCacheEntry&);
+  //  virtual void lookupNow (const PLEXIL::State&, PLEXIL::StateCacheEntry&);
 };
 
 extern "C" {

--- a/ow_plexil/src/plexil-adapter/OwlatAdapter.h
+++ b/ow_plexil/src/plexil-adapter/OwlatAdapter.h
@@ -19,7 +19,6 @@ public:
   OwlatAdapter& operator= (const OwlatAdapter&) = delete;
 
   virtual bool initialize();
-  //  virtual void lookupNow (const PLEXIL::State&, PLEXIL::StateCacheEntry&);
 };
 
 extern "C" {

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
@@ -813,3 +813,8 @@ Value OwlatInterface::getTiltDegrees() const
 {
   return m_tilt_radians * R2D;
 }
+
+Value OwlatInterface::getJointVelocity (int joint) const
+{
+  return 0; // stub
+}

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
@@ -35,6 +35,8 @@ const string Name_OwlatArmTareFS =        "/owlat_sim/ARM_TARE_FS";
 const string Name_OwlatTaskPSP =          "/owlat_sim/TASK_PSP";
 const string Name_OwlatTaskScoop =        "/owlat_sim/TASK_SCOOP";
 
+const size_t OwlatJoints = 6;
+
 // Used as indices into the subsequent vector.
 enum class LanderOps {
   OwlatUnstow,
@@ -814,17 +816,21 @@ Value OwlatInterface::getTiltDegrees() const
   return m_tilt_radians * R2D;
 }
 
-Value OwlatInterface::getJointVelocity (int joint) const
+Value OwlatInterface::getJointTelemetry (int joint, TelemetryType type) const
 {
-  return 0; // stub
-}
-
-Value OwlatInterface::getJointPosition (int joint) const
-{
-  return 0; // stub
-}
-
-Value OwlatInterface::getJointEffort (int joint) const
-{
-  return 0; // stub
+  if (joint >= 0 && joint < OwlatJoints) {
+    switch (type) {
+    case TelemetryType::Position: return m_arm_joint_angles[joint];
+      case TelemetryType::Velocity: return m_arm_joint_velocities[joint];
+      case TelemetryType::Effort: return m_arm_joint_torques[joint];
+      case TelemetryType::Acceleration: return m_arm_joint_accelerations[joint];
+    default:
+      ROS_ERROR ("getJointTelemetry: unsupported telemetry type.");
+      break;
+    }
+  }
+  else {
+    ROS_ERROR ("getJointTelemetry: invalid joint index %d", joint);
+  }
+  return 0;
 }

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
@@ -818,3 +818,13 @@ Value OwlatInterface::getJointVelocity (int joint) const
 {
   return 0; // stub
 }
+
+Value OwlatInterface::getJointPosition (int joint) const
+{
+  return 0; // stub
+}
+
+Value OwlatInterface::getJointEffort (int joint) const
+{
+  return 0; // stub
+}

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
@@ -820,13 +820,12 @@ Value OwlatInterface::getJointTelemetry (int joint, TelemetryType type) const
 {
   if (joint >= 0 && joint < OwlatJoints) {
     switch (type) {
-    case TelemetryType::Position: return m_arm_joint_angles[joint];
+      case TelemetryType::Position: return m_arm_joint_angles[joint];
       case TelemetryType::Velocity: return m_arm_joint_velocities[joint];
       case TelemetryType::Effort: return m_arm_joint_torques[joint];
       case TelemetryType::Acceleration: return m_arm_joint_accelerations[joint];
     default:
       ROS_ERROR ("getJointTelemetry: unsupported telemetry type.");
-      break;
     }
   }
   else {

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.h
@@ -17,6 +17,7 @@
 // ow_plexil
 #include <Value.hh>
 #include "PlexilInterface.h"
+#include "joint_support.h"
 
 // OWLAT Sim (installation required)
 #include <owlat_sim_msgs/ARM_UNSTOWAction.h>
@@ -131,9 +132,7 @@ class OwlatInterface : public PlexilInterface
   PLEXIL::Value getPanRadians() const;
   PLEXIL::Value getTiltRadians() const;
   PLEXIL::Value getTiltDegrees() const;
-  PLEXIL::Value getJointVelocity(int joint) const;
-  PLEXIL::Value getJointPosition(int joint) const;
-  PLEXIL::Value getJointEffort(int joint) const;
+  PLEXIL::Value getJointTelemetry (int joint, TelemetryType type) const;
 
  private:
 

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.h
@@ -132,7 +132,9 @@ class OwlatInterface : public PlexilInterface
   PLEXIL::Value getTiltRadians() const;
   PLEXIL::Value getTiltDegrees() const;
   PLEXIL::Value getJointVelocity(int joint) const;
-  
+  PLEXIL::Value getJointPosition(int joint) const;
+  PLEXIL::Value getJointEffort(int joint) const;
+
  private:
 
   // Actions

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.h
@@ -131,7 +131,8 @@ class OwlatInterface : public PlexilInterface
   PLEXIL::Value getPanRadians() const;
   PLEXIL::Value getTiltRadians() const;
   PLEXIL::Value getTiltDegrees() const;
-
+  PLEXIL::Value getJointVelocity(int joint) const;
+  
  private:
 
   // Actions

--- a/ow_plexil/src/plexil-adapter/adapter_support.cpp
+++ b/ow_plexil/src/plexil-adapter/adapter_support.cpp
@@ -142,7 +142,13 @@ void receiveString (const string& state_name, const string& val)
              vector<Value> (1, val));
 }
 
-void receiveBoolString (const string& state_name, bool val, const string& arg)
+void receiveBoolFromString (const string& state_name, bool val, const string& arg)
+{
+  propagate (create_state(state_name, vector<Value> (1, arg)),
+             vector<Value> (1, val));
+}
+
+void receiveDoubleFromInt (const string& state_name, double val, int arg)
 {
   propagate (create_state(state_name, vector<Value> (1, arg)),
              vector<Value> (1, val));

--- a/ow_plexil/src/plexil-adapter/adapter_support.h
+++ b/ow_plexil/src/plexil-adapter/adapter_support.h
@@ -63,9 +63,10 @@ void command_status_callback (int id, bool success);
 void receiveBool (const std::string& state_name, bool val);
 void receiveDouble (const std::string& state_name, double val);
 void receiveString (const std::string& state_name, const std::string& val);
-void receiveBoolString (const std::string& state_name,
-                        bool val,
-                        const std::string& arg);
+void receiveBoolFromString (const std::string& state_name,
+                            bool val,
+                            const std::string& arg);
+void receiveDoubleFromInt (const std::string& state_name, double val, int arg);
 void receiveDoubleVector (const std::string& state_name, vector<double> vals);
 
 

--- a/ow_plexil/src/plexil-adapter/joint_support.h
+++ b/ow_plexil/src/plexil-adapter/joint_support.h
@@ -38,16 +38,19 @@ struct JointProperties
 
 struct JointTelemetry
 {
-  JointTelemetry (double p = 0, double v = 0, double e = 0)
+  JointTelemetry (double p = 0, double v = 0, double e = 0, double a = 0)
   : position(p),
     velocity(v),
-    effort(e) { }
+    effort(e),
+    acceleration(a)
+  { }
 
   // Use compiler's copy constructor, destructor, assignment.
 
   double position;
   double velocity;
   double effort;
+  double acceleration;
 };
 
 enum class TelemetryType {

--- a/ow_plexil/src/plexil-adapter/joint_support.h
+++ b/ow_plexil/src/plexil-adapter/joint_support.h
@@ -13,10 +13,12 @@
 
 #include <string>
 
-const size_t KnownJoints = 9;
+const size_t NumJoints = 9;
 
 enum Joint {
-  // NOTE: we could use the names in /joint_states, but these seem more readable.
+  // This enumeration must list all joints and in the same order as
+  // the topic /joint_states, which is alphabetical by joint name
+  // there.  The names used here are different but more readable.
   ANTENNA_PAN = 0,
   ANTENNA_TILT = 1,
   DISTAL_PITCH = 2,

--- a/ow_plexil/src/plexil-adapter/joint_support.h
+++ b/ow_plexil/src/plexil-adapter/joint_support.h
@@ -44,19 +44,12 @@ struct JointTelemetry
 {
   // Structure to store the latest joint telemetry readings.
 
-  JointTelemetry (double p = 0, double v = 0, double e = 0, double a = 0)
-  : position(p),
-    velocity(v),
-    effort(e),
-    acceleration(a)
-  { }
+  // Use compiler's default methods.
 
-  // Use compiler's copy constructor, destructor, assignment.
-
-  double position;
-  double velocity;
-  double effort;
-  double acceleration;
+  double position = 0;
+  double velocity = 0;
+  double effort = 0;
+  double acceleration = 0;
 };
 
 enum class TelemetryType {

--- a/ow_plexil/src/plexil-adapter/joint_support.h
+++ b/ow_plexil/src/plexil-adapter/joint_support.h
@@ -15,8 +15,8 @@
 
 const size_t KnownJoints = 9;
 
-// NOTE: we could use the names in /joint_states, but these seem more readable.
 enum Joint {
+  // NOTE: we could use the names in /joint_states, but these seem more readable.
   ANTENNA_PAN = 0,
   ANTENNA_TILT = 1,
   DISTAL_PITCH = 2,
@@ -30,6 +30,8 @@ enum Joint {
 
 struct JointProperties
 {
+  // A structure to store useful static properties about joints.
+
   // Use compiler's default methods.
   std::string plexilName; // human-readable, no spaces
   double softTorqueLimit;
@@ -38,6 +40,8 @@ struct JointProperties
 
 struct JointTelemetry
 {
+  // Structure to store the latest joint telemetry readings.
+
   JointTelemetry (double p = 0, double v = 0, double e = 0, double a = 0)
   : position(p),
     velocity(v),

--- a/ow_plexil/src/plexil-adapter/joint_support.h
+++ b/ow_plexil/src/plexil-adapter/joint_support.h
@@ -7,24 +7,30 @@
 
 // Support for lander joints, based on ROS /joint_states message.
 
+// NOTE: This package (ow_plexil) is implemented for the lander in the
+// ow_simulator package.  Specifically, the joints and joint ordering
+// (in /joint_states) is assumed fixed, and is often hardcoded.
+
 #include <string>
 
-enum class Joint {
-  shoulder_yaw,
-  shoulder_pitch,
-  proximal_pitch,
-  distal_pitch,
-  hand_yaw,
-  scoop_yaw,
-  antenna_pan,
-  antenna_tilt,
-  grinder
+const size_t KnownJoints = 9;
+
+// NOTE: we could use the names in /joint_states, but these seem more readable.
+enum Joint {
+  ANTENNA_PAN = 0,
+  ANTENNA_TILT = 1,
+  DISTAL_PITCH = 2,
+  GRINDER = 3,
+  HAND_YAW = 4,
+  PROXIMAL_PITCH = 5,
+  SCOOP_YAW = 6,
+  SHOULDER_PITCH = 7,
+  SHOULDER_YAW = 8
 };
 
 struct JointProperties
 {
   // Use compiler's default methods.
-  std::string rosName;
   std::string plexilName; // human-readable, no spaces
   double softTorqueLimit;
   double hardTorqueLimit;
@@ -42,6 +48,13 @@ struct JointTelemetry
   double position;
   double velocity;
   double effort;
+};
+
+enum class TelemetryType {
+  Position,
+  Velocity,
+  Effort,
+  Acceleration
 };
 
 #endif

--- a/ow_plexil/src/plexil-adapter/joint_support.h
+++ b/ow_plexil/src/plexil-adapter/joint_support.h
@@ -17,8 +17,8 @@ const size_t NumJoints = 9;
 
 enum Joint {
   // This enumeration must list all joints and in the same order as
-  // the topic /joint_states, which is alphabetical by joint name
-  // there.  The names used here are different but more readable.
+  // the topic /joint_states, which is alphabetical by joint name.
+  // The names used here are different but more readable.
   ANTENNA_PAN = 0,
   ANTENNA_TILT = 1,
   DISTAL_PITCH = 2,

--- a/ow_plexil/src/plexil-adapter/subscriber.cpp
+++ b/ow_plexil/src/plexil-adapter/subscriber.cpp
@@ -3,22 +3,27 @@
 // this repository.
 
 #include "subscriber.h"
-using std::vector;
 
-// The subscribers.  Their naming convention is:
+// The subscribers.
+// The naming convention for Lookups without parameters is:
 //   Subscribe<value-type><param-type>...
+// The naming convention for Lookups with parameters is:
+//   Subscribe<value-type>From<param-type>...
+// where value-type and param-type are ad hoc, CamelCase names.
 
 static SubscribeBool SubscriberBool = nullptr;
 static SubscribeDouble SubscriberDouble = nullptr;
 static SubscribeString SubscriberString = nullptr;
-static SubscribeBoolString SubscriberBoolString = nullptr;
 static SubscribeDoubleVector SubscriberDoubleVector = nullptr;
+static SubscribeBoolFromString SubscriberBoolFromString = nullptr;
+static SubscribeDoubleFromInt SubscriberDoubleFromInt = nullptr;
 
 void setSubscriber (SubscribeBool s) { SubscriberBool = s; }
 void setSubscriber (SubscribeDouble s) { SubscriberDouble = s; }
 void setSubscriber (SubscribeString s) { SubscriberString = s; }
-void setSubscriber (SubscribeBoolString s) { SubscriberBoolString = s; }
+void setSubscriber (SubscribeBoolFromString s) { SubscriberBoolFromString = s; }
 void setSubscriber (SubscribeDoubleVector s) { SubscriberDoubleVector = s; }
+void setSubscriber (SubscribeDoubleFromInt s) { SubscriberDoubleFromInt = s; }
 
 // The overloaded publish function, one for each value/parameter combination
 // found in this application.
@@ -38,12 +43,17 @@ void publish (const string& state_name, const string& val)
   SubscriberString (state_name, val);
 }
 
-void publish (const std::string& state_name, bool val, const std::string& arg)
-{
-  SubscriberBoolString (state_name, val, arg);
-}
-
 void publish (const std::string& state_name, vector<double> vals)
 {
   SubscriberDoubleVector (state_name, vals);
+}
+
+void publish (const std::string& state_name, bool val, const std::string& arg)
+{
+  SubscriberBoolFromString (state_name, val, arg);
+}
+
+void publish (const string& state_name, double val, int arg)
+{
+  SubscriberDoubleFromInt (state_name, val, arg);
 }

--- a/ow_plexil/src/plexil-adapter/subscriber.h
+++ b/ow_plexil/src/plexil-adapter/subscriber.h
@@ -5,9 +5,10 @@
 #ifndef Ow_Plexil_Subscriber
 #define Ow_Plexil_Subscriber
 
-// This is a barebones publish-subscribe facility for PLEXIL.  It provides a set
-// of subscription functions specific to various combinations of return type and
-// parameters.
+// This is a barebones publish-subscribe facility for PLEXIL.  It
+// provides a set of subscription functions specific to various
+// combinations of a PLEXIL Lookup's return type and parameters.  Only
+// those used by OceanWATERS are defined.
 
 // To do: incorporate the new template-based version of this pattern developed
 // in the summer of 2020 by Albert Kutsyy.
@@ -22,25 +23,30 @@ typedef void (* SubscribeBool) (const string& state_name, bool val);
 typedef void (* SubscribeDouble) (const string& state_name, double val);
 typedef void (* SubscribeString) (const string& state_name,
                                   const string& val);
-typedef void (* SubscribeBoolString) (const string& state_name,
-                                      bool val, const string& arg);
 typedef void (* SubscribeDoubleVector) (const string& state_name,
-                                      vector<double> vals);
+                                        vector<double> vals);
+typedef void (* SubscribeBoolFromString) (const string& state_name,
+                                          bool val, const string& arg);
+typedef void (* SubscribeDoubleFromInt) (const string& state_name,
+                                         double val, int arg);
+
 
 
 // Setters for subscribers of each supported type signature
 void setSubscriber (SubscribeBool);
 void setSubscriber (SubscribeDouble);
 void setSubscriber (SubscribeString);
-void setSubscriber (SubscribeBoolString);
 void setSubscriber (SubscribeDoubleVector);
+void setSubscriber (SubscribeBoolFromString);
+void setSubscriber (SubscribeDoubleFromInt);
+
 
 // Publish a state name, which notifies the subscriber.
 void publish (const string& state_name, bool val);
 void publish (const string& state_name, double val);
 void publish (const string& state_name, const string& val);
-void publish (const string& state_name, bool val, const string& arg);
 void publish (const string& state_name, vector<double> vals);
-using std::vector;
+void publish (const string& state_name, bool val, const string& arg);
+void publish (const string& state_name, double val, int arg);
 
 #endif


### PR DESCRIPTION
### Summary

 - Implemented unified interface for joint telemetries: position, effort/torque, velocity, acceleration.

### Supporting Changes

- Revamped existing representation and management of joint telemetry in PLEXIL adapter.

### Future work

- Much repetitive coding that could be streamlined.
- Antenna pan/tilt lookups could be implemented in the new interface rather than be separate.

### Test

Two tests are needed, for OceanWATERS and OWLAT.  First do a clean build that also builds for OWLAT (`catkin build -DOWLAT=ON`).  Re-source the OS init file each shell.

1. OceanWATERS
 - Start the Atacama world
 - Run the `TestTelemetry` plan.  Expected output is below.
 - Terminate both nodes for the OWLAT run.
```
[ INFO]: PLEXIL: Pan degees: -0.000374146164403517
[ INFO]: PLEXIL: Pan radians: -6.53011105811174e-06
[ INFO]: PLEXIL: Tilt degees: -0.671719016855934
[ INFO]: PLEXIL: Tilt radians: -0.0117237084923953
[ INFO]: PLEXIL: Position of joint 0 = -6.53011105811174e-06
[ INFO]: PLEXIL: Velocity of joint 0 = -2.41949916810734e-09
[ INFO]: PLEXIL: Effort of joint 0 = -5.16886089485524e-08
[ WARN]: jointTelemetry: acceleration not available for antenna joint.
[ INFO]: PLEXIL: Acceleration of joint 0 = 0
[ INFO]: PLEXIL: Position of joint 1 = -0.0117237084923953
[ INFO]: PLEXIL: Velocity of joint 1 = -3.05800119775946e-09
[ INFO]: PLEXIL: Effort of joint 1 = 2.37190864632781
[ WARN]: jointTelemetry: acceleration not available for antenna joint.
[ INFO]: PLEXIL: Acceleration of joint 1 = 0
[ INFO]: PLEXIL: Position of joint 2 = 2.88909033861065
[ INFO]: PLEXIL: Velocity of joint 2 = -6.43104181733693e-19
[ INFO]: PLEXIL: Effort of joint 2 = 1.82882900637571
[ INFO]: PLEXIL: Acceleration of joint 2 = -4.90600624849805e-16
[ INFO]: PLEXIL: Position of joint 3 = -0.120415069096364
[ INFO]: PLEXIL: Velocity of joint 3 = -0.00185637261719489
[ INFO]: PLEXIL: Effort of joint 3 = 0
[ INFO]: PLEXIL: Acceleration of joint 3 = 7.18058973431094e-05
[ INFO]: PLEXIL: Position of joint 4 = -1.24344978758018e-14
[ INFO]: PLEXIL: Velocity of joint 4 = 2.14554665630918e-18
[ INFO]: PLEXIL: Effort of joint 4 = 1.24355270296518e-11
[ INFO]: PLEXIL: Acceleration of joint 4 = 1.41459351537809e-16
[ INFO]: PLEXIL: Position of joint 5 = 3.60139097927089
[ INFO]: PLEXIL: Velocity of joint 5 = 2.01341640281611e-17
[ INFO]: PLEXIL: Effort of joint 5 = 5.15696364889991
[ INFO]: PLEXIL: Acceleration of joint 5 = 3.05818482822919e-15
[ INFO]: PLEXIL: Position of joint 6 = 8.88178419700125e-16
[ INFO]: PLEXIL: Velocity of joint 6 = 1.7969177386686e-18
[ INFO]: PLEXIL: Effort of joint 6 = 1.37298359110987e-17
[ INFO]: PLEXIL: Acceleration of joint 6 = 8.25443378170301e-17
[ INFO]: PLEXIL: Position of joint 7 = 1.55654376610611
[ INFO]: PLEXIL: Velocity of joint 7 = -1.41119465092063e-16
[ INFO]: PLEXIL: Effort of joint 7 = 3.10665754099172
[ INFO]: PLEXIL: Acceleration of joint 7 = -1.30032810491309e-14
[ INFO]: PLEXIL: Position of joint 8 = -1.49999999999678
[ INFO]: PLEXIL: Velocity of joint 8 = -2.50808633234961e-17
[ INFO]: PLEXIL: Effort of joint 8 = 6.80961724848328e-12
[ INFO]: PLEXIL: Acceleration of joint 8 = 2.02732222915155e-15
```

2. OWLAT test
 - Start roscore
 - `launch_owlat Scoop`
 - Launch owlat_exec and run the TestTelemetry plan.  E.g. `roslaunch ow_plexil owlat_exec.launch plan:=TelemetryTest.plx`.  Output should be as follows.

```
[ INFO]: Starting PLEXIL executive node...
[ INFO]: Executive node started, ready for PLEXIL plans.
[ INFO]: PLEXIL: Pan degees: 0
[ INFO]: PLEXIL: Pan radians: 0
[ INFO]: PLEXIL: Tilt degees: 0
[ INFO]: PLEXIL: Tilt radians: 0
[ INFO]: PLEXIL: Position of joint 0 = -6.68719914197442e-07
[ INFO]: PLEXIL: Velocity of joint 0 = 0
[ INFO]: PLEXIL: Effort of joint 0 = 0
[ INFO]: PLEXIL: Acceleration of joint 0 = 0
[ INFO]: PLEXIL: Position of joint 1 = -1.99000421035986
[ INFO]: PLEXIL: Velocity of joint 1 = 1.12020177876595e-06
[ INFO]: PLEXIL: Effort of joint 1 = 0
[ INFO]: PLEXIL: Acceleration of joint 1 = 0
[ INFO]: PLEXIL: Position of joint 2 = -3.86771435772015e-08
[ INFO]: PLEXIL: Velocity of joint 2 = 9.0606469559997e-09
[ INFO]: PLEXIL: Effort of joint 2 = 0.0195286236618256
[ INFO]: PLEXIL: Acceleration of joint 2 = -2.10235034485418e-09
[ INFO]: PLEXIL: Position of joint 3 = 3.10003013951662
[ INFO]: PLEXIL: Velocity of joint 3 = -3.75286495544945e-08
[ INFO]: PLEXIL: Effort of joint 3 = -0.115904641858132
[ INFO]: PLEXIL: Acceleration of joint 3 = 2.35063168929628e-10
[ INFO]: PLEXIL: Position of joint 4 = 1.38054097649685e-08
[ INFO]: PLEXIL: Velocity of joint 4 = -3.59024678005457e-09
[ INFO]: PLEXIL: Effort of joint 4 = -0.0191918291123874
[ INFO]: PLEXIL: Acceleration of joint 4 = 6.11062489497272e-10
[ INFO]: PLEXIL: Position of joint 5 = 1.84802149969342e-07
[ INFO]: PLEXIL: Velocity of joint 5 = -4.79501136214769e-08
[ INFO]: PLEXIL: Effort of joint 5 = -0.25336554980601
[ INFO]: PLEXIL: Acceleration of joint 5 = 1.17776565389249e-08
[ERROR]: getJointTelemetry: invalid joint index 6
[ INFO]: PLEXIL: Position of joint 6 = 0
[ERROR]: getJointTelemetry: invalid joint index 6
[ INFO]: PLEXIL: Velocity of joint 6 = 0
[ERROR]: getJointTelemetry: invalid joint index 6
[ INFO]: PLEXIL: Effort of joint 6 = 0
[ERROR]: getJointTelemetry: invalid joint index 6
[ INFO]: PLEXIL: Acceleration of joint 6 = 0
[ERROR]: getJointTelemetry: invalid joint index 7
[ INFO]: PLEXIL: Position of joint 7 = 0
[ERROR]: getJointTelemetry: invalid joint index 7
[ INFO]: PLEXIL: Velocity of joint 7 = 0
[ERROR]: getJointTelemetry: invalid joint index 7
[ INFO]: PLEXIL: Effort of joint 7 = 0
[ERROR]: getJointTelemetry: invalid joint index 7
[ INFO]: PLEXIL: Acceleration of joint 7 = 0
[ERROR]: getJointTelemetry: invalid joint index 8
[ INFO]: PLEXIL: Position of joint 8 = 0
[ERROR]: getJointTelemetry: invalid joint index 8
[ INFO]: PLEXIL: Velocity of joint 8 = 0
[ERROR]: getJointTelemetry: invalid joint index 8
[ INFO]: PLEXIL: Effort of joint 8 = 0
[ERROR]: getJointTelemetry: invalid joint index 8
[ INFO]: PLEXIL: Acceleration of joint 8 = 0
```