### PR TITLE
Lookup handler fix and refactor

### DIFF
--- a/ow_plexil/src/plexil-adapter/LanderAdapter.h
+++ b/ow_plexil/src/plexil-adapter/LanderAdapter.h
@@ -23,7 +23,7 @@ class LanderAdapter : public PlexilAdapter
   static bool checkAngle (const char* name, double val, double min, double max,
                           double tolerance);
 
-  // Pointer to concrete instance (OwAdapter or OwlatAdapter)
+  // Pointer to concrete instance (OwInterface or OwlatInterface)
   static LanderInterface* s_interface;
 
   static float PanMinDegrees;

--- a/ow_plexil/src/plexil-adapter/LanderAdapter.h
+++ b/ow_plexil/src/plexil-adapter/LanderAdapter.h
@@ -13,6 +13,7 @@
 
 // PLEXIL
 #include <LookupReceiver.hh>
+#include <State.hh>
 
 class LanderInterface;
 
@@ -40,12 +41,44 @@ class LanderAdapter : public PlexilAdapter
 
  protected:
   template<typename T>
-  auto lookupHandler (const T& val)
+  auto lookupHandler_constant (const T& val)
   {
     return [=] (const PLEXIL::State&, PLEXIL::LookupReceiver* r) {
              r->update(PLEXIL::Value(val));
            };
   }
+
+  template<typename T, typename Class, typename Base>
+  auto lookupHandler_function0 (const Class& instance,
+                                T(Base::*method)() const)
+  {
+    return [&instance, method] (const PLEXIL::State&,
+                                PLEXIL::LookupReceiver* r) {
+             r->update(PLEXIL::Value((instance.*method)()));
+           };
+  }
+
+  template<typename T, typename Class, typename Base>
+  auto lookupHandler_function1 (const Class& instance,
+                                T(Base::*method)(const std::string&) const)
+  {
+    return [&instance, method] (const PLEXIL::State& s,
+                                PLEXIL::LookupReceiver* r) {
+             std::string arg;
+             s.parameters()[0].getValue(arg);
+             r->update(PLEXIL::Value((instance.*method)(arg)));
+           };
+  }
+
+  /* For future reference: an attempt using std::bind() that doesn't build:
+  template <typename T, typename Callable>
+  auto lookupHandler_callable (Callable c)
+  {
+    return [&] (const PLEXIL::State&, PLEXIL::LookupReceiver* r) {
+             r->update(PLEXIL::Value(c()));
+           };
+  }
+  */
 };
 
 #endif

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -961,7 +961,7 @@ vector<double> OwInterface::getEndEffectorFT () const
   return m_end_effector_ft;
 }
 
-vector<string> OwInterface::getActiveFaults (string subsystem_name) const
+vector<string> OwInterface::getActiveFaults (const string& subsystem_name) const
 {
   if (m_fault_dependencies_on){
     return m_fault_dependencies->getActiveFaults(subsystem_name);
@@ -975,7 +975,7 @@ vector<string> OwInterface::getActiveFaults (string subsystem_name) const
   }
 }
 
-bool OwInterface::isOperable (string subsystem_name) const
+bool OwInterface::isOperable (const string& subsystem_name) const
 {
   if (m_fault_dependencies_on){
     return m_fault_dependencies->checkIsOperable(subsystem_name);
@@ -988,7 +988,7 @@ bool OwInterface::isOperable (string subsystem_name) const
   }
 }
 
-bool OwInterface::isFaulty (string subsystem_name) const
+bool OwInterface::isFaulty (const string& subsystem_name) const
 {
   if (m_fault_dependencies_on){
     return m_fault_dependencies->checkIsFaulty(subsystem_name);

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -325,6 +325,12 @@ void OwInterface::initialize()
       subscribe("/arm_end_effector_force_torque", QueueSize,
                 &OwInterface::ftCallback, this)));
 
+  m_subscribers.push_back
+    (make_unique<ros::Subscriber>
+     (m_genericNodeHandle ->
+      subscribe("/joint_states", QueueSize,
+                &OwInterface::jointStatesCallback, this)));
+
   connectActionServer (m_armFindSurfaceClient, Name_ArmFindSurface,
                        "/ArmFindSurface/status");
   connectActionServer (m_armMoveJointsClient, Name_ArmMoveJoints,

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -134,9 +134,9 @@ class OwInterface : public LanderInterface
   bool   hardTorqueLimitReached (const std::string& joint_name) const;
   bool   softTorqueLimitReached (const std::string& joint_name) const;
   bool   systemFault () const override;
-  std::vector<std::string>   getActiveFaults (std::string subsystem_name) const;
-  bool   isOperable (std::string subsystem_name) const;
-  bool   isFaulty (std::string subsystem_name) const;
+  std::vector<std::string> getActiveFaults (const std::string& subsystem) const;
+  bool   isOperable (const std::string& subsystem_name) const;
+  bool   isFaulty (const std::string& subsystem_name) const;
   std::vector<double> getArmEndEffectorFT () const override;
 
  private:


### PR DESCRIPTION
### Summary

- Fixes broken lookups that were failing `GuardedMove` and other lookups because their handlers were incorrectly initialized.
- Introduces new template-based lookup handlers that fixes the above problem and streamlines the remaining handlers.
- Trivial interface changes in `OwInterface` needed to support the new handlers.
- Unrelated: subscribes jointStatesCallback(), which fixes the TorqueTest plan.

### Test

The following tests the fix with known broken plans, both the new template handlers,  as well as regression for newer features.

1. Start the Atacama world.
2. Launch Plexil with:
    `roslaunch ow_plexil ow_exec.launch fault_dependencies_file:="FaultDependenciesModel.xml"`
3. Run the plans Demo and ReferenceMission1 and see that the GuardedMoves work and the plans run to completion.   Note that RM1 may exhibit known intermittent problems unrelated to this branch.
4. Run TorqueTest and see that some (any) joints get a soft or hard overtorque warning.
5. Test any other plans you like.
6. Finally, run the plan HealthMonitorDemo and try injecting and clearing some arm faults.  You'll need Ctrl-C to terminate the plan.