### PR TITLE
Oceanwater 1023-1025 battery telemetry unification

### DIFF
--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -543,7 +543,7 @@ void OwInterface::initialize()
     m_subscribers.push_back
       (make_unique<ros::Subscriber>
        (m_genericNodeHandle ->
-        subscribe("/state_of_charge", QSize, soc_callback)));
+        subscribe("/battery_state_of_charge", QSize, soc_callback)));
 
     m_subscribers.push_back
       (make_unique<ros::Subscriber>
@@ -554,7 +554,7 @@ void OwInterface::initialize()
     m_subscribers.push_back
       (make_unique<ros::Subscriber>
        (m_genericNodeHandle ->
-        subscribe("/remaining_useful_life", QSize,
+        subscribe("/battery_remaining_useful_life", QSize,
                   rul_callback)));
 
     m_subscribers.push_back

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -8,10 +8,12 @@
 
 // OW - external
 #include <ow_lander/Light.h>
+#include <owl_msgs/BatteryTemperature.h>
+#include <owl_msgs/RemainingUsefulLife.h>
+#include <owl_msgs/StateOfCharge.h>
 
 // ROS
 #include <std_msgs/Float64.h>
-#include <std_msgs/Int16.h>
 #include <std_msgs/Empty.h>
 
 // C++
@@ -314,22 +316,22 @@ static double StateOfCharge       = NAN;
 static double RemainingUsefulLife = NAN;
 static double BatteryTemperature  = NAN;
 
-static void soc_callback (const std_msgs::Float64::ConstPtr& msg)
+static void soc_callback (const owl_msgs::StateOfCharge::ConstPtr& msg)
 {
-  StateOfCharge = msg->data;
+  StateOfCharge = msg->value;
   publish ("StateOfCharge", StateOfCharge);
 }
 
-static void rul_callback (const std_msgs::Int16::ConstPtr& msg)
+static void rul_callback (const owl_msgs::RemainingUsefulLife::ConstPtr& msg)
 {
   // NOTE: This is not being called as of 4/12/21.  Jira OW-656 addresses.
-  RemainingUsefulLife = msg->data;
+  RemainingUsefulLife = msg->value;
   publish ("RemainingUsefulLife", RemainingUsefulLife);
 }
 
-static void temperature_callback (const std_msgs::Float64::ConstPtr& msg)
+static void temperature_callback (const owl_msgs::BatteryTemperature::ConstPtr& msg)
 {
-  BatteryTemperature = msg->data;
+  BatteryTemperature = msg->value;
   publish ("BatteryTemperature", BatteryTemperature);
 }
 
@@ -541,18 +543,18 @@ void OwInterface::initialize()
     m_subscribers.push_back
       (make_unique<ros::Subscriber>
        (m_genericNodeHandle ->
-        subscribe("/power_system_node/state_of_charge", QSize, soc_callback)));
+        subscribe("/state_of_charge", QSize, soc_callback)));
 
     m_subscribers.push_back
       (make_unique<ros::Subscriber>
        (m_genericNodeHandle ->
-        subscribe("/power_system_node/battery_temperature", QSize,
+        subscribe("/battery_temperature", QSize,
                   temperature_callback)));
 
     m_subscribers.push_back
       (make_unique<ros::Subscriber>
        (m_genericNodeHandle ->
-        subscribe("/power_system_node/remaining_useful_life", QSize,
+        subscribe("/remaining_useful_life", QSize,
                   rul_callback)));
 
     m_subscribers.push_back

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -21,7 +21,6 @@
 #include <owl_msgs/PowerFaultsStatus.h>
 #include <owl_msgs/SystemFaultsStatus.h>
 
-
 // ow_simulator (ROS Actions)
 #include <actionlib/client/simple_action_client.h>
 #include <actionlib_msgs/GoalStatusArray.h>

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -15,11 +15,12 @@
 #include <ow_plexil/IdentifyLocationAction.h>
 
 // ow_simulator
-#include <owl_msgs/SystemFaultsStatus.h>
 #include <owl_msgs/ArmJointAccelerations.h>
 #include <owl_msgs/ArmFaultsStatus.h>
 #include <owl_msgs/PanTiltFaultsStatus.h>
 #include <owl_msgs/PowerFaultsStatus.h>
+#include <owl_msgs/SystemFaultsStatus.h>
+
 
 // ow_simulator (ROS Actions)
 #include <actionlib/client/simple_action_client.h>
@@ -44,10 +45,6 @@
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <geometry_msgs/Point.h>
-#include <owl_msgs/SystemFaultsStatus.h>
-#include <owl_msgs/ArmFaultsStatus.h>
-#include <owl_msgs/PowerFaultsStatus.h>
-#include <owl_msgs/PanTiltFaultsStatus.h>
 #include <ros/ros.h>
 
 // C++


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-934](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-934) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1023](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1023) |
| Jira Ticket 🎟️ | [OCEANWATER-1024](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1024) |
| Jira Ticket 🎟️ | [OCEANWATER-1025](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1025) |

**This issue has a corresponding and required branch on [ow_simulator](https://github.com/nasa/ow_autonomy/pull/304).**

## Summary of Changes
* Create messages for BatteryTemperature, RemainingUsefulLife, and StateOfCharge in the `owl_msgs` package according to the Telemetry Unification Doc.
* Change existing power_system_node messages to publish without the `/power_system_node` prefix.
* Update references in ow_power_system_node, ow_faults_detection, and ow_plexil to use new types and prefixes.

## Test

## Test
* After building and sourcing, show the new messages in owl_msgs with: 
  * `rosmsg package owl_msgs`
  * `rosmsg show owl_msgs/BatteryTemperature`
  *  `rosmsg show owl_msgs/RemainingUsefulLife`
  *  `rosmsg show owl_msgs/StateOfCharge`
* Since FaultDetection is dependent on BatteryTemperature and StateOfCharge, their continued functionality can be verified using the testing procedure in [OCEANWATER-1014_implement_telemetry_power_faults_status](https://github.com/nasa/ow_simulator/pull/299), while also echoing the updated topics `/battery_temperature` and `/state_of_charge` (without the `/power_system_node` prefix).
  * Note: `remaining_useful_life` has no current dependent module, but it can be observed with `echo /remaining_useful_life` during tests.