### PR TITLE
Oceanwater 1073 PLEXIL interface to telemetry

### DIFF
--- a/ow_plexil/src/plans/CameraCapture.plp
+++ b/ow_plexil/src/plans/CameraCapture.plp
@@ -4,9 +4,31 @@
 
 // Capture an image with the stereo camera.
 
-#include "lander-commands.h"
+#include "plan-interface.h"
 
 CameraCapture:
 {
-  SynchronousCommand camera_capture ();
+  Boolean FaultDetected = false;
+
+  PostCondition !Lookup(CameraFault);
+
+  if Lookup(CameraFault)
+  {
+    log_error ("Command camera_capture not sent to ",
+               "lander due to active camera fault.");
+    FaultDetected = true;
+  }
+
+  SendCameraCapture:
+  {
+    Start !Lookup(CameraFault);
+
+    if FaultDetected
+    {
+      log_info ("Camera fault resolved, ",
+                "sending camera_capture command to lander...");
+    }
+    SynchronousCommand camera_capture ();
+  }
 }
+

--- a/ow_plexil/src/plans/plan-interface.h
+++ b/ow_plexil/src/plans/plan-interface.h
@@ -80,16 +80,26 @@ Boolean Lookup AntennaPanFault;
 Boolean Lookup AntennaTiltFault;
 Boolean Lookup ArmFault;
 Boolean Lookup PowerFault;
+Boolean Lookup CameraFault;
 
 // Relevant with GuardedMove only:
 Boolean Lookup GroundFound;
 Real    Lookup GroundPosition;
 
 // Antenna
-Real    Lookup PanRadians;
-Real    Lookup PanDegrees;
-Real    Lookup TiltRadians;
-Real    Lookup TiltDegrees;
+Real Lookup PanRadians;
+Real Lookup PanDegrees;
+Real Lookup TiltRadians;
+Real Lookup TiltDegrees;
+
+// Joints
+Real Lookup JointVelocity (Integer joint_index);
+Real Lookup JointEffort (Integer joint_index);
+Real Lookup JointPosition (Integer joint_index);
+Real Lookup JointAcceleration (Integer joint_index);
+
+// Force/Torque Sensor
+Real[6] Lookup ArmEndEffectorForceTorque;
 
 
 // Misc
@@ -102,7 +112,9 @@ Boolean Lookup Running (String operation_name);
 // Query the goal status of the ROS action corresponding to a given library action
 Integer Lookup ActionGoalStatus (String action_name);
 
+// Function
 Boolean Lookup AnglesEquivalent (Real deg1, Real deg2, Real tolerance);
+
 
 //////// PLEXIL Utilities
 

--- a/ow_plexil/src/plans/plan-interface.h
+++ b/ow_plexil/src/plans/plan-interface.h
@@ -103,6 +103,8 @@ Real Lookup JointAcceleration (Integer joint_index);
 
 Real[6] Lookup ArmEndEffectorForceTorque;
 Real[7] Lookup ArmPose;
+Boolean Lookup UsingOceanWATERS;
+Boolean Lookup UsingOWLAT;
 
 // Query whether a given operation is running.  Uses the operation names as
 // defined in OwInterface.cpp.  Generally not needed, but supports more

--- a/ow_plexil/src/plans/plan-interface.h
+++ b/ow_plexil/src/plans/plan-interface.h
@@ -98,11 +98,11 @@ Real Lookup JointEffort (Integer joint_index);
 Real Lookup JointPosition (Integer joint_index);
 Real Lookup JointAcceleration (Integer joint_index);
 
-// Force/Torque Sensor
-Real[6] Lookup ArmEndEffectorForceTorque;
-
 
 // Misc
+
+Real[6] Lookup ArmEndEffectorForceTorque;
+Real[7] Lookup ArmPose;
 
 // Query whether a given operation is running.  Uses the operation names as
 // defined in OwInterface.cpp.  Generally not needed, but supports more

