### PR TITLE
Hotfix to support OWLAT Sim 0.5.4

### DIFF
--- a/ow_plexil/src/plans/owlat/ArmSetup.plp
+++ b/ow_plexil/src/plans/owlat/ArmSetup.plp
@@ -2,7 +2,7 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// This is test sequence 4.9.1 in the OWLAT 5.3 User Guide.  It is
+// This is test sequence 4.9.1 in the OWLAT 0.5.4 User Guide.  It is
 // reused in several other test sequences.
 
 #include "owlat-interface.h"

--- a/ow_plexil/src/plans/owlat/TestOwlatActions.plp
+++ b/ow_plexil/src/plans/owlat/TestOwlatActions.plp
@@ -3,7 +3,7 @@
 // this repository.
 
 // Tests all OWLAT actions, using (when possible) the test sequences
-// provided in the OWLAT 5.3 user guide.  The order is approximately
+// provided in the OWLAT 0.5.4 user guide.  The order is approximately
 // that of their coverage in the user guide.
 
 #include "owlat-interface.h"
@@ -30,11 +30,9 @@ TestOwlatActions:
   LibraryCall TestOwlatArmFindSurface;
   LibraryCall TestTaskPSP;
   LibraryCall TestTaskPenetrometer;
-  // Does not work. See comments in that plan.
-  //  LibraryCall TestShearBevameter;
+  LibraryCall TestShearBevameter;
   LibraryCall TestOwlatTaskScoopCircular;
-  LibraryCall TestOwlatTaskScoopLinear;
-  LibraryCall TestTaskDiscardSample;
+  LibraryCall TestTaskDiscardSample; // also tests TaskScoopLinear
   LibraryCall TestPanTiltMoveJoints;
   log_info ("Finished OWLAT action test.");
 }

--- a/ow_plexil/src/plans/owlat/TestOwlatArmFindSurface.plp
+++ b/ow_plexil/src/plans/owlat/TestOwlatArmFindSurface.plp
@@ -2,7 +2,7 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Test sequence 4.11.1 in the OWLAT 5.3 user guide.
+// Test sequence 4.11.1 in the OWLAT 0.5.4 user guide.
 
 #include "owlat-interface.h"
 

--- a/ow_plexil/src/plans/owlat/TestOwlatArmMoveCartesian.plp
+++ b/ow_plexil/src/plans/owlat/TestOwlatArmMoveCartesian.plp
@@ -2,7 +2,8 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Test sequence 4.10.1 in the OWLAT 5.3 user guide.
+// Test sequence 4.10.1 in the OWLAT 0.5.4 user guide. Tests both
+// ArmMoveCartesian and ArmMoveCartesianGuarded.
 
 #include "owlat-interface.h"
 

--- a/ow_plexil/src/plans/owlat/TestOwlatArmMoveJoints.plp
+++ b/ow_plexil/src/plans/owlat/TestOwlatArmMoveJoints.plp
@@ -2,6 +2,8 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
+// Test sequence 4.8.1 in the OWLAT Sim 0.5.4 user guide.
+
 #include "owlat-interface.h"
 
 TestOwlatArmMoveJoints:

--- a/ow_plexil/src/plans/owlat/TestOwlatMiscActions.plp
+++ b/ow_plexil/src/plans/owlat/TestOwlatMiscActions.plp
@@ -3,7 +3,8 @@
 // this repository.
 
 // Test misc actions that don't have a prescribed test sequence in the
-// OWLAT 5.3 user guide.
+// OWLAT 0.5.4 user guide.  Note that FaultSet and FaultClear are not
+// yet included, and need a PLEXIL interface.
 
 #include "owlat-interface.h"
 

--- a/ow_plexil/src/plans/owlat/TestOwlatTaskScoopCircular.plp
+++ b/ow_plexil/src/plans/owlat/TestOwlatTaskScoopCircular.plp
@@ -2,7 +2,7 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Test sequence 4.15.1 in the OWLAT 5.3 user guide.
+// Test sequence 4.15.1 in the OWLAT 0.5.4 user guide.
 
 #include "owlat-interface.h"
 
@@ -15,7 +15,7 @@ TestOwlatTaskScoopCircular:
                                       Relative = false,
                                       Point = #(0 0 0.43),
                                       Normal = #(0 0 -1),
