### PR TITLE
Oceanwater 1092 move exposure to its own action

### DIFF
--- a/ow_plexil/src/plans/CameraCapture.plp
+++ b/ow_plexil/src/plans/CameraCapture.plp
@@ -8,6 +8,5 @@
 
 CameraCapture:
 {
-  In Real ExposureSecs;
-  SynchronousCommand camera_capture (ExposureSecs);
+  SynchronousCommand camera_capture ();
 }

--- a/ow_plexil/src/plans/CameraSetExposure.plp
+++ b/ow_plexil/src/plans/CameraSetExposure.plp
@@ -1,0 +1,15 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// Set the camera's exposure time in seconds.
+//   The default is 0.05 seconds.
+//   Values <= 0 mean to use the last exposure setting.
+
+#include "lander-commands.h"
+
+CameraSetExposure:
+{
+  In Real Seconds;
+  SynchronousCommand camera_set_exposure (Seconds);
+}

--- a/ow_plexil/src/plans/ImagePass.plp
+++ b/ow_plexil/src/plans/ImagePass.plp
@@ -16,7 +16,7 @@ ImagePass: UncheckedSequence
   InOut Real PanAngle;
   InOut Boolean ReversePan;
 
-  LibraryCall CameraCapture (ExposureSecs = 0);
+  LibraryCall CameraCapture ();
   if (ReversePan) {
     log_debug ("Reverse pan. Pan =", PanAngle, "Lo=", PanLo,
                "Increment=", PanIncrement);

--- a/ow_plexil/src/plans/PanAndShoot.plp
+++ b/ow_plexil/src/plans/PanAndShoot.plp
@@ -19,5 +19,5 @@ PanAndShoot:
   In Real PanAngle, TiltAngle;
 
   LibraryCall PanTilt (PanDegrees = PanAngle, TiltDegrees = TiltAngle);
-  LibraryCall CameraCapture (ExposureSecs = 0);
+  LibraryCall CameraCapture ();
 }

--- a/ow_plexil/src/plans/TestCameraCapture.plp
+++ b/ow_plexil/src/plans/TestCameraCapture.plp
@@ -2,7 +2,7 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Perform a sequence of camera captures, testing various exposures.
+// Perform a sequence of camera captures, varying the exposures.
 // Verification of this test requires inspecting the images, e.g. in
 // RQT's image viewer.  A simulation world (e.g. atacama_y1a) that has
 // interesting features at the chosen pan/tilt will also help.
@@ -17,31 +17,36 @@ TestCameraCapture: UncheckedSequence
   LibraryCall PanTilt (PanDegrees = 35, TiltDegrees = 35);
 
   log_info ("Taking image using default exposure (0.05 secs)...");
-  LibraryCall CameraCapture (ExposureSecs = 0);
+  LibraryCall CameraCapture ();
   Wait 3;
 
   log_info ("Taking image with 0.02 second exposure (should be very dark)...");
-  LibraryCall CameraCapture (ExposureSecs = 0.02);
+  LibraryCall CameraSetExposure (Seconds = 0.02);
+  LibraryCall CameraCapture ();
   Wait 3;
 
   log_info ("Taking image with 0.07 second exposure (should be bright)...");
-  LibraryCall CameraCapture (ExposureSecs = 0.07);
+  LibraryCall CameraSetExposure (Seconds = 0.07);
+  LibraryCall CameraCapture ();
   Wait 3;
 
   log_info ("Taking image with previous exposure time...");
-  LibraryCall CameraCapture (ExposureSecs = -1);
+  LibraryCall CameraSetExposure (Seconds = -1);
+  LibraryCall CameraCapture ();
   Wait 3;
 
   log_info ("Taking image with 1 second exposure (should be almost white)...");
-  LibraryCall CameraCapture (ExposureSecs = 1);
+  LibraryCall CameraSetExposure (Seconds = 1);
+  LibraryCall CameraCapture ();
   Wait 3;
 
   log_info ("Taking image with previous exposure time...");
-  LibraryCall CameraCapture (ExposureSecs = 0);
+  LibraryCall CameraCapture ();
   Wait 3;
 
   log_info ("Taking image with 0.05 second exposure (camera default)...");
-  LibraryCall CameraCapture (ExposureSecs = 0.05);
+  LibraryCall CameraSetExposure (Seconds = 0.05);
+  LibraryCall CameraCapture ();
 
   log_info ("TestCameraCapture finished.");
 }

--- a/ow_plexil/src/plans/lander-commands.h
+++ b/ow_plexil/src/plans/lander-commands.h
@@ -14,7 +14,8 @@
 // plan-interface.h) that wraps these commands in a way that they
 // called synchronously.
 
-Command camera_capture (Real exposure_secs);
+Command camera_set_exposure (Real seconds);
+Command camera_capture ();
 
 Command pan_tilt (Real pan_degrees, Real tilt_degrees);
 
@@ -22,7 +23,7 @@ Command arm_move_joint (Boolean relative,
                         Integer joint,
                         Real angle);
 
