### PR TITLE
Hotfix for EuropaMission plan

### DIFF
--- a/ow_plexil/src/plans/EuropaMission.plp
+++ b/ow_plexil/src/plans/EuropaMission.plp
@@ -243,7 +243,7 @@ EuropaMission: Concurrence
     }
 
     log_info ("Europa Mission, Sol 0 finished.");
-    set_boot_ok();
+    set_boot_ok(true, 0);
     SynchronousCommand flush_checkpoints();
     MissionInProgress = false;
   }

--- a/ow_plexil/src/plans/common/common-interface.h
+++ b/ow_plexil/src/plans/common/common-interface.h
@@ -163,10 +163,11 @@ Boolean Command set_checkpoint (...);
 // Flushes all changes (including set_boot_ok) to disk.
 Boolean Command flush_checkpoints ();
 
-// Sets IsBootOK, returns previous value. Actual:
-//Integer Command set_boot_ok (Boolean state=True, Integer boot=0);
-// Declared as:
-Integer Command set_boot_ok (...);
+// Marks the given boot number is_ok.  This command has optional arguments:
+//   Command set_boot_ok (Boolean state=True, Integer boot=0);
+// But due to a bug in its implementation, it requires at least one of
+// these (either one).  The effective way to declare this command is as follows.
+Command set_boot_ok (...);
 
 // Returns the total number of boots ever logged.
 Integer Lookup NumberOfTotalBoots ();


### PR DESCRIPTION
### Summary

This fixes the EuropaMission plan, which was broken due to an error in one of its PLEXIL Checkpoint calls.  The fix was simple, though pointed out some issues in the set_boot_ok function that will be addressed in PLEXIL.  They don't affect the nominal operation of this plan.

### Reviewer Suggestions

I think one review and test is sufficient and I request @AstroStucky .  @mogumbo , you can review/test if you like, or just be the second approver needed for this hotfix.
### Test

1. Start the Atacama world.
2. Start the executive launch and run the plan EuropaMission.
3. See [Release test 10.11](https://babelfish.arc.nasa.gov/confluence/pages/viewpage.action?pageId=220561639)