### PR TITLE
Dig force aware procedures

### DIFF
--- a/ow_plexil/src/plans/Demo.plp
+++ b/ow_plexil/src/plans/Demo.plp
@@ -24,7 +24,7 @@ Demo:
   if (Lookup(GroundFound)) {
     log_info ("A grind...");
     LibraryCall TaskGrind (X = 2.0, Y = 0, Depth = 0.05,
-                           Length = 0.3, Parallel = true,
+                           Length = 0.5, Parallel = true,
                            GroundPos = Lookup(GroundPosition));
     log_info ("A circular dig...");
     LibraryCall TaskScoopCircular (Frame = 0, Relative = false,

--- a/ow_plexil/src/plans/Demo.plp
+++ b/ow_plexil/src/plans/Demo.plp
@@ -23,7 +23,7 @@ Demo:
                            SearchDistance = 0.5);
   if (Lookup(GroundFound)) {
     log_info ("A grind...");
-    LibraryCall TaskGrind (X = 2.0, Y = 0, Depth = 0.05,
+    LibraryCall TaskGrind (X = 2.0, Y = 0, Depth = 0.025,
                            Length = 0.5, Parallel = true,
                            GroundPos = Lookup(GroundPosition));
     log_info ("A circular dig...");

--- a/ow_plexil/src/plans/EuropaMission.plp
+++ b/ow_plexil/src/plans/EuropaMission.plp
@@ -185,7 +185,7 @@ EuropaMission: Concurrence
                                  Y = trench_y,
                                  GroundPos = ground_pos,
                                  Length = trench_length,
-                                 BiteDepth = 0.05,
+                                 BiteDepth = 0.03,
                                  NumPasses = 2,
                                  Parallel = parallel);
         }

--- a/ow_plexil/src/plans/ReferenceMission1.plp
+++ b/ow_plexil/src/plans/ReferenceMission1.plp
@@ -88,7 +88,7 @@ ReferenceMission1: Concurrence
                              Y = trench_y,
                              GroundPos = ground_pos,
                              Length = trench_length,
-                             BiteDepth = 0.05,
+                             BiteDepth = 0.03,
                              NumPasses = 2,
                              Parallel = parallel);
       LibraryCall RemoveTailings (X = trench_x,

--- a/ow_plexil/src/plans/ReferenceMission2.plp
+++ b/ow_plexil/src/plans/ReferenceMission2.plp
@@ -132,7 +132,7 @@ ReferenceMission2: Concurrence
                                Y = trench_y,
                                GroundPos = ground_pos,
                                Length = trench_length,
-                               BiteDepth = 0.05,
+                               BiteDepth = 0.03,
                                NumPasses = 2,
                                Parallel = parallel);
       }

--- a/ow_plexil/src/plans/TestActions.plp
+++ b/ow_plexil/src/plans/TestActions.plp
@@ -80,13 +80,13 @@ TestActions: UncheckedSequence
   LibraryCall TaskDiscardSample (Frame = BASE_FRAME, Relative = false,
                                  Point = #(1.5 0.8 0.65), Height = 0.1);
 
-  LibraryCall TaskGrind (X = 1.6, Y = 0.02, Depth = 0.05,
+  LibraryCall TaskGrind (X = 1.8, Y = 0.02, Depth = 0.05,
                          Length = 0.6, Parallel = true,
                          GroundPos = GP);
 
-  LibraryCall TaskScoopLinear (Frame = BASE_FRAME, Relative = false,
-                               X = 1.5, Y = 0.02, Z = GP,
-                               Depth = 0.05, Length = 0.1);
+  LibraryCall TaskScoopLinear (Frame = 0, Relative = false,
+                               X = 1.8, Y = 0.02, Z = GP,
+                               Depth = 0.05, Length = 0.4);
 
   LibraryCall TaskDeliverSample ();
   LibraryCall DockIngestSample ();

--- a/ow_plexil/src/plans/TestActions.plp
+++ b/ow_plexil/src/plans/TestActions.plp
@@ -52,7 +52,7 @@ TestActions: UncheckedSequence
 
   LibraryCall ArmMoveCartesian_Q (Frame = BASE_FRAME,
                                   Relative = true,
-                                  Position = #(0 0 -0.2),
+                                  Position = #(0 0 0.2),
                                   Orientation = #(0 0 0 1));
 
   LibraryCall CameraSetExposure (Seconds = 1);
@@ -64,7 +64,7 @@ TestActions: UncheckedSequence
 
   LibraryCall ArmMoveCartesian_Q (Frame = BASE_FRAME,
                                   Relative = true,
-                                  Position = #(0 0 -0.2),
+                                  Position = #(0 0 0.2),
                                   Orientation = #(0 0 0 1));
 
   LibraryCall LightSetIntensity (Side = "right", Intensity = 1.0);
@@ -75,7 +75,7 @@ TestActions: UncheckedSequence
 
   LibraryCall TaskScoopCircular (Frame = BASE_FRAME, Relative = false,
                                  X = 1.75, Y = 0.1, Z = GP,
-                                 Depth = 0.045, Parallel = false);
+                                 Depth = 0.07, Parallel = false);
 
   LibraryCall TaskDiscardSample (Frame = BASE_FRAME, Relative = false,
                                  Point = #(1.5 0.8 0.65), Height = 0.1);


### PR DESCRIPTION
## Sibling PR
[ow_simulator #364](https://github.com/nasa/ow_simulator/pull/364)

## Purpose
With the Balovnev model producing a realistic dig force we can no longer dig as deep as we like. Additionally, the new dig force trajectories may have broken some Plexil plans. This branch ensures all current Plexil plans still work with the new dig model epic branch in ow_simulator. 

## Changes
* Updated the following plans to work well with new dig force model:
  * TestActions.plp 
  * Demo.plp
  * ReferenceMission1.plp
  * ReferenceMission2.plp

## Testing
Run each of the modified plans, and ensure they work. Optionally you can run each of the plans with ow_simulator on the branch from [ow_simulator #365](https://github.com/nasa/ow_simulator/pull/365)

