### PR TITLE
Oceanwater 1106 minor message edits

### DIFF
--- a/ow_plexil/src/plans/CameraCapture.plp
+++ b/ow_plexil/src/plans/CameraCapture.plp
@@ -8,27 +8,5 @@
 
 CameraCapture:
 {
-  Boolean FaultDetected = false;
-
-  PostCondition !Lookup(CameraFault);
-
-  if Lookup(CameraFault)
-  {
-    log_error ("Command camera_capture not sent to ",
-               "lander due to active camera fault.");
-    FaultDetected = true;
-  }
-
-  SendCameraCapture:
-  {
-    Start !Lookup(CameraFault);
-
-    if FaultDetected
-    {
-      log_info ("Camera fault resolved, ",
-                "sending camera_capture command to lander...");
-    }
-    SynchronousCommand camera_capture ();
-  }
+  SynchronousCommand camera_capture ();
 }
-

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -115,10 +115,10 @@ static bool lookup (const string& state_name,
     value_out = OwInterface::instance()->running (operation);
   }
   else if (state_name == "StateOfCharge") {
-    value_out = OwInterface::instance()->getStateOfCharge();
+    value_out = OwInterface::instance()->getBatteryStateOfCharge();
   }
   else if (state_name == "RemainingUsefulLife") {
-    value_out = OwInterface::instance()->getRemainingUsefulLife();
+    value_out = OwInterface::instance()->getBatteryRemainingUsefulLife();
   }
   else if (state_name == "BatteryTemperature") {
     value_out = OwInterface::instance()->getBatteryTemperature();

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -8,9 +8,9 @@
 
 // OW - external
 #include <ow_lander/Light.h>
+#include <owl_msgs/BatteryRemainingUsefulLife.h>
+#include <owl_msgs/BatteryStateOfCharge.h>
 #include <owl_msgs/BatteryTemperature.h>
-#include <owl_msgs/RemainingUsefulLife.h>
-#include <owl_msgs/StateOfCharge.h>
 
 // ROS
 #include <std_msgs/Float64.h>
@@ -315,21 +315,21 @@ bool OwInterface::anglesEquivalent (double deg1, double deg2, double tolerance)
 
 ///////////////////////// Power support /////////////////////////////////////
 
-static double StateOfCharge       = NAN;
-static double RemainingUsefulLife = NAN;
-static double BatteryTemperature  = NAN;
+static double BatteryStateOfCharge       = NAN;
+static double BatteryRemainingUsefulLife = NAN;
+static double BatteryTemperature         = NAN;
 
-static void soc_callback (const owl_msgs::StateOfCharge::ConstPtr& msg)
+static void soc_callback (const owl_msgs::BatteryStateOfCharge::ConstPtr& msg)
 {
-  StateOfCharge = msg->value;
-  publish ("StateOfCharge", StateOfCharge);
+  BatteryStateOfCharge = msg->value;
+  publish ("StateOfCharge", BatteryStateOfCharge);
 }
 
-static void rul_callback (const owl_msgs::RemainingUsefulLife::ConstPtr& msg)
+static void rul_callback (const owl_msgs::BatteryRemainingUsefulLife::ConstPtr& msg)
 {
   // NOTE: This is not being called as of 4/12/21.  Jira OW-656 addresses.
-  RemainingUsefulLife = msg->value;
-  publish ("RemainingUsefulLife", RemainingUsefulLife);
+  BatteryRemainingUsefulLife = msg->value;
+  publish ("RemainingUsefulLife", BatteryRemainingUsefulLife);
 }
 
 static void temperature_callback (const owl_msgs::BatteryTemperature::ConstPtr& msg)
@@ -1181,14 +1181,14 @@ double OwInterface::getTiltVelocity () const
   return JointTelemetries[ANTENNA_TILT].velocity;
 }
 
-double OwInterface::getStateOfCharge () const
+double OwInterface::getBatteryStateOfCharge () const
 {
-  return StateOfCharge;
+  return BatteryStateOfCharge;
 }
 
-double OwInterface::getRemainingUsefulLife () const
+double OwInterface::getBatteryRemainingUsefulLife () const
 {
-  return RemainingUsefulLife;
+  return BatteryRemainingUsefulLife;
 }
 
 double OwInterface::getBatteryTemperature () const

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -135,8 +135,8 @@ class OwInterface : public PlexilInterface
   double getPanDegrees () const;
   double getPanVelocity () const;
   double getTiltVelocity () const;
-  double getStateOfCharge () const;
-  double getRemainingUsefulLife () const;
+  double getBatteryStateOfCharge () const;
+  double getBatteryRemainingUsefulLife () const;
   double getBatteryTemperature () const;
   bool   groundFound () const;
   double groundPosition () const;


### PR DESCRIPTION
This is a minor fix that addresses a missing publishing of the camera fault and a simple renaming of the battery fault messages.
The testing is mostly regression testing.

Before testing, build with respective branch on [ow_simulator](https://github.com/nasa/ow_simulator/pull/315).
---
Testing: 

- Launch the atacama sim and the ow_plexil node in separate sourced terminals.
- Test the battery faults and camera faults
- Observe that the camera fault does get set to NO_IMAGE and is exonerated both in plexil and the rostopics
- Observe that the battery faults work under the rename.