### PR TITLE
Oceanwater 955 delivery command unification

### DIFF
--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -294,10 +294,10 @@ static void dig_linear (Command* cmd, AdapterExecInterface* intf)
   acknowledge_command_sent(*cr);
 }
 
-static void deliver (Command* cmd, AdapterExecInterface* intf)
+static void taskDeliverSample (Command* cmd, AdapterExecInterface* intf)
 {
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
-  OwInterface::instance()->deliver (CommandId);
+  OwInterface::instance()->taskDeliverSample (CommandId);
   acknowledge_command_sent(*cr);
 }
 
@@ -435,7 +435,7 @@ bool OwAdapter::initialize()
   g_configuration->registerCommandHandler("arm_move_joints", arm_move_joints);
   g_configuration->registerCommandHandler("dig_circular", dig_circular);
   g_configuration->registerCommandHandler("dig_linear", dig_linear);
-  g_configuration->registerCommandHandler("deliver", deliver);
+  g_configuration->registerCommandHandler("taskDeliverSample", taskDeliverSample);
   g_configuration->registerCommandHandler("discard", discard);
   g_configuration->registerCommandHandler("pan_tilt", pan_tilt);
   g_configuration->registerCommandHandler("identify_sample_location",

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -294,7 +294,7 @@ static void dig_linear (Command* cmd, AdapterExecInterface* intf)
   acknowledge_command_sent(*cr);
 }
 