-Command arm_move_joints (Boolean relative, 
+Command arm_move_joints (Boolean relative,
                          Real angles[6]);
 
 Command dig_circular (Real x,

--- a/ow_plexil/src/plans/plan-interface.h
+++ b/ow_plexil/src/plans/plan-interface.h
@@ -62,7 +62,8 @@ LibraryAction Discard (In Real X,
                        In Real Y,
                        In Real Z);
 
-LibraryAction CameraCapture (In Real ExposureSecs);
+LibraryAction CameraSetExposure (In Real Seconds);
+LibraryAction CameraCapture ();
 
 // Lander queries
 

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -350,11 +350,18 @@ static void pan_tilt (Command* cmd, AdapterExecInterface* intf)
 
 static void camera_capture (Command* cmd, AdapterExecInterface* intf)
 {
+  unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
+  OwInterface::instance()->cameraCapture (CommandId);
+  acknowledge_command_sent(*cr);
+}
+
+static void camera_set_exposure (Command* cmd, AdapterExecInterface* intf)
+{
   double exposure_secs;
   const vector<Value>& args = cmd->getArgValues();
   args[0].getValue (exposure_secs);
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
-  OwInterface::instance()->cameraCapture (exposure_secs, CommandId);
+  OwInterface::instance()->cameraSetExposure (exposure_secs, CommandId);
   acknowledge_command_sent(*cr);
 }
 
@@ -434,6 +441,8 @@ bool OwAdapter::initialize()
   g_configuration->registerCommandHandler("identify_sample_location",
                                           identify_sample_location);
   g_configuration->registerCommandHandler("camera_capture", camera_capture);
+  g_configuration->registerCommandHandler("camera_set_exposure",
+                                          camera_set_exposure);
   g_configuration->registerCommandHandler("light_set_intensity",
                                           light_set_intensity);
   OwInterface::instance()->setCommandStatusCallback (command_status_callback);

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -36,6 +36,7 @@
 #include <ow_lander/AntennaPanTiltAction.h>
 #include <ow_lander/DiscardAction.h>
 #include <ow_lander/CameraCaptureAction.h>
+#include <ow_lander/CameraSetExposureAction.h>
 #include <ow_lander/LightSetIntensityAction.h>
 
 // ROS
@@ -74,6 +75,8 @@ using DiscardActionClient =
   actionlib::SimpleActionClient<ow_lander::DiscardAction>;
 using CameraCaptureActionClient =
   actionlib::SimpleActionClient<ow_lander::CameraCaptureAction>;
+using CameraSetExposureActionClient =
+  actionlib::SimpleActionClient<ow_lander::CameraSetExposureAction>;
 using LightSetIntensityActionClient =
   actionlib::SimpleActionClient<ow_lander::LightSetIntensityAction>;
 
@@ -111,7 +114,8 @@ class OwInterface : public PlexilInterface
                                               int id);
 
   void panTiltAntenna (double pan_degrees, double tilt_degrees, int id);
-  void cameraCapture (double exposure_secs, int id);
+  void cameraCapture (int id);
+  void cameraSetExposure (double exposure_secs, int id);
   void digLinear (double x, double y, double depth, double length,
                   double ground_pos, int id);
   void digCircular (double x, double y, double depth,
@@ -171,7 +175,8 @@ class OwInterface : public PlexilInterface
   void panTiltAntennaAction (double pan_degrees, double tilt_degrees, int id);
   void deliverAction (int id);
   void discardAction (double x, double y, double z, int id);
-  void cameraCaptureAction (double exposure_secs, int id);
+  void cameraCaptureAction (int id);
+  void cameraSetExposureAction (double exposure_secs, int id);
   void lightSetIntensityAction (const std::string& side, double intensity, int id);
   void jointStatesCallback (const sensor_msgs::JointState::ConstPtr&);
   void armJointAccelerationsCb (const owl_msgs::ArmJointAccelerations::ConstPtr&);
@@ -260,6 +265,7 @@ class OwInterface : public PlexilInterface
   std::unique_ptr<PanTiltActionClient> m_panTiltClient;
   std::unique_ptr<DiscardActionClient> m_discardClient;
   std::unique_ptr<CameraCaptureActionClient> m_cameraCaptureClient;
+  std::unique_ptr<CameraSetExposureActionClient> m_cameraSetExposureClient;
   std::unique_ptr<LightSetIntensityActionClient> m_lightSetIntensityClient;
 
   std::unique_ptr<IdentifySampleLocationActionClient> m_identifySampleLocationClient;


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-933](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-933) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1092](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1092) |

This PR is accompanied by https://github.com/nasa/ow_simulator/pull/305

## Summary of Changes
* Removed exposure from CameraCapture action and created CameraSetExposure action

## Test (added by @kmdalal)
* Start the Atacama world.
* Run the plan `TestCameraCapture.plx`, watching the ow_plexil terminal and Image Viewer in rqt carefully.   You can run it again if you missed anything.  Check that the visual result is as described in the plan printout.