-                                      Depth = 0.01, // 0.025 caused goal error
+                                      Depth = 0.025,
                                       ScoopAngle = 1.57);
   LibraryCall SafeStow();
   log_info ("Finished TaskScoopCircular test.");

--- a/ow_plexil/src/plans/owlat/TestOwlatTaskScoopLinear.plp
+++ b/ow_plexil/src/plans/owlat/TestOwlatTaskScoopLinear.plp
@@ -2,7 +2,7 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Test sequence 4.16.1 in the OWLAT 5.3 user guide.
+// Test sequence 4.16.1 in the OWLAT 0.5.4 user guide.
 
 #include "owlat-interface.h"
 

--- a/ow_plexil/src/plans/owlat/TestPanTiltMoveJoints.plp
+++ b/ow_plexil/src/plans/owlat/TestPanTiltMoveJoints.plp
@@ -2,7 +2,7 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Test sequence 4.19.1 in the OWLAT 5.3 user guide, plus one more
+// Test sequence 4.19.1 in the OWLAT 0.5.4 user guide, plus one more
 // call so that pan is non-zero.
 
 #include "owlat-interface.h"

--- a/ow_plexil/src/plans/owlat/TestShearBevameter.plp
+++ b/ow_plexil/src/plans/owlat/TestShearBevameter.plp
@@ -2,16 +2,13 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Test sequence 4.14.1 in the OWLAT 5.3 user guide.
-
-// Fails during bevameter action.  For some reason, the MaxTorque
-// threshold is never reached, and we've tried values as high as 1.0.
-// Reproducable at Ames, but not JPL.  We have given up as of 6/9/23.
+// Test 4.14.1 in the OWLAT Sim 0.5.4 user guide.
 
 #include "owlat-interface.h"
 
 TestShearBevameter:
 {
+  log_info ("Starting ShearBevameter test...");
   LibraryCall ArmUnstow();
   LibraryCall ArmSetTool(Tool=TOOL_BEVAMETER);
   LibraryCall TaskShearBevameter (Frame = TOOL_FRAME,
@@ -21,4 +18,5 @@ TestShearBevameter:
                                   Preload = 5.0,
                                   MaxTorque = 0.1);
   LibraryCall SafeStow();
+  log_info ("Finished ShearBevameter test.");
 }

--- a/ow_plexil/src/plans/owlat/TestTaskDiscardSample.plp
+++ b/ow_plexil/src/plans/owlat/TestTaskDiscardSample.plp
@@ -2,14 +2,15 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Test sequence 4.18.1 in the OWLAT 5.3 user guide.
+// Test sequence 4.18.1 in the OWLAT 0.5.4 user guide.
 
 #include "owlat-interface.h"
 
 TestTaskDiscardSample:
 {
-  log_info ("Starting TaskDiscardSample test...");
+  log_info ("Starting TaskScoopLinear and TaskDiscardSample test...");
   LibraryCall ArmUnstow();
+  LibraryCall ArmSetTool(Tool=TOOL_SCOOP);
   // Same as in TestOwlatTaskScoopLinear, test sequence 4.16.1
   LibraryCall OwlatTaskScoopLinear (Frame = TOOL_FRAME,
                                     Relative = false,
@@ -22,5 +23,5 @@ TestTaskDiscardSample:
                                  Point = #(0.1 0.2 0.5),
                                  Height = 0.05);
   LibraryCall SafeStow();
-  log_info ("Finished TaskDiscardSample test.");
+  log_info ("Finished TaskScoopLinear and TaskDiscardSample test.");
 }

--- a/ow_plexil/src/plans/owlat/TestTaskPSP.plp
+++ b/ow_plexil/src/plans/owlat/TestTaskPSP.plp
@@ -2,7 +2,7 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Test sequence 4.12.1 in the OWLAT 5.3 user guide.
+// Test sequence 4.12.1 in the OWLAT 0.5.4 user guide.
 
 #include "owlat-interface.h"
 
@@ -13,8 +13,8 @@ TestTaskPSP:
   LibraryCall ArmSetTool(Tool=TOOL_PSP);
   LibraryCall TaskPSP (Frame = TOOL_FRAME,
                        Relative = false,
-                       Point = #(0 0 0.5 ),
-                       Normal = #(0 0 -1 ),
+                       Point = #(0 0 0.5),
+                       Normal = #(0 0 -1),
                        MaxDepth = 0.3,
                        MaxForce = 10);
   LibraryCall SafeStow();

