### PR TITLE
Hotfix for FaultDependenciesDemo plan

### DIFF
--- a/ow_plexil/src/plans/FaultDependenciesDemo.plp
+++ b/ow_plexil/src/plans/FaultDependenciesDemo.plp
@@ -5,19 +5,31 @@
 // This plan demonstrates aspects of the Fault Dependencies framework,
 // described in the OceanWATERS user guide at
 // https://github.com/nasa/ow_simulator/wiki/Autonomy, and requires
-// its use.
+// its use.  In particular you must start the executive as follows:
+//
+//   roslaunch ow_plexil ow_exec.launch fault_dependencies_file:="FaultDependenciesModel.xml"
+//
+// This plan has a main action and a backup action, only one of which
+// should operate at a time, depending on operability (fault) status.
+//
+// The main action is that the antenna will pan, tilt and then take a
+// picture, repeatedly.  If the Pan Fault is active it will only Tilt
+// and Take a Picture. If the Tilt Fault is active it will only Pan
+// and take a picture. If the Camera Fault is active, an image capture
+// will still be attempted, and the final result shown.  If and only
+// if both Pan and Tilt are inoperable, the backup action will begin.
 
-// The Antenna will Pan, Tilt and then take a picture. If the Pan
-// Fault is active it will only Tilt and Take a Picture. If the Tilt
-// Fault is active it will only Pan and take a picture. If both Pan
-// and Tilt are inoperable, the backup action will begin and
-// unstow/stow the arm repeatably. Camera faults will prevent a
-// picture from being taken until they are cleared.
+// The backup action is to unstow/stow the arm repeatedly.  Any arm
+// fault will pause the backup action until the faults are cleared.
+// Whenever the antenna is operable (pan or tilt), the backup action
+// will stop, and main action will resume.
 
-// NOTE: As of 10/18/2023, the backup action should be robust to
-// faults, but due to an unknown bug it will freeze the whole plan if
-// an arm fault is activated during execution. This is being
-// investigated.
+// Note that it may take up to 20 seconds to see the expected reaction
+// to fault injection and clearing, because a ROS action in progress
+// needs to complete.  At present PLEXIL does not have a finer degree
+// of control over ROS actions -- they must run to completion once
+// started.
+
 
 #include "ow-interface.h"
 

--- a/ow_plexil/src/plans/FaultDependenciesDemo.plp
+++ b/ow_plexil/src/plans/FaultDependenciesDemo.plp
@@ -7,11 +7,12 @@
 // https://github.com/nasa/ow_simulator/wiki/Autonomy, and requires
 // its use.
 
-// The Antenna will Pan, Tilt and then take a picture. If the Pan Fault is active
-// it will only Tilt and Take a Picture. If the Tilt Fault is active it will only
-// Pan and take a picture. If both Pan and Tilt are inoperable, the backup action
-// will begin and unstow/stow the arm repeatably. Camera faults will prevent a picture
-// from being taken until they are cleared.
+// The Antenna will Pan, Tilt and then take a picture. If the Pan
+// Fault is active it will only Tilt and Take a Picture. If the Tilt
+// Fault is active it will only Pan and take a picture. If both Pan
+// and Tilt are inoperable, the backup action will begin and
+// unstow/stow the arm repeatably. Camera faults will prevent a
+// picture from being taken until they are cleared.
 
 // NOTE: As of 10/18/2023, the backup action should be robust to
 // faults, but due to an unknown bug it will freeze the whole plan if
@@ -20,100 +21,87 @@
 
 #include "ow-interface.h"
 
