### PR TITLE
Oceanwater 1078

### DIFF
--- a/ow_plexil/src/plans/FaultHandlingPattern1.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern1.plp
@@ -8,15 +8,11 @@
 
 #include "plan-interface.h"
 
-LibraryAction InitializeAntennaAndArm ();
-
 FaultHandlingPattern1:
 {
   Real NewAngle = 0;
 
   log_info ("Starting FaultHandlingPattern1 plan...");
-
-  LibraryCall InitializeAntennaAndArm ();
 
   UncheckedSequence
   {

--- a/ow_plexil/src/plans/FaultHandlingPattern1.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern1.plp
@@ -16,33 +16,26 @@ FaultHandlingPattern1:
 
   log_info ("Starting FaultHandlingPattern1 plan...");
 
-  // Temporarily commented out to make testing shorter
-  //LibraryCall InitializeAntennaAndArm ();
+  LibraryCall InitializeAntennaAndArm ();
 
   UncheckedSequence
   {
-    RepeatCondition true;
-    Wait .2;
-    log_info ("Currently in Top Level Unchecked Sequence");
+    Repeat true;
 
-    Pattern1Image:
+    Wait .2;
+
+    Pattern1PanAntenna:
     {
       Start !Lookup(AntennaPanFault);
-
-      // Exit Condition option (Correct behavior)
-      // ExitCondition Lookup(AntennaPanFault);
-
-      // Invariant Condition (Causes freezing)
-      InvariantCondition !Lookup(AntennaPanFault);
+      Exit Lookup(AntennaPanFault);
 
       NewAngle = (Lookup(PanDegrees) + 15) mod 360;
-      log_info ("Currently in Child Level Pattern1Image");
 
       if NewAngle > 180{
         NewAngle = NewAngle - 360;
       }
 
-      LibraryCall PanTiltMoveJoints (PanDegrees=NewAngle, TiltDegrees=0);
+      LibraryCall Pan (Degrees=NewAngle);
     }
   }
 }

--- a/ow_plexil/src/plans/FaultHandlingPattern1.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern1.plp
@@ -2,8 +2,8 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Pan in 15 degree increments as long as no antenna fault is present.  If an
-// antenna fault is occurs, pause until the fault is removed.  This plan must be
+// Pan in 15 degree increments as long as no antenna pan fault is present.  If an
+// antenna pan fault occurs, pause until the fault is removed.  This plan must be
 // terminated with an interrupt (e.g. Control-C).
 
 #include "plan-interface.h"
@@ -18,14 +18,22 @@ FaultHandlingPattern1:
 
   LibraryCall InitializeAntennaAndArm ();
 
-  Pattern1Image:
+  UncheckedSequence
   {
-    Repeat true;
-    Start !Lookup(AntennaFault);
+    RepeatCondition true;
+    Wait .2;
+    Pattern1Image:
+    {
+      Start !Lookup(AntennaFault);
+      ExitCondition Lookup(AntennaFault);
+      NewAngle = (Lookup(PanDegrees) + 15) mod 360;
 
-    NewAngle = (Lookup(PanDegrees) + 15) mod 360;
+      if NewAngle > 180{
+        NewAngle = NewAngle - 360;
+      }
 
-    LibraryCall PanTiltMoveJoints (PanDegrees=NewAngle, TiltDegrees=0);
+      LibraryCall PanTiltMoveJoints (PanDegrees=NewAngle, TiltDegrees=0);
+    }
   }
 }
 

--- a/ow_plexil/src/plans/FaultHandlingPattern1.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern1.plp
@@ -16,17 +16,27 @@ FaultHandlingPattern1:
 
   log_info ("Starting FaultHandlingPattern1 plan...");
 