--- a/ow_plexil/src/plans/owlat/TestTaskPenetrometer.plp
+++ b/ow_plexil/src/plans/owlat/TestTaskPenetrometer.plp
@@ -2,7 +2,7 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Test sequence 4.13.1 in the OWLAT 5.3 user guide.
+// Test sequence 4.13.1 in the OWLAT 0.5.4 user guide.
 
 #include "owlat-interface.h"
 

--- a/ow_plexil/src/plans/owlat/owlat-interface.h
+++ b/ow_plexil/src/plans/owlat/owlat-interface.h
@@ -12,9 +12,10 @@
 
 #define TOOL_NONE 0
 #define TOOL_PSP  1
-#define TOOL_BEVAMETER 2
-#define TOOL_SCOOP 3
-#define TOOL_PENETROMETER 4
+#define TOOL_PENETROMETER 2
+#define TOOL_BEVAMETER 3
+#define TOOL_SCOOP 4
+#define TOOL_DRILL 5
 
 // Note that in cases where OceanWATERS has an action with the same
 // name (but different signature, else it would be in ../common), the

--- a/ow_plexil/src/plans/owlat/owlat-interface.h
+++ b/ow_plexil/src/plans/owlat/owlat-interface.h
@@ -12,9 +12,9 @@
 
 #define TOOL_NONE 0
 #define TOOL_PSP  1
-#define TOOL_PENETROMETER 2
-#define TOOL_BEVAMETER 3
-#define TOOL_SCOOP 4
+#define TOOL_BEVAMETER 2
+#define TOOL_SCOOP 3
+#define TOOL_PENETROMETER 4
 #define TOOL_DRILL 5
 
 // Note that in cases where OceanWATERS has an action with the same

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.h
@@ -187,16 +187,20 @@ class OwlatInterface : public LanderInterface
         owl_msgs::SystemFaultsStatus::ARM_EXECUTION_ERROR,false)},
     {"TASK_GOAL_ERROR", std::make_pair(
         owl_msgs::SystemFaultsStatus::TASK_GOAL_ERROR,false)},
-    {"CAM_GOAL_ERROR", std::make_pair(
-        owl_msgs::SystemFaultsStatus::CAM_GOAL_ERROR,false)},
-    {"CAM_EXECUTION_ERROR", std::make_pair(
-        owl_msgs::SystemFaultsStatus::CAM_EXECUTION_ERROR,false)},
+    {"CAMERA_GOAL_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::CAMERA_GOAL_ERROR,false)},
+    {"CAMERA_EXECUTION_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::CAMERA_EXECUTION_ERROR,false)},
     {"PAN_TILT_GOAL_ERROR", std::make_pair(
         owl_msgs::SystemFaultsStatus::PAN_TILT_GOAL_ERROR,false)},
     {"PAN_TILT_EXECUTION_ERROR", std::make_pair(
         owl_msgs::SystemFaultsStatus::PAN_TILT_EXECUTION_ERROR,false)},
-    {"POWER_EXECUTION_ERROR", std::make_pair(
-        owl_msgs::SystemFaultsStatus::POWER_EXECUTION_ERROR,false)}
+    {"DRILL_GOAL_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::DRILL_GOAL_ERROR,false)},
+    {"DRILL_EXECUTION_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::DRILL_EXECUTION_ERROR,false)},
+    {"LANDER_EXECUTION_ERROR", std::make_pair(
+        owl_msgs::SystemFaultsStatus::LANDER_EXECUTION_ERROR,false)}
   };
 
   std::vector<double> m_end_effector_ft;


### PR DESCRIPTION
### Summary

These are the changes (all minor) needed to supported OWLAT Sim 0.5.4, i.e. make the Release 12 tests work with this version of OWLAT.

Most of the tests needed no modification.  Notably, one failing test from before (bevameter) now works, and all test actions use exactly the arguments given in the OWLAT user guide.

### Test

Install OWLAT Sim 0.5.4.

Perform all [Release 12 OWLAT tests.](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST-012-11+OWLAT+Simulator)

### Review suggestion

One review/test is sufficient, and this should be @AstroStucky.  @mogumbo you can review if you like, though just a second approval would be acceptable.