-FaultDependenciesDemo:
+FaultDependenciesDemo: UncheckedSequence
 {
-
   Real NewPanAngle = 0;
   Real NewTiltAngle = 20;
   Real Count = 0;
-  Boolean BackupAction = false;
-  Boolean CameraFault = false;
 
   log_info ("Starting FaultDependenciesDemo plan...");
 
   Run: Concurrence
   {
-
-    PanTiltPattern: Sequence
+    MainAction:
     {
-      StartCondition Lookup(IsOperable("Antenna")) && !BackupAction;
       RepeatCondition true;
-      Wait 2;
 
-      NewPanAngle = (Lookup(PanDegrees) + 15) mod 360;
-      if NewPanAngle > 180 {
-        NewPanAngle = NewPanAngle - 360;
-      }
-      if Count % 2 == 0{
-        NewTiltAngle = 10;
-      }
-      else{
-        NewTiltAngle = -10;
-      }
-      Count = Count + 1;
+      PanTiltPattern: UncheckedSequence
+      {
+        StartCondition Lookup(IsOperable("Pan")) || Lookup(IsOperable("Tilt"));
+        ExitCondition !Lookup(IsOperable("Pan")) && !Lookup(IsOperable("Tilt"));
 
-      if Lookup(IsOperable("Pan")) && Lookup(IsOperable("Tilt")) {
-        log_info("Panning and Tilting...");
-        LibraryCall PanTiltMoveJoints (PanDegrees=NewPanAngle, TiltDegrees=NewTiltAngle);
-      }
-      elseif Lookup(IsOperable("Tilt")){
-        log_info("Pan Inoperable, executing Tilt only...");
-        LibraryCall Tilt (Degrees=NewTiltAngle);
-      }
-      elseif Lookup(IsOperable("Pan")){
-        log_info("Tilt Inoperable, executing Pan only...");
-        LibraryCall Pan (Degrees=NewPanAngle);
-      }
-      else{
-        log_info("Tilt and Pan Inoperable, beginning backup pattern...");
-        BackupAction = true;
-      }
+        NewPanAngle = (Lookup(PanDegrees) + 15) mod 360;
 
+        if NewPanAngle > 180 NewPanAngle = NewPanAngle - 360;
 
-      if Lookup(IsOperable("CameraCapture")){
-        log_info("Taking Picture...");
-        LibraryCall CameraCapture();
-      }
-      else{
-        CameraFault=true;
-      }
+        if Count % 2 == 0 NewTiltAngle = 10;
+        else NewTiltAngle = -10;
+        endif;
 
-      if CameraFault{
-        LibraryCall CameraCapture();
-        if Lookup(IsOperable("CameraCapture")){
-          log_info("Camera now Operable, picture taken");
-          CameraFault = false;
+        Count = Count + 1;
+
+        if Lookup(IsOperable("Pan")) && Lookup(IsOperable("Tilt")) {
+          log_info("Panning and Tilting...");
+          LibraryCall PanTiltMoveJoints (PanDegrees=NewPanAngle,
+                                         TiltDegrees=NewTiltAngle);
         }
-        else{
-          CameraFault = true;
-          log_info("WARNING: Camera Is Inoperable, no picture taken.");
+        elseif Lookup(IsOperable("Tilt")){
+          log_info("Pan Inoperable, executing Tilt only...");
+          LibraryCall Tilt (Degrees=NewTiltAngle);
         }
+        elseif Lookup(IsOperable("Pan")){
+          log_info("Tilt Inoperable, executing Pan only...");
+          LibraryCall Pan (Degrees=NewPanAngle);
+        }
+        else log_info("Tilt and Pan inoperable.");
+        endif;
+
+        if Lookup(IsOperable("CameraCapture")) {
+          log_info("Taking Picture...");
+          LibraryCall CameraCapture();
+        }
+        else {
+          log_info("Camera is faulted, attempting picture to clear fault...");
+          LibraryCall CameraCapture();
+          if Lookup(IsOperable("CameraCapture")) {
+            log_info("Camera now Operable, picture taken");
+          }
+          else log_warning("Camera Is Inoperable, no picture taken.");
+        }
+        endif;
       }
+      Wait 1; // Gives BackupAction a chance to run.
     }
 
-    StowingPattern: Sequence
+    BackupAction:
     {
-      StartCondition BackupAction && Lookup(IsOperable("Arm"));
       RepeatCondition true;
-      Wait 1;
+      StowingPattern: UncheckedSequence
+      {
+        StartCondition (!Lookup(IsOperable("Tilt")) &&
+                        !Lookup(IsOperable("Pan")) &&
+                        Lookup(IsOperable("Arm")));
+        ExitCondition !Lookup(IsOperable("Arm"));
 
-      if Lookup(IsOperable("ArmUnstow")){
-        LibraryCall ArmUnstow();
-      }
-      else{
-        log_info("WARNING: ArmUnstow Is Inoperable, action skipped.");
-      }
-      if Lookup(IsOperable("ArmUnstow")){
-        LibraryCall ArmStow();
-      }
-      else{
-        log_info("WARNING: ArmStow Is Inoperable, action skipped.");
-      }
+        if Lookup(IsOperable("ArmUnstow")) LibraryCall ArmUnstow();
+        else log_warning("ArmUnstow Is Inoperable, action skipped.");
+        endif;
 
-      if Lookup(IsOperable("Pan")) || Lookup(IsOperable("Tilt")){
-        log_info("Stopping backup action, resuming main pattern");
-        BackupAction = false;
+        if Lookup(IsOperable("ArmStow")) LibraryCall ArmStow();
+        else log_warning("ArmStow Is Inoperable, action skipped.");
+        endif;
       }
+      Wait 1; // Gives MainAction a chance to run.
     }
   }
 }


### PR DESCRIPTION
### Summary

 - Fixes problem of plan often freezing after antenna or arm faults were injected.
 - Restructures and simplifies plan for better readability as well.
 - Plan description in its comments is revised.

### Test

1. Have all other repositories on master branch and rebuild workspace.
2. Re-source <ow_workspace>/devel/setup.bash.
3. Start any simulator world.
4. Start the executive node as follows:
    roslaunch ow_plexil ow_exec.launch fault_dependencies_file:="FaultDependenciesModel.xml"
5. Perform [Release 12 test 10.16](https://babelfish.arc.nasa.gov/confluence/pages/viewpage.action?pageId=220561639)

### Reviewer Notes

 - Suggest @AstroStucky review code and test, and @mogumbo test only (feel free to also review code).
 - The plan as a whole may be easier to review than the diff, since it was restructured so much.  The key fix was the addition of wrapper nodes to the main and backup actions that contain only a Repeat condition.