--- a/ow_plexil/src/plans/unified/TestTelemetry.plp
+++ b/ow_plexil/src/plans/unified/TestTelemetry.plp
@@ -11,6 +11,17 @@ TestTelemetry:
   Real FT[6]; // end effector force/torque
   Real ArmPose[7]; // Position (x,y,z) followed by orientation (x,y,z,w).
 
+  log_info ("Starting telemetry tests...");
+  
+  // Testbed
+  if (Lookup(UsingOceanWATERS)) log_info ("OceanWATERS is in use.");
+  else log_info ("OceanWATERS is NOT in use.");
+  endif;
+
+  if (Lookup(UsingOWLAT)) log_info ("OWLAT is in use.");
+  else log_info ("OWLAT is NOT in use.");
+  endif;
+
   // Pan/Tilt telemetry.
 
   // Note that the current version of OWLAT Sim has neither a pan/tilt
@@ -43,10 +54,14 @@ TestTelemetry:
   for (Integer i = 0; i < 6; i + 1) {
     log_info ("  ", FT[i]);
   }
+  log_info ("}");
 
   ArmPose = Lookup(ArmPose);
   log_info ("Arm pose: {");
   for (Integer i = 0; i < 7; i + 1) {
     log_info ("  ", ArmPose[i]);
   }
+  log_info ("}");
+
+  log_info ("Telemetry tests finished.");
 }

--- a/ow_plexil/src/plans/unified/TestTelemetry.plp
+++ b/ow_plexil/src/plans/unified/TestTelemetry.plp
@@ -9,6 +9,7 @@
 TestTelemetry:
 {
   Real FT[6]; // end effector force/torque
+  Real ArmPose[7]; // Position (x,y,z) followed by orientation (x,y,z,w).
 
   // Pan/Tilt telemetry.
 
@@ -41,5 +42,11 @@ TestTelemetry:
   log_info ("Arm end effector force/torque: {");
   for (Integer i = 0; i < 6; i + 1) {
     log_info ("  ", FT[i]);
+  }
+
+  ArmPose = Lookup(ArmPose);
+  log_info ("Arm pose: {");
+  for (Integer i = 0; i < 7; i + 1) {
+    log_info ("  ", ArmPose[i]);
   }
 }

--- a/ow_plexil/src/plans/unified/TestTelemetry.plp
+++ b/ow_plexil/src/plans/unified/TestTelemetry.plp
@@ -8,6 +8,8 @@
 
 TestTelemetry:
 {
+  Real FT[6]; // end effector force/torque
+
   // Pan/Tilt telemetry.
 
   // Note that the current version of OWLAT Sim has neither a pan/tilt
@@ -27,11 +29,17 @@ TestTelemetry:
   // while OWLAT has a total of 6 joints, all arm.  Nonetheless, this
   // code will do the "right" thing on each testbed, which includes
   // producing warnings/errors for invalid indices and options.
-  
+
   for (Integer j = 0; j < 9; j + 1) {
     log_info ("Position of joint ", j, " = ", Lookup(JointPosition(j)));
     log_info ("Velocity of joint ", j, " = ", Lookup(JointVelocity(j)));
     log_info ("Effort of joint ", j, " = ", Lookup(JointEffort(j)));
     log_info ("Acceleration of joint ", j, " = ", Lookup(JointAcceleration(j)));
+  }
+
+  FT = Lookup(ArmEndEffectorForceTorque);
+  log_info ("Arm end effector force/torque: {");
+  for (Integer i = 0; i < 6; i + 1) {
+    log_info ("  ", FT[i]);
   }
 }

--- a/ow_plexil/src/plans/unified/unified-interface.h
+++ b/ow_plexil/src/plans/unified/unified-interface.h
@@ -38,7 +38,8 @@ Real Lookup JointVelocity     (Integer joint);
 Real Lookup JointPosition     (Integer joint);
 Real Lookup JointEffort       (Integer joint);
 