-static void taskDeliverSample (Command* cmd, AdapterExecInterface* intf)
+static void task_deliver_sample (Command* cmd, AdapterExecInterface* intf)
 {
   unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
   OwInterface::instance()->taskDeliverSample (CommandId);
@@ -435,7 +435,7 @@ bool OwAdapter::initialize()
   g_configuration->registerCommandHandler("arm_move_joints", arm_move_joints);
   g_configuration->registerCommandHandler("dig_circular", dig_circular);
   g_configuration->registerCommandHandler("dig_linear", dig_linear);
-  g_configuration->registerCommandHandler("taskDeliverSample", taskDeliverSample);
+  g_configuration->registerCommandHandler("deliver", task_deliver_sample);
   g_configuration->registerCommandHandler("discard", discard);
   g_configuration->registerCommandHandler("pan_tilt", pan_tilt);
   g_configuration->registerCommandHandler("identify_sample_location",

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -57,7 +57,7 @@ const string Op_ArmMoveJoint           = "ArmMoveJoint";
 const string Op_ArmMoveJoints          = "ArmMoveJoints";
 const string Op_DigCircular            = "DigCircular";
 const string Op_DigLinear              = "DigLinear";
-const string Op_Deliver                = "Deliver";
+const string Op_TaskDeliverSample      = "TaskDeliverSample";
 const string Op_Discard                = "Discard";
 const string Op_Grind                  = "Grind";
 const string Op_ArmStow                = "ArmStow";
@@ -74,7 +74,7 @@ static vector<string> LanderOpNames = {
   Op_ArmMoveJoints,
   Op_DigCircular,
   Op_DigLinear,
-  Op_Deliver,
+  Op_TaskDeliverSample,
   Op_Discard,
   Op_PanTiltAntenna,
   Op_Grind,
@@ -116,7 +116,7 @@ static map<string, int> ActionGoalStatusMap {
   { Op_ArmMoveJoints, NOGOAL },
   { Op_DigCircular, NOGOAL },
   { Op_DigLinear, NOGOAL },
-  { Op_Deliver, NOGOAL },
+  { Op_TaskDeliverSample, NOGOAL },
   { Op_Discard, NOGOAL },
   { Op_CameraCapture, NOGOAL },
   { Op_CameraSetExposure, NOGOAL },
@@ -493,8 +493,8 @@ void OwInterface::initialize()
       make_unique<DigCircularActionClient>(Op_DigCircular, true);
     m_digLinearClient =
       make_unique<DigLinearActionClient>(Op_DigLinear, true);
-    m_deliverClient =
-      make_unique<DeliverActionClient>(Op_Deliver, true);
+    m_taskDeliverSampleClient =
+      make_unique<TaskDeliverSampleActionClient>(Op_TaskDeliverSample, true);
     m_discardClient =
       make_unique<DiscardActionClient>(Op_Discard, true);
     m_cameraCaptureClient =
@@ -614,11 +614,11 @@ void OwInterface::initialize()
     }
     else addSubscriber ("/DigLinear/status", Op_DigLinear);
 
-    if (! m_deliverClient->
+    if (! m_taskDeliverSampleClient->
         waitForServer(ros::Duration(ACTION_SERVER_TIMEOUT_SECS))) {
-      ROS_ERROR ("Deliver action server did not connect!");
+      ROS_ERROR ("TaskDeliverSample action server did not connect!");
     }
-    else addSubscriber ("/Deliver/status", Op_Deliver);
+    else addSubscriber ("/TaskDeliverSample/status", Op_TaskDeliverSample);
 
     if (! m_discardClient->
         waitForServer(ros::Duration(ACTION_SERVER_TIMEOUT_SECS))) {
@@ -750,10 +750,10 @@ void OwInterface::cameraSetExposureAction (double exposure_secs, int id)
 }
 
 
-void OwInterface::deliver (int id)
+void OwInterface::taskDeliverSample (int id)
 {
-  if (! markOperationRunning (Op_Deliver, id)) return;
-  thread action_thread (&OwInterface::deliverAction, this, id);
+  if (! markOperationRunning (Op_TaskDeliverSample, id)) return;
+  thread action_thread (&OwInterface::taskDeliverSampleAction, this, id);
   action_thread.detach();
 }
 
@@ -765,20 +765,20 @@ void OwInterface::discard (double x, double y, double z, int id)
 }
 
 
-void OwInterface::deliverAction (int id)
+void OwInterface::taskDeliverSampleAction (int id)
 {
-  DeliverGoal goal;
+  TaskDeliverSampleGoal goal;
 
-  ROS_INFO ("Starting Deliver()");
+  ROS_INFO ("Starting TaskDeliverSample()");
 
-  runAction<actionlib::SimpleActionClient<DeliverAction>,
-            DeliverGoal,
-            DeliverResultConstPtr,
-            DeliverFeedbackConstPtr>
-    (Op_Deliver, m_deliverClient, goal, id,
-     default_action_active_cb (Op_Deliver),
-     default_action_feedback_cb<DeliverFeedbackConstPtr> (Op_Deliver),
-     default_action_done_cb<DeliverResultConstPtr> (Op_Deliver));
+  runAction<actionlib::SimpleActionClient<TaskDeliverSampleAction>,
+            TaskDeliverSampleGoal,
+            TaskDeliverSampleResultConstPtr,
+            TaskDeliverSampleFeedbackConstPtr>
+    (Op_TaskDeliverSample, m_taskDeliverSampleClient, goal, id,
+     default_action_active_cb (Op_TaskDeliverSample),
+     default_action_feedback_cb<TaskDeliverSampleFeedbackConstPtr> (Op_TaskDeliverSample),
+     default_action_done_cb<TaskDeliverSampleResultConstPtr> (Op_TaskDeliverSample));
 }
 
 void OwInterface::discardAction (double x, double y, double z, int id)

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -32,7 +32,7 @@
 #include <ow_lander/ArmMoveJointsAction.h>
 #include <ow_lander/DigCircularAction.h>
 #include <ow_lander/DigLinearAction.h>
-#include <ow_lander/DeliverAction.h>
+#include <owl_msgs/TaskDeliverSampleAction.h>
 #include <ow_lander/AntennaPanTiltAction.h>
 #include <ow_lander/DiscardAction.h>
 #include <ow_lander/CameraCaptureAction.h>
@@ -67,8 +67,8 @@ using DigCircularActionClient =
   actionlib::SimpleActionClient<ow_lander::DigCircularAction>;
 using DigLinearActionClient =
   actionlib::SimpleActionClient<ow_lander::DigLinearAction>;
-using DeliverActionClient =
-  actionlib::SimpleActionClient<ow_lander::DeliverAction>;
+using TaskDeliverSampleActionClient =
+  actionlib::SimpleActionClient<ow_lander::TaskDeliverSampleAction>;
 using PanTiltActionClient =
   actionlib::SimpleActionClient<ow_lander::AntennaPanTiltAction>;
 using DiscardActionClient =
@@ -124,7 +124,7 @@ class OwInterface : public PlexilInterface
               bool parallel, double ground_pos, int id);
   void armStow (int id);
   void armUnstow (int id);
-  void deliver (int id);
+  void taskDeliverSample (int id);
   void discard (double x, double y, double z, int id);
   void lightSetIntensity (const std::string& side, double intensity, int id);
 
@@ -173,7 +173,7 @@ class OwInterface : public PlexilInterface
   void digLinearAction (double x, double y, double depth, double length,
                         double ground_pos, int id);
   void panTiltAntennaAction (double pan_degrees, double tilt_degrees, int id);
-  void deliverAction (int id);
+  void taskDeliverSampleAction (int id);
   void discardAction (double x, double y, double z, int id);
   void cameraCaptureAction (int id);
   void cameraSetExposureAction (double exposure_secs, int id);
@@ -261,7 +261,7 @@ class OwInterface : public PlexilInterface
   std::unique_ptr<GrindActionClient> m_grindClient;
   std::unique_ptr<DigCircularActionClient> m_digCircularClient;
   std::unique_ptr<DigLinearActionClient> m_digLinearClient;
-  std::unique_ptr<DeliverActionClient> m_deliverClient;
+  std::unique_ptr<TaskDeliverSampleActionClient> m_taskDeliverSampleClient;
   std::unique_ptr<PanTiltActionClient> m_panTiltClient;
   std::unique_ptr<DiscardActionClient> m_discardClient;
   std::unique_ptr<CameraCaptureActionClient> m_cameraCaptureClient;

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -26,13 +26,13 @@
 #include <actionlib_msgs/GoalStatusArray.h>
 #include <owl_msgs/ArmUnstowAction.h>
 #include <owl_msgs/ArmStowAction.h>
+#include <owl_msgs/TaskDeliverSampleAction.h>
 #include <ow_lander/GrindAction.h>
 #include <ow_lander/GuardedMoveAction.h>
 #include <ow_lander/ArmMoveJointAction.h>
 #include <ow_lander/ArmMoveJointsAction.h>
 #include <ow_lander/DigCircularAction.h>
 #include <ow_lander/DigLinearAction.h>
-#include <owl_msgs/TaskDeliverSampleAction.h>
 #include <ow_lander/AntennaPanTiltAction.h>
 #include <ow_lander/DiscardAction.h>
 #include <ow_lander/CameraCaptureAction.h>

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -68,7 +68,7 @@ using DigCircularActionClient =
 using DigLinearActionClient =
   actionlib::SimpleActionClient<ow_lander::DigLinearAction>;
 using TaskDeliverSampleActionClient =
-  actionlib::SimpleActionClient<ow_lander::TaskDeliverSampleAction>;
+  actionlib::SimpleActionClient<owl_msgs::TaskDeliverSampleAction>;
 using PanTiltActionClient =
   actionlib::SimpleActionClient<ow_lander::AntennaPanTiltAction>;
 using DiscardActionClient =


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-933](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-933) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-955](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-955) |


### Summary of Changes
* Remove goal, feedback, and result components of Deliver action.
* Rename action to TaskDeliverSample.
* Move action file to owl_msgs package.
* Update references to be consistent with new name.

### Test
* This branch must be tested with the corresponding branch in `ow_simulator`. 
* Do a clean build.  This itself verifies most of renaming and moving.
* Start any simulator world
* Run `task_deliver_sample_action_client.py` and see that the arm performs the deliver movement normally.