-  LibraryCall InitializeAntennaAndArm ();
+  // Temporarily commented out to make testing shorter
+  //LibraryCall InitializeAntennaAndArm ();
 
   UncheckedSequence
   {
     RepeatCondition true;
     Wait .2;
+    log_info ("Currently in Top Level Unchecked Sequence");
+
     Pattern1Image:
     {
-      Start !Lookup(AntennaFault);
-      ExitCondition Lookup(AntennaFault);
+      Start !Lookup(AntennaPanFault);
+
+      // Exit Condition option (Correct behavior)
+      // ExitCondition Lookup(AntennaPanFault);
+
+      // Invariant Condition (Causes freezing)
+      InvariantCondition !Lookup(AntennaPanFault);
+
       NewAngle = (Lookup(PanDegrees) + 15) mod 360;
+      log_info ("Currently in Child Level Pattern1Image");
 
       if NewAngle > 180{
         NewAngle = NewAngle - 360;

--- a/ow_plexil/src/plans/FaultHandlingPattern2.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern2.plp
@@ -25,15 +25,26 @@ FaultHandlingPattern2:
   Run: Concurrence
   {
 
-    Pattern2Image:
+  UncheckedSequence
+  {
+    RepeatCondition true;
+
+    Wait .2;
+
+    Pattern2PanAntenna:
     {
-      Repeat true;
-      Start !Lookup(AntennaFault);
+      Start !Lookup(AntennaPanFault);
+      Exit Lookup(AntennaPanFault);
 
       NewAngle = (Lookup(PanDegrees) + 15) mod 360;
 
-      LibraryCall PanTiltMoveJoints (PanDegrees=NewAngle, TiltDegrees=0);
+      if NewAngle > 180{
+        NewAngle = NewAngle - 360;
+      }
+
+      LibraryCall Pan (Degrees=NewAngle);
     }
+  }
 
     Pattern2UnstowStow:
     {

--- a/ow_plexil/src/plans/FaultHandlingPattern2.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern2.plp
@@ -12,15 +12,11 @@
 
 #include "plan-interface.h"
 
-LibraryAction InitializeAntennaAndArm ();
-
 FaultHandlingPattern2:
 {
   Real NewAngle = 0;
 
   log_info ("Starting FaultHandlingPattern2 plan...");
-
-  LibraryCall InitializeAntennaAndArm ();
 
   Run: Concurrence
   {
@@ -52,8 +48,7 @@ FaultHandlingPattern2:
       Start !Lookup(ArmFault);
       Invariant !Lookup(ArmFault);
 
-      LibraryCall ArmUnstow();
-      LibraryCall ArmStow();
+      LibraryCall StowSequence();
     }
   }
 }

--- a/ow_plexil/src/plans/FaultHandlingPattern3.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern3.plp
@@ -2,35 +2,29 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// If no faults are occurring, this plan will pan 180 degrees,
-// and then unstow and stow the arm.
+// WARNING: This plan cannot work as intended until greater fault/action support
+// is added to the simulator. This serves mostly as a syntactic example.
 
-// Only the AntennaPan action will hault for resolution,
-// if an arm fault is triggered for Unstow, it will also prevent Stow from running. 
+// DESIRED BEHAVIOR: If no faults are present, this plan will pan 180 degrees,
+// unstow and then stow the arm. If a fault is injected, the plan will pause 
+// until resolution.
 
-// Upon resolution, the antenna will continue to pan, but halted arm actions
-// will not complete before moving to the next node.
+// LIMITATIONS: If an arm fault is triggered during Unstow, it will skip the Stow node. 
 
-// If a fault is injected during an operation, that operation will only
+// NOTE: If a fault is injected during an operation, that operation will only
 // halt immediately if the fault injected is associated with it directly,
 // i.e. an antenna fault during panning or an arm fault during
 // unstowing or stowing.
 
-// Otherwise, the pausing will visually become apparent when the next
-// operation does not begin due to it.
 
 #include "plan-interface.h"
-
-LibraryAction InitializeAntennaAndArm ();
 
 FaultHandlingPattern3:
 {
 
   log_info ("Starting FaultHandlingPattern3 plan...");
 
-  LibraryCall InitializeAntennaAndArm ();
-
-  Image:
+  PanAntenna:
   {
     Start !Lookup(AntennaPanFault);
     Invariant !Lookup(AntennaPanFault);

--- a/ow_plexil/src/plans/FaultHandlingPattern3.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern3.plp
@@ -5,11 +5,11 @@
 // If no faults are occurring, this plan will pan 180 degrees,
 // and then unstow and stow the arm.
 
-// If any fault is injected, the plan will pause and wait for resolution.
-// Resolution is defined as the removal of the fault.
+// Only the AntennaPan action will hault for resolution,
+// if an arm fault is triggered for Unstow, it will also prevent Stow from running. 
 
-// Upon resolution, the halted action will not complete,
-// but the plan will continue to the next node.
+// Upon resolution, the antenna will continue to pan, but halted arm actions
+// will not complete before moving to the next node.
 
 // If a fault is injected during an operation, that operation will only
 // halt immediately if the fault injected is associated with it directly,
@@ -32,9 +32,10 @@ FaultHandlingPattern3:
 
   Image:
   {
-    Start !Lookup(AntennaFault);
+    Start !Lookup(AntennaPanFault);
+    Invariant !Lookup(AntennaPanFault);
 
-    LibraryCall PanTiltMoveJoints (PanDegrees=180, TiltDegrees=0);
+    LibraryCall Pan (Degrees=180);
   }
 
   Unstow:

--- a/ow_plexil/src/plans/FaultHandlingPattern4.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern4.plp
@@ -2,39 +2,25 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Pattern summary: Execute a sequence of actions. If a fault is injected
-// during a related action, the action will stop and end in the ABORTED state.
-// If/when the fault is cleared, the action will automatically be 
-// attempted again.
+// WARNING: This plan cannot work as intended until greater fault/action support
+// is added to the simulator. This serves mostly as a syntactic example.
 
-// WARNING: As of 6/30/23 the Stow action will not be attempted again
+// DESIRED BEHAVIOR: If no faults are present, this plan will pan 180 degrees,
+// unstow and then stow the arm. If a fault is injected, the plan will pause 
+// until resolution, and then attempt the interrupted action again.
+
+// LIMITATIONS: the Stow action will not be attempted again
 // after a fault, this is due to limitations in goal fault support that will be 
 // added in a later release. The Unstow Action will also sometimes not repeat depending
-// on when the fault is triggered
+// on when the fault is triggered. When injecting a fault during an arm operation,
+// you should wait until you see the action aborted message before clearing the fault.
 
-// More specifically: If no faults are occurring, this plan will pan 180 
-// degrees, and then unstow and stow the arm.
-
-// If any fault is injected, the plan will pause and wait for resolution.
-
-// If a fault is injected during an operation, that operation will only
+// NOTE: If a fault is injected during an operation, that operation will only
 // halt immediately if the fault injected is associated with it directly,
-// i.e. an antenna fault during panning or an arm fault during 
+// i.e. an antenna fault during panning or an arm fault during
 // unstowing or stowing.
 
-// NOTE that as of September 8th, 2021, only the ant_pan_effort_failure
-// will halt the panning action in this plan.
-
-// IMPORTANT NOTE: When injecting a fault during an arm operation,
-// you should wait until you see the action aborted, 
-// e.g. "Stow finished in state ABORTED" before clearing the fault.
-// Otherwise the action will show as completed, even though it halted
-// before completing the task. This is due to some bugs in the simulator,
-// and the fact that ROS action states are not exposed to PLEXIL.
-
 #include "plan-interface.h"
-
-LibraryAction InitializeAntennaAndArm ();
 
 LibraryAction MissionSequence (InOut Boolean mission_in_progress,
                                InOut Boolean pan_done,
@@ -49,8 +35,6 @@ FaultHandlingPattern4:
   Boolean StowDone = false;
 
   log_info ("Starting FaultHandlingPattern4 plan...");
-
-  LibraryCall InitializeAntennaAndArm ();
 
   RunMission: Concurrence
   {

--- a/ow_plexil/src/plans/FaultHandlingPattern4.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern4.plp
@@ -7,9 +7,10 @@
 // If/when the fault is cleared, the action will automatically be 
 // attempted again.
 
-// WARNING: As of 6/30/23 the Stow and Unstow actions will not be attempted again
+// WARNING: As of 6/30/23 the Stow action will not be attempted again
 // after a fault, this is due to limitations in goal fault support that will be 
-// added in a later release. 
+// added in a later release. The Unstow Action will also sometimes not repeat depending
+// on when the fault is triggered
 
 // More specifically: If no faults are occurring, this plan will pan 180 
 // degrees, and then unstow and stow the arm.

--- a/ow_plexil/src/plans/FaultHandlingPattern4.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern4.plp
@@ -7,6 +7,10 @@
 // If/when the fault is cleared, the action will automatically be 
 // attempted again.
 
+// WARNING: As of 6/30/23 the Stow and Unstow actions will not be attempted again
+// after a fault, this is due to limitations in goal fault support that will be 
+// added in a later release. 
+
 // More specifically: If no faults are occurring, this plan will pan 180 
 // degrees, and then unstow and stow the arm.
 

--- a/ow_plexil/src/plans/FaultHandlingPattern5.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern5.plp
@@ -7,6 +7,10 @@
 // As long as the action is stopped, a backup action will repeat. If/when the
 // fault is cleared, the original action will automatically be attempted again.
 
+// WARNING: As of 6/30/23 the Stow and Unstow actions will not be attempted again
+// after a fault, this is due to limitations in goal fault support that will be 
+// added in a later release. 
+
 // More specifically: If no faults are occurring, this plan will pan 180
 // degrees, and then unstow and stow the arm.
 
@@ -83,12 +87,16 @@ FaultHandlingPattern5:
       Real NewAngle;
 
       Repeat MissionInProgress;
-      Start MissionInProgress && Lookup(ArmFault) && PanDone;
+      Start MissionInProgress && Lookup(ArmFault) && PanDone && !Lookup(AntennaPanFault);
       Skip !MissionInProgress;
 
       NewAngle = (Lookup(PanDegrees) + 15) mod 360;
 
-      LibraryCall PanTiltMoveJoints (PanDegrees=NewAngle, TiltDegrees=0);
+      if NewAngle > 180{
+        NewAngle = NewAngle - 360;
+      }
+
+      LibraryCall Pan (Degrees=NewAngle);
 
     }
 

--- a/ow_plexil/src/plans/FaultHandlingPattern5.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern5.plp
@@ -7,9 +7,10 @@
 // As long as the action is stopped, a backup action will repeat. If/when the
 // fault is cleared, the original action will automatically be attempted again.
 
-// WARNING: As of 6/30/23 the Stow and Unstow actions will not be attempted again
+// WARNING: As of 6/30/23 the Stow action will not be attempted again
 // after a fault, this is due to limitations in goal fault support that will be 
-// added in a later release. 
+// added in a later release. The Unstow Action will also sometimes not repeat depending
+// on when the fault is triggered
 
 // More specifically: If no faults are occurring, this plan will pan 180
 // degrees, and then unstow and stow the arm.

--- a/ow_plexil/src/plans/FaultHandlingPattern5.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern5.plp
@@ -2,41 +2,26 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Pattern summary: Execute a sequence of actions. If a fault is injected
-// during a related action, the action will stop and end in the ABORTED state.
-// As long as the action is stopped, a backup action will repeat. If/when the
-// fault is cleared, the original action will automatically be attempted again.
+// WARNING: This plan cannot work as intended until greater fault/action support
+// is added to the simulator. This serves mostly as a syntactic example.
 
-// WARNING: As of 6/30/23 the Stow action will not be attempted again
+// DESIRED BEHAVIOR: If no faults are present, this plan will pan 180 degrees,
+// unstow and then stow the arm. If a fault is injectected during stow or unstow,
+// a backup panning action will run until the fault is cleared. It will then attempt 
+// the interrupted action again.
+
+// LIMITATIONS: the Stow action will not be attempted again
 // after a fault, this is due to limitations in goal fault support that will be 
 // added in a later release. The Unstow Action will also sometimes not repeat depending
-// on when the fault is triggered
+// on when the fault is triggered. When injecting a fault during an arm operation,
+// you should wait until you see the action aborted message before clearing the fault.
 
-// More specifically: If no faults are occurring, this plan will pan 180
-// degrees, and then unstow and stow the arm.
-
-// If a relevant fault is injected, the plan will stop the current action
-// and start repeating a panning action as backup to the original action.
-
-// If a fault is injected during an operation, that operation will only
+// NOTE: If a fault is injected during an operation, that operation will only
 // halt immediately if the fault injected is associated with it directly,
 // i.e. an antenna fault during panning or an arm fault during
 // unstowing or stowing.
 
-// NOTE that as of September 8th, 2021, only the ant_pan_effort_failure
-// will halt the panning action in this plan.
-
-// IMPORTANT NOTE: When injecting a fault during an arm operation,
-// you should wait until you see the action aborted,
-// e.g. "Stow finished in state ABORTED" before clearing the fault.
-// Otherwise the action will show as completed, even though it halted
-// before completing the task. This is due to some bugs in the simulator,
-// and the fact that ROS action states are not exposed to PLEXIL.
-
-
 #include "plan-interface.h"
-
-LibraryAction InitializeAntennaAndArm ();
 
 LibraryAction MissionSequence (InOut Boolean mission_in_progress,
                                InOut Boolean pan_done,
@@ -53,8 +38,6 @@ FaultHandlingPattern5:
   Boolean StowDone = false;
 
   log_info ("Starting FaultHandlingPattern5 plan...");
-
-  LibraryCall InitializeAntennaAndArm ();
 
   RunMission: Concurrence
   {

--- a/ow_plexil/src/plans/FaultHandlingPattern6.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern6.plp
@@ -8,9 +8,10 @@
 // the battery level is sufficient. If/when the fault is cleared, the original
 // action will automatically be attempted again.
 
-// WARNING: As of 6/30/23 the Stow and Unstow actions will not be attempted again
+// WARNING: As of 6/30/23 the Stow action will not be attempted again
 // after a fault, this is due to limitations in goal fault support that will be 
-// added in a later release. 
+// added in a later release. The Unstow Action will also sometimes not repeat depending
+// on when the fault is triggered
 
 // More specifically: If no faults are occurring, this plan will pan 180
 // degrees, and then unstow and stow the arm.

--- a/ow_plexil/src/plans/FaultHandlingPattern6.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern6.plp
@@ -8,6 +8,10 @@
 // the battery level is sufficient. If/when the fault is cleared, the original
 // action will automatically be attempted again.
 
+// WARNING: As of 6/30/23 the Stow and Unstow actions will not be attempted again
+// after a fault, this is due to limitations in goal fault support that will be 
+// added in a later release. 
+
 // More specifically: If no faults are occurring, this plan will pan 180
 // degrees, and then unstow and stow the arm.
 
@@ -156,7 +160,11 @@ FaultHandlingPattern6:
 
       NewAngle = (Lookup(PanDegrees) + 15) mod 360;
 
-      LibraryCall PanTiltMoveJoints (PanDegrees=NewAngle, TiltDegrees=0);
+      if NewAngle > 180{
+        NewAngle = NewAngle - 360;
+      }
+
+      LibraryCall Pan (Degrees=NewAngle);
     }
 
     LibraryCall MissionSequence2 (mission_in_progress=MissionInProgress,

--- a/ow_plexil/src/plans/FaultHandlingPattern6.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern6.plp
@@ -2,48 +2,26 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Pattern summary: Execute a sequence of actions. If a fault is injected
-// during a related action, the action will stop and end in the ABORTED state.
-// As long as the action is stopped, a backup action will repeat but only if
-// the battery level is sufficient. If/when the fault is cleared, the original
-// action will automatically be attempted again.
+// WARNING: This plan cannot work as intended until greater fault/action support
+// is added to the simulator. This serves mostly as a syntactic example.
 
-// WARNING: As of 6/30/23 the Stow action will not be attempted again
+// DESIRED BEHAVIOR: If no faults are present, this plan will pan 180 degrees,
+// unstow and then stow the arm. If a fault is injectected during stow or unstow,
+// a backup panning action will run until the fault is cleared, if the battery level
+// is sufficient. It will then attempt the interrupted action again.
+
+// LIMITATIONS: the Stow action will not be attempted again
 // after a fault, this is due to limitations in goal fault support that will be 
 // added in a later release. The Unstow Action will also sometimes not repeat depending
-// on when the fault is triggered
+// on when the fault is triggered. When injecting a fault during an arm operation,
+// you should wait until you see the action aborted message before clearing the fault.
 
-// More specifically: If no faults are occurring, this plan will pan 180
-// degrees, and then unstow and stow the arm.
-
-// If a power fault is injected, any action occurring will stop and
-// end in the ABORTED state. If the power fault is resolved, they will
-// automatically restart.
-
-// If a relevant fault is injected, the plan will stop the current action.
-
-// If there is sufficient battery power, the plan will start repeating a
-// panning action as backup to the original action.
-
-// If a fault is injected during an operation, that operation will only
+// NOTE: If a fault is injected during an operation, that operation will only
 // halt immediately if the fault injected is associated with it directly,
 // i.e. an antenna fault during panning or an arm fault during
 // unstowing or stowing.
 
-// NOTE that as of September 8th, 2021, only the ant_pan_effort_failure
-// will halt the panning action in this plan.
-
-// IMPORTANT NOTE: When injecting a fault during an arm operation,
-// you should wait until you see the action aborted,
-// e.g. "Stow finished in state ABORTED" before clearing the fault.
-// Otherwise the action will show as completed, even though it halted
-// before completing the task. This is due to some bugs in the simulator,
-// and the fact that ROS action states are not exposed to PLEXIL.
-
-
 #include "plan-interface.h"
-
-LibraryAction InitializeAntennaAndArm ();
 
 LibraryAction MonitorPower (In Boolean continue,
                             InOut Boolean battery_temp_ok,
@@ -71,8 +49,6 @@ FaultHandlingPattern6:
   Boolean StowDone = false;
 
   log_info ("Starting FaultHandlingPattern6 plan...");
-
-  LibraryCall InitializeAntennaAndArm ();
 
   RunMission: Concurrence
   {

--- a/ow_plexil/src/plans/MissionSequence.plp
+++ b/ow_plexil/src/plans/MissionSequence.plp
@@ -38,7 +38,7 @@ MissionSequence:
 
     LibraryCall Pan (Degrees=180);
 
-    if 180 - (abs(Lookup(PanDegrees)) % 180) < PanToleranceDegrees
+    if 180 - (min(180, abs(Lookup(PanDegrees)) % 180)) < PanToleranceDegrees
     {
       pan_done = true;
     }

--- a/ow_plexil/src/plans/MissionSequence.plp
+++ b/ow_plexil/src/plans/MissionSequence.plp
@@ -36,9 +36,9 @@ MissionSequence:
     Start !Lookup(AntennaFault);
     Skip pan_done;
 
-    LibraryCall PanTiltMoveJoints (PanDegrees=180, TiltDegrees=0);
+    LibraryCall Pan (Degrees=180);
 
-    if abs(180 - abs(Lookup(PanDegrees))) < PanToleranceDegrees
+    if 180 - (abs(Lookup(PanDegrees)) % 180) < PanToleranceDegrees
     {
       pan_done = true;
     }

--- a/ow_plexil/src/plans/MissionSequence2.plp
+++ b/ow_plexil/src/plans/MissionSequence2.plp
@@ -37,9 +37,9 @@ MissionSequence2:
     Start !Lookup(AntennaFault) && !Lookup(PowerFault);
     Skip pan_done;
 
-    LibraryCall PanTiltMoveJoints (PanDegrees=180, TiltDegrees=0);
+    LibraryCall Pan (Degrees=180);
 
-    if abs(180 - abs(Lookup(PanDegrees))) < PanToleranceDegrees
+    if 180 - (abs(Lookup(PanDegrees)) % 180) < PanToleranceDegrees
     {
       pan_done = true;
     }

--- a/ow_plexil/src/plans/MissionSequence2.plp
+++ b/ow_plexil/src/plans/MissionSequence2.plp
@@ -39,7 +39,7 @@ MissionSequence2:
 
     LibraryCall Pan (Degrees=180);
 
-    if 180 - (abs(Lookup(PanDegrees)) % 180) < PanToleranceDegrees
+    if 180 - (min(180, abs(Lookup(PanDegrees)) % 180)) < PanToleranceDegrees
     {
       pan_done = true;
     }

--- a/ow_plexil/src/plans/Pan.plp
+++ b/ow_plexil/src/plans/Pan.plp
@@ -12,9 +12,9 @@ Pan:
 
   Boolean FaultDetected = false;
 
-  PostCondition !Lookup(AntennaFault);
+  PostCondition !Lookup(AntennaPanFault);
 
-  if Lookup(AntennaFault)
+  if Lookup(AntennaPanFault)
   {
     log_error ("Command pan not sent to lander due to active antenna fault(s).");
     FaultDetected = true;
@@ -22,7 +22,7 @@ Pan:
 
   SendPan:
   {
-    Start !Lookup(AntennaFault);
+    Start !Lookup(AntennaPanFault);
 
     if FaultDetected
     {

--- a/ow_plexil/src/plans/Tilt.plp
+++ b/ow_plexil/src/plans/Tilt.plp
@@ -12,9 +12,9 @@ Tilt:
 
   Boolean FaultDetected = false;
 
-  PostCondition !Lookup(AntennaFault);
+  PostCondition !Lookup(AntennaTiltFault);
 
-  if Lookup(AntennaFault)
+  if Lookup(AntennaTiltFault)
   {
     log_error ("Command tilt not sent to lander due to active antenna fault(s).");
     FaultDetected = true;
@@ -22,7 +22,7 @@ Tilt:
 
   SendTilt:
   {
-    Start !Lookup(AntennaFault);
+    Start !Lookup(AntennaTiltFault);
 
     if FaultDetected
     {


### PR DESCRIPTION
## Summary
Testing and fixes for fault handling pattern plans 1-6.

- Fixed Panning code in plans 1-6 to not error out with new antenna limits.
- Fixed logic in plans 1 and 2 to allow for repeating actions after a fault occurs during or before execution.
- Changed PanTiltMoveJoints() -> Pan() in plans 1-6 for simplicity and better fault checking.
- Changed Pan.plp and Tilt.plp to use their specific fault lookup instead of the general AntennaFault lookup.
- Updated documentation on all plans to better describe the current behaviors. Particularly plans 4-6. 

## Notes on Code
All plans now run to completion, however only plans 1 and 2 work completely as intended. Plans 3-6 were created when PLEXIL did not have access to as much fault introspection, and some workarounds were needed. They do not always demonstrate the desired behavior which I noted in the comments above each file. 

The plans themselves are very useful examples. Once more fault work has been done (health monitor, goal faults, etc) I would like to revisit and update them.

I think there are two options for merging the FaultPatterns into  release 11-1: 
1. Merge all fault handling patterns, with my additional warnings/notes to serve as example plans. 
2. Only merge plans 1 and 2, and merge plans 3-6 at a later date once they are updated with the new proposed fault tools. 

I will also create a JIRA ticket to update plans 3-6. 

## Build
1. ow_simulator should be on master branch, as this change will be merged into release 11-1
3. ```catkin clean```
4. ```catkin build```

## Test
For all plans: 
1. ``` roslaunch ow europa_terminator_workspace.launch ```
2. ``` roslaunch ow_plexil ow_exec.launch plan:="FaultHandlingPattern1.plx" ``` (Or you can use the GUI, replacing 1 with 
whatever plan you would like to run)
3. Use the Dynamic reconfigure GUI to insert ant_pan_joint_locked_failure, and any arm faults. For FaultPattern6, you can trigger a low batter fault by setting power draw to its highest value, and triggering the backup action until it triggers.

### FaultPattern1: 
**Original Desired Behavior**: Pan in 15 degree increments as long as no antenna pan fault is present.  If an antenna pan fault occurs, pause until the fault is removed.  This plan must be terminated with an interrupt (e.g. Control-C).
**Actual Behavior:** Works correctly. 

### FaultPattern2: 
**Original Desired Behavior**: Panning and arm unstowing/stowing as long as no relevant fault is present. An arm fault will not prevent the arm from moving and vice versa. 
**Actual Behavior:** Works correctly. 

### FaultPattern3: 
**Original Desired Behavior:** Pan to 180 degrees, unstow arm, and then stow. If a relevant fault is present the action will be paused and then skipped once the fault is resolved. 

**Actual Behavior:** Pan will always complete its action (this is due to how the action is set up). If an arm fault occurs during stow or unstow the plan will end. 

### FaultPattern4: 
**Original Desired Behavior:** Pan to 180 degrees, unstow arm, and then stow. If a relevant fault is detected, pause that action and then resume once the fault is cleared. 

**Actual Behavior:** Unstow will not always resume after a fault is cleared. If arm fault occurs during stow the plan will end. 

### FaultPattern5: 
**Original Desired Behavior:** Pan to 180 degrees, unstow arm, and then stow. If a relevant fault is detected, pause that action and start a backup pan action (unless the fault is an antenna fault) until the fault is cleared, where it will then resume the original action.

**Actual Behavior:** Unstow will not always resume after a fault is cleared. If arm fault occurs during stow the plan will end. 

### FaultPattern6: 
**Original Desired Behavior:** Pan to 180 degrees, unstow arm, and then stow. If a relevant fault is detected, pause that action and start a backup pan action (unless the fault is an antenna fault) until the fault is cleared, where it will then resume the original action. This also has additional checks for battery life faults which work as intended.

**Actual Behavior:** Unstow will not always resume after a fault is cleared. If arm fault occurs during stow the plan will end.

Thanks!