-// Force/Torque Sensor
+// Misc
 Real[6] Lookup ArmEndEffectorForceTorque;
+Real[7] Lookup ArmPose;
 
 #endif

--- a/ow_plexil/src/plans/unified/unified-interface.h
+++ b/ow_plexil/src/plans/unified/unified-interface.h
@@ -41,5 +41,8 @@ Real Lookup JointEffort       (Integer joint);
 // Misc
 Real[6] Lookup ArmEndEffectorForceTorque;
 Real[7] Lookup ArmPose;
+Boolean Lookup UsingOceanWATERS;
+Boolean Lookup UsingOWLAT;
+
 
 #endif

--- a/ow_plexil/src/plans/unified/unified-interface.h
+++ b/ow_plexil/src/plans/unified/unified-interface.h
@@ -38,4 +38,7 @@ Real Lookup JointVelocity     (Integer joint);
 Real Lookup JointPosition     (Integer joint);
 Real Lookup JointEffort       (Integer joint);
 
+// Force/Torque Sensor
+Real[6] Lookup ArmEndEffectorForceTorque;
+
 #endif

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -155,6 +155,10 @@ static bool lookup (const string& state_name,
     vector<double> ft = OwInterface::instance()->getEndEffectorFT();
     value_out = (Value) ft;
   }
