### PR TITLE
ow-compile-plan fix

### DIFF
--- a/ow_plexil/scripts/ow-compile-plan
+++ b/ow_plexil/scripts/ow-compile-plan
@@ -20,7 +20,6 @@ then
 fi
 
 input_file="$1"
-output_directory="$PLEXIL_PLAN_DIR/../../.private/ow_plexil/etc/plexil/"
 
 if [ ! -f "${input_file}" ]; then
     echo "Input file '${input_file}' not found."
@@ -28,6 +27,13 @@ if [ ! -f "${input_file}" ]; then
 fi
 
 base_filename=$(basename "$input_file" .plp)
+output_filename="${base_filename}.plx"
+output_directory="$PLEXIL_PLAN_DIR/../../.private/ow_plexil/etc/plexil/"
+output_file="${output_directory}${output_filename}"
 
 # The '-p' option formats the output XML.
-plexilc -p -o "${output_directory}${base_filename}.plx" "${input_file}"
+plexilc -p -o "${output_file}" "${input_file}"
+
+# Create a symlink required by catkin
+ln -sf "${output_file}" "$PLEXIL_PLAN_DIR/$output_filename"
+


### PR DESCRIPTION
=== Summary ===

The existing script worked only for plans that had already been built using catkin.  It did not work for brand new plans because it did not create a symbolic link needed by catkin.  This simple fix adds that symlink.

=== Test ===

1. cd to the `src/plans` directory.
2. Call `ow-compile-plan` on any existing `.plp` file.
3. Create a new '.plp` file (you can copy an existing one).
4. Call `ow-compile-plan` on the new file.
5. Start any simulator world, and then the ow-exec launch.
6. See that you can select and start both of the plans above.

