### PR TITLE
Oceanwater 943 Support ArmStow and ArmUnstow

### DIFF
--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -183,18 +183,18 @@ static bool lookup (const string& state_name,
   return retval;
 }
 
-static void stow (Command* cmd, AdapterExecInterface* intf)
+static void arm_stow (Command* cmd, AdapterExecInterface* intf)
 {
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
-  OwInterface::instance()->stow (CommandId);
+  OwInterface::instance()->armStow (CommandId);
   acknowledge_command_sent(*cr);
 
 }
 
-static void unstow (Command* cmd, AdapterExecInterface* intf)
+static void arm_unstow (Command* cmd, AdapterExecInterface* intf)
 {
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
-  OwInterface::instance()->unstow (CommandId);
+  OwInterface::instance()->armUnstow (CommandId);
   acknowledge_command_sent(*cr);
 }
 
@@ -420,8 +420,8 @@ OwAdapter::OwAdapter(AdapterExecInterface& execInterface,
 bool OwAdapter::initialize()
 {
   CommonAdapter::initialize();
-  g_configuration->registerCommandHandler("stow", stow);
-  g_configuration->registerCommandHandler("unstow", unstow);
+  g_configuration->registerCommandHandler("stow", arm_stow);
+  g_configuration->registerCommandHandler("unstow", arm_unstow);
   g_configuration->registerCommandHandler("grind", grind);
   g_configuration->registerCommandHandler("guarded_move", guarded_move);
   g_configuration->registerCommandHandler("arm_move_joint", arm_move_joint);

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -33,6 +33,7 @@ using std::shared_ptr;
 using std::make_unique;
 
 using namespace ow_lander;
+using namespace owl_msgs;
 
 //////////////////// Utilities ////////////////////////
 

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -843,8 +843,7 @@ void OwInterface::unstow (int id)  // as action
 
 void OwInterface::unstowAction (int id)
 {
-  UnstowGoal goal;
-  goal.goal = 0;  // Arbitrary, meaningless value
+  UnstowGoal goal; // empty/undefined
 
   runAction<actionlib::SimpleActionClient<UnstowAction>,
             UnstowGoal,
@@ -865,8 +864,7 @@ void OwInterface::stow (int id)  // as action
 
 void OwInterface::stowAction (int id)
 {
-  StowGoal goal;
-  goal.goal = 0;  // Arbitrary, meaningless value
+  StowGoal goal; // empty/undefined
 
   runAction<actionlib::SimpleActionClient<StowAction>,
             StowGoal,

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -24,8 +24,8 @@
 // ow_simulator (ROS Actions)
 #include <actionlib/client/simple_action_client.h>
 #include <actionlib_msgs/GoalStatusArray.h>
-#include <owl_msgs/UnstowAction.h>
-#include <owl_msgs/StowAction.h>
+#include <owl_msgs/ArmUnstowAction.h>
+#include <owl_msgs/ArmStowAction.h>
 #include <ow_lander/GrindAction.h>
 #include <ow_lander/GuardedMoveAction.h>
 #include <ow_lander/ArmMoveJointAction.h>
@@ -50,10 +50,10 @@
 #include <string>
 #include <memory>
 
-using UnstowActionClient =
-  actionlib::SimpleActionClient<owl_msgs::UnstowAction>;
-using StowActionClient =
-  actionlib::SimpleActionClient<owl_msgs::StowAction>;
+using ArmUnstowActionClient =
+  actionlib::SimpleActionClient<owl_msgs::ArmUnstowAction>;
+using ArmStowActionClient =
+  actionlib::SimpleActionClient<owl_msgs::ArmStowAction>;
 using GrindActionClient =
   actionlib::SimpleActionClient<ow_lander::GrindAction>;
 using GuardedMoveActionClient =
@@ -118,8 +118,8 @@ class OwInterface : public PlexilInterface
                     double ground_pos, bool parallel, int id);
   void grind (double x, double y, double depth, double length,
               bool parallel, double ground_pos, int id);
-  void stow (int id);
-  void unstow (int id);
+  void armStow (int id);
+  void armUnstow (int id);
   void deliver (int id);
   void discard (double x, double y, double z, int id);
   void lightSetIntensity (const std::string& side, double intensity, int id);
@@ -151,8 +151,8 @@ class OwInterface : public PlexilInterface
   template<typename Service>
   void callService (ros::ServiceClient, Service, std::string name, int id);
 
-  void unstowAction (int id);
-  void stowAction (int id);
+  void armStowAction (int id);
+  void armUnstowAction (int id);
   void grindAction (double x, double y, double depth, double length,
                     bool parallel, double ground_pos, int id);
   void guardedMoveAction (double x, double y, double z,
@@ -251,8 +251,8 @@ class OwInterface : public PlexilInterface
   std::unique_ptr<GuardedMoveActionClient> m_guardedMoveClient;
   std::unique_ptr<ArmMoveJointActionClient> m_armMoveJointClient;
   std::unique_ptr<ArmMoveJointsActionClient> m_armMoveJointsClient;
-  std::unique_ptr<UnstowActionClient> m_unstowClient;
-  std::unique_ptr<StowActionClient> m_stowClient;
+  std::unique_ptr<ArmUnstowActionClient> m_armUnstowClient;
+  std::unique_ptr<ArmStowActionClient> m_armStowClient;
   std::unique_ptr<GrindActionClient> m_grindClient;
   std::unique_ptr<DigCircularActionClient> m_digCircularClient;
   std::unique_ptr<DigLinearActionClient> m_digLinearClient;

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -24,8 +24,8 @@
 // ow_simulator (ROS Actions)
 #include <actionlib/client/simple_action_client.h>
 #include <actionlib_msgs/GoalStatusArray.h>
-#include <ow_lander/UnstowAction.h>
-#include <ow_lander/StowAction.h>
+#include <owl_msgs/UnstowAction.h>
+#include <owl_msgs/StowAction.h>
 #include <ow_lander/GrindAction.h>
 #include <ow_lander/GuardedMoveAction.h>
 #include <ow_lander/ArmMoveJointAction.h>
@@ -51,9 +51,9 @@
 #include <memory>
 
 using UnstowActionClient =
-  actionlib::SimpleActionClient<ow_lander::UnstowAction>;
+  actionlib::SimpleActionClient<owl_msgs::UnstowAction>;
 using StowActionClient =
-  actionlib::SimpleActionClient<ow_lander::StowAction>;
+  actionlib::SimpleActionClient<owl_msgs::StowAction>;
 using GrindActionClient =
   actionlib::SimpleActionClient<ow_lander::GrindAction>;
 using GuardedMoveActionClient =


### PR DESCRIPTION
### Summary

 - Support the newly named and moved actions ArmStow and ArmUnstow.
 - **Note:** the names of these commands in PLEXIL have not been changed because of the pervasiveness of the needed editing, and since the meaning of "stow" and "unstow" is clear.

### Test
 - This branch must be tested with the corresponding branch in ow_simulator.
 - Do a clean build. This itself verifies most of renaming and moving.
 - Start any simulator world.
 - `roslaunch ow_plexil ow_exec.launch`
 - Run the `Unstow.plx` plan and see that the arm unstows normally.
 - Run the `Stow.plx` plan and see that the arm stows normally.