+  else if (state_name == "ArmPose") {
+    vector<double> pose = OwInterface::instance()->getArmPose();
+    value_out = (Value) pose;
+  }
   else if (state_name == "ActionGoalStatus") {
     string s;
     args[0].getValue(s);

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -148,6 +148,13 @@ static bool lookup (const string& state_name,
   else if (state_name == "PowerFault") {
     value_out = OwInterface::instance()->powerFault();
   }
+  else if (state_name == "CameraFault") {
+    value_out = OwInterface::instance()->cameraFault();
+  }
+  else if (state_name == "ArmEndEffectorForceTorque") {
+    vector<double> ft = OwInterface::instance()->getEndEffectorFT();
+    value_out = (Value) ft;
+  }
   else if (state_name == "ActionGoalStatus") {
     string s;
     args[0].getValue(s);
@@ -406,8 +413,8 @@ static void identify_sample_location (Command* cmd, AdapterExecInterface* intf)
   const vector<Value>& args = cmd->getArgValues();
   args[0].getValue (num_pictures);
   args[1].getValue (filter_type);
-  std::unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
-  std::vector<double> point_vector;
+  unique_ptr<CommandRecord>& cr = new_command_record(cmd, intf);
+  vector<double> point_vector;
   // Get our sample point from identifySampleLocation
   point_vector = OwInterface::instance()->identifySampleLocation (num_pictures,
                                                                   filter_type,

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -81,6 +81,12 @@ static bool lookup (const string& state_name,
   else STATE_STUB(SampleGood, true)
   else STATE_STUB(CollectAndTransferTimeout, 10)
 
+  else if (state_name == "UsingOceanWATERS") {
+    value_out = true;
+  }
+  else if (state_name == "UsingOWLAT") {
+    value_out = false;
+  }
   else if (state_name == "TiltRadians") {
     value_out = OwInterface::instance()->getTiltRadians();
   }

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -233,6 +233,23 @@ void OwInterface::antennaFaultCallback
   updateFaultStatus (msg->value, m_panTiltErrors, "ANTENNA", "AntennaFault");
 }
 
+void OwInterface::cameraFaultCallback
+(const owl_msgs::CameraFaultsStatus::ConstPtr& msg)
+{
+  updateFaultStatus (msg->value, m_cameraErrors, "CAMERA", "CameraFault");
+}
+
+void OwInterface::ftCallback
+(const owl_msgs::ArmEndEffectorForceTorque::ConstPtr& msg)
+{
+  m_endEffectorFT[0] = msg->value.force.x;
+  m_endEffectorFT[1] = msg->value.force.y;
+  m_endEffectorFT[2] = msg->value.force.z;
+  m_endEffectorFT[3] = msg->value.torque.x;
+  m_endEffectorFT[4] = msg->value.torque.y;
+  m_endEffectorFT[5] = msg->value.torque.z;
+}
+
 static double normalize_degrees (double angle)
 {
   static double pi = R2D * M_PI;
@@ -422,6 +439,11 @@ bool OwInterface::powerFault () const
   return faultActive (m_powerErrors);
 }
 
+bool OwInterface::cameraFault () const
+{
+  return faultActive (m_cameraErrors);
+}
+
 template<typename T>
 static t_action_done_cb<T> guarded_move_done_cb (const string& opname)
 {
@@ -472,7 +494,10 @@ OwInterface* OwInterface::instance ()
 OwInterface::OwInterface ()
   : m_currentPanRadians (0),
     m_currentTiltRadians (0)
-{ }
+{
+  m_endEffectorFT.resize(6);
+  m_endEffectorFT = {0,0,0,0,0,0};
+}
 
 void OwInterface::initialize()
 {
@@ -571,13 +596,13 @@ void OwInterface::initialize()
     m_subscribers.push_back
       (make_unique<ros::Subscriber>
        (m_genericNodeHandle ->
-        subscribe("/faults/arm_faults_status", QSize,
+        subscribe("/arm_faults_status", QSize,
                   &OwInterface::armFaultCallback, this)));
 
     m_subscribers.push_back
       (make_unique<ros::Subscriber>
        (m_genericNodeHandle ->
-        subscribe("/faults/power_faults_status", QSize,
+        subscribe("/power_faults_status", QSize,
                   &OwInterface::powerFaultCallback, this)));
 
     m_subscribers.push_back
@@ -585,6 +610,18 @@ void OwInterface::initialize()
        (m_genericNodeHandle ->
         subscribe("/pan_tilt_faults_status", QSize,
                   &OwInterface::antennaFaultCallback, this)));
+
+    m_subscribers.push_back
+      (make_unique<ros::Subscriber>
+       (m_genericNodeHandle ->
+        subscribe("/camera_faults_status", QSize,
+                  &OwInterface::cameraFaultCallback, this)));
+
+    m_subscribers.push_back
+      (make_unique<ros::Subscriber>
+       (m_genericNodeHandle ->
+        subscribe("/arm_end_effector_force_torque", QSize,
+                  &OwInterface::ftCallback, this)));
 
     // Connect action clients to servers and add subscribers for
     // action status.
@@ -682,7 +719,6 @@ void OwInterface::addSubscriber (const string& topic, const string& operation)
        boost::bind(&OwInterface::actionGoalStatusCallback,
                    this, _1, operation))));
 }
-
 
 void OwInterface::panTiltAntenna (double pan_degrees, double tilt_degrees, int id)
 {
@@ -1206,6 +1242,11 @@ bool OwInterface::softTorqueLimitReached (const string& joint_name) const
 {
   return (JointsAtSoftTorqueLimit.find (joint_name) !=
           JointsAtSoftTorqueLimit.end());
+}
+
+vector<double> OwInterface::getEndEffectorFT () const
+{
+  return m_endEffectorFT;
 }
 
 int OwInterface::actionGoalStatus (const string& action_name) const

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -250,6 +250,17 @@ void OwInterface::ftCallback
   m_endEffectorFT[5] = msg->value.torque.z;
 }
 
+void OwInterface::armPoseCallback (const owl_msgs::ArmPose::ConstPtr& msg)
+{
+  m_armPose[0] = msg->value.position.x;
+  m_armPose[1] = msg->value.position.y;
+  m_armPose[2] = msg->value.position.z;
+  m_armPose[3] = msg->value.orientation.x;
+  m_armPose[4] = msg->value.orientation.y;
+  m_armPose[5] = msg->value.orientation.z;
+  m_armPose[6] = msg->value.orientation.w;
+}
+
 static double normalize_degrees (double angle)
 {
   static double pi = R2D * M_PI;
@@ -497,6 +508,8 @@ OwInterface::OwInterface ()
 {
   m_endEffectorFT.resize(6);
   m_endEffectorFT = {0,0,0,0,0,0};
+  m_armPose.resize(7);
+  m_armPose = {0,0,0,0,0,0,0};
 }
 
 void OwInterface::initialize()
@@ -1248,6 +1261,12 @@ vector<double> OwInterface::getEndEffectorFT () const
 {
   return m_endEffectorFT;
 }
+
+vector<double> OwInterface::getArmPose () const
+{
+  return m_armPose;
+}
+
 
 int OwInterface::actionGoalStatus (const string& action_name) const
 {

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -22,6 +22,7 @@
 #include <owl_msgs/CameraFaultsStatus.h>
 #include <owl_msgs/SystemFaultsStatus.h>
 #include <owl_msgs/ArmEndEffectorForceTorque.h>
+#include <owl_msgs/ArmPose.h>
 
 // ow_simulator (ROS Actions)
 #include <actionlib/client/simple_action_client.h>
@@ -141,6 +142,7 @@ class OwInterface : public PlexilInterface
   double getRemainingUsefulLife () const;
   double getBatteryTemperature () const;
   std::vector<double> getEndEffectorFT () const;
+  std::vector<double> getArmPose () const;
   bool   groundFound () const;
   double groundPosition () const;
   bool   systemFault () const;
@@ -196,6 +198,7 @@ class OwInterface : public PlexilInterface
   void actionGoalStatusCallback (const actionlib_msgs::GoalStatusArray::ConstPtr&,
                                  const std::string);
   void ftCallback (const owl_msgs::ArmEndEffectorForceTorque::ConstPtr&);
+  void armPoseCallback (const owl_msgs::ArmPose::ConstPtr&);
 
   template <typename T1, typename T2>
     void updateFaultStatus (T1 msg_val, T2&,
@@ -304,6 +307,7 @@ class OwInterface : public PlexilInterface
   // Misc state
   double m_currentPanRadians, m_currentTiltRadians;
   std::vector<double> m_endEffectorFT;
+  std::vector<double> m_armPose;
 };
 
 #endif


### PR DESCRIPTION
## Summary

- NOTE: only the OceanWATERS part of this work is complete.  The OWLAT part awaits its next release and will be a separate PR.
- New and modified PLEXIL interfaces (plan and C++ adapter level) to new and modified unified telemetries.  See Jira OCEANWATER-1073 for a summary of the telemetry that should be supported.
- Updated test plans for telemetry.
- New lookups `UsingOceanWATERS` and `UsingOWLAT` to verify testbed in use.
- NOTE: there is some duplication of Lookup declarations, to be resolved under a separate Jira OW-1103.

## Test

- Clean build of workspace with `ow-simulator` on branch `OCEANWATER-934_telemetry_unification_epic`.  Resource setup file in each shell.
- Start Atacama world.
- Run the plan `TestTelemetry.plx`.  Output should be approximately the following.
```
[ INFO]: PLEXIL: Starting telemetry tests...
[ INFO]: PLEXIL: OceanWATERS is in use.
[ INFO]: PLEXIL: OWLAT is NOT in use.
[ INFO]: PLEXIL: Pan degees: -0.000356523972550514
[ INFO]: PLEXIL: Pan radians: -6.22251718329636e-06
[ INFO]: PLEXIL: Tilt degees: -0.565471419031357
[ INFO]: PLEXIL: Tilt radians: -0.00986933808802171
[ INFO]: PLEXIL: Position of joint 0 = -6.22251718329636e-06
[ INFO]: PLEXIL: Velocity of joint 0 = 1.96277990160645e-09
[ INFO]: PLEXIL: Effort of joint 0 = -1.05458752841514e-07
[ WARN]: jointTelemetry: acceleration not available for antenna joint.
[ INFO]: PLEXIL: Acceleration of joint 0 = 0
[ INFO]: PLEXIL: Position of joint 1 = -0.00986933808802171
[ INFO]: PLEXIL: Velocity of joint 1 = 2.29348767380635e-09
[ INFO]: PLEXIL: Effort of joint 1 = 2.35334316103972
[ WARN]: jointTelemetry: acceleration not available for antenna joint.
[ INFO]: PLEXIL: Acceleration of joint 1 = 0
[ INFO]: PLEXIL: Position of joint 2 = 2.89064063527565
[ INFO]: PLEXIL: Velocity of joint 2 = -2.64198145839762e-17
[ INFO]: PLEXIL: Effort of joint 2 = 1.82965803493657
[ INFO]: PLEXIL: Acceleration of joint 2 = 1.42771144184033e-15
[ INFO]: PLEXIL: Position of joint 3 = -0.17495870840708
[ INFO]: PLEXIL: Velocity of joint 3 = 3.63483824415362e-11
[ INFO]: PLEXIL: Effort of joint 3 = 0
[ INFO]: PLEXIL: Acceleration of joint 3 = -6.7517892821125e-08
[ INFO]: PLEXIL: Position of joint 4 = 8.88178419700125e-16
[ INFO]: PLEXIL: Velocity of joint 4 = -1.67279515185195e-18
[ INFO]: PLEXIL: Effort of joint 4 = -7.4271438517333e-13
[ INFO]: PLEXIL: Acceleration of joint 4 = -3.6784236905599e-16
[ INFO]: PLEXIL: Position of joint 5 = 3.60560022176808
[ INFO]: PLEXIL: Velocity of joint 5 = -3.58150149062099e-17
[ INFO]: PLEXIL: Effort of joint 5 = 5.97983777333336
[ INFO]: PLEXIL: Acceleration of joint 5 = -1.33956897828208e-15
[ INFO]: PLEXIL: Position of joint 6 = 0
[ INFO]: PLEXIL: Velocity of joint 6 = -4.57567384222411e-18
[ INFO]: PLEXIL: Effort of joint 6 = 8.40668127312641e-14
[ INFO]: PLEXIL: Acceleration of joint 6 = -1.9168809511726e-16
[ INFO]: PLEXIL: Position of joint 7 = 1.55908580348612
[ INFO]: PLEXIL: Velocity of joint 7 = 4.62279412377965e-17
[ INFO]: PLEXIL: Effort of joint 7 = 3.06705594282307
[ INFO]: PLEXIL: Acceleration of joint 7 = 1.39330157208234e-14
[ INFO]: PLEXIL: Position of joint 8 = -1.49999999999676
[ INFO]: PLEXIL: Velocity of joint 8 = -2.91101685512997e-17
[ INFO]: PLEXIL: Effort of joint 8 = -3.98785257588762e-10
[ INFO]: PLEXIL: Acceleration of joint 8 = 6.08873741926235e-17
[ INFO]: PLEXIL: Arm end effector force/torque: {
[ INFO]: PLEXIL:   -3.06456244216794
[ INFO]: PLEXIL:   -14.9670806904271
[ INFO]: PLEXIL:   0.10797213266772
[ INFO]: PLEXIL:   -0.0269321803784921
[ INFO]: PLEXIL:   -0.109700655196756
[ INFO]: PLEXIL:   -1.32635119045798
[ INFO]: PLEXIL: }
[ INFO]: PLEXIL: Arm pose: {
[ INFO]: PLEXIL:   0
[ INFO]: PLEXIL:   0
[ INFO]: PLEXIL:   0
[ INFO]: PLEXIL:   0
[ INFO]: PLEXIL:   0
[ INFO]: PLEXIL:   0
[ INFO]: PLEXIL:   0
[ INFO]: PLEXIL: }
[ INFO]: PLEXIL: Telemetry tests finished.
```
- Run the plan `ReferenceMission1.plx` for regression.  Should run normally as before.