### PR TITLE
Script to compile a single plan

### DIFF
--- a/ow_plexil/README.md
+++ b/ow_plexil/README.md
@@ -21,6 +21,8 @@ Contents
 `src/plexil-adapter` contains the supporting code needed to run the PLEXIL plans,
 and also the ROS node implementations.
 
+`scripts` contains supporting Python scripts.
+
 See the `README.md` files in each subdirectory for more information.
 
 

--- a/ow_plexil/scripts/README.md
+++ b/ow_plexil/scripts/README.md
@@ -1,0 +1,7 @@
+This directory contains Python scripts that support the `ow_plexil`
+package.
+
+`plexilcow` compiles a single PLEXIL plan.
+
+`identify_sample_location.py` performs basic image analysis using the
+`OpenCV` package and is used by a few PLEXIL plans.

--- a/ow_plexil/scripts/README.md
+++ b/ow_plexil/scripts/README.md
@@ -1,7 +1,7 @@
 This directory contains Python scripts that support the `ow_plexil`
 package.
 
-`plexilcow` compiles a single PLEXIL plan.
+`ow-compile-plan` compiles a single PLEXIL plan.
 
 `identify_sample_location.py` performs basic image analysis using the
 `OpenCV` package and is used by a few PLEXIL plans.

--- a/ow_plexil/scripts/README.md
+++ b/ow_plexil/scripts/README.md
@@ -1,4 +1,4 @@
-This directory contains Python scripts that support the `ow_plexil`
+This directory contains scripts that support the `ow_plexil`
 package.
 
 `ow-compile-plan` compiles a single PLEXIL plan.

--- a/ow_plexil/scripts/ow-compile-plan
+++ b/ow_plexil/scripts/ow-compile-plan
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# plexilcow (PLEXIL Compiler for OceanWATERS).
-
 # Simple script for compiling a single PLEXIL plan (.plp file).
 # Compiled version (.plx) is placed in the current deployment
 # directory.  Assumes that the PLEXIL compiler (plexilc) is in the
@@ -12,8 +10,17 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
+if [ -z "$PLEXIL_PLAN_DIR" ]
+then
+    echo 'Error: environment PLEXIL_PLAN_DIR is not defined, '
+    echo 'which suggests that your workspace is not set up. '
+    echo 'See that your workspace is built and that your '
+    echo 'devel/setup.bash file is sourced.'
+    exit 1
+fi
+
 input_file="$1"
-output_directory="$HOME/ow/devel/.private/ow_plexil/etc/plexil/"
+output_directory="$PLEXIL_PLAN_DIR/../../.private/ow_plexil/etc/plexil/"
 
 if [ ! -f "${input_file}" ]; then
     echo "Input file '${input_file}' not found."
@@ -23,5 +30,4 @@ fi
 base_filename=$(basename "$input_file" .plp)
 
 # The '-p' option formats the output XML.
-
 plexilc -p -o "${output_directory}${base_filename}.plx" "${input_file}"

--- a/ow_plexil/scripts/plexilcow
+++ b/ow_plexil/scripts/plexilcow
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# plexilcow (PLEXIL Compiler for OceanWATERS).
+
+# Simple script for compiling a single PLEXIL plan (.plp file).
+# Compiled version (.plx) is placed in the current deployment
+# directory.  Assumes that the PLEXIL compiler (plexilc) is in the
+# user's search path.
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <filename.plp>"
+    exit 1
+fi
+
+input_file="$1"
+output_directory="$HOME/ow/devel/.private/ow_plexil/etc/plexil/"
+
+if [ ! -f "${input_file}" ]; then
+    echo "Input file '${input_file}' not found."
+    exit 1
+fi
+
+base_filename=$(basename "$input_file" .plp)
+
+# The '-p' option formats the output XML.
+
+plexilc -p -o "${output_directory}${base_filename}.plx" "${input_file}"


### PR DESCRIPTION
This is just a new convenience script for users.

To test it, CD to any directory containing a PLEXIL plan (.plp) file, type `ow-compile-plan <filename.plp>` and see that there's a new `.plx` version of this plan in `<ow_workspace>/devel/.private/ow_plexil/etc/plexil/`

Note that PLEXIL plans from all source directories are compiled to this one destination directory.
