### PR TITLE
Hotfix for health monitor plans

### DIFF
--- a/ow_plexil/src/plans/HealthMonitor.plp
+++ b/ow_plexil/src/plans/HealthMonitor.plp
@@ -2,16 +2,19 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// This plan monitors the faultDependencies of each subsystem. When a
+// This plan monitors the fault dependencies of each subsystem. When a
 // subsystem becomes inoperable, it prints out a message with the
 // status and cause.  Other plans are intended to use the
 // HealthMonitor with the InOut Boolean variables that are updated
-// every second. This is intended to make monitoring faults easiera
+// every second. This is intended to make monitoring faults easier
 // and less verbose in new plans.
 
 // NOTE: this plan requires use of the Fault Dependencies framework,
 // which is documented in OceanWATERS user guide at
-// https://github.com/nasa/ow_simulator/wiki/Autonomy.
+// https://github.com/nasa/ow_simulator/wiki/Autonomy. In particular
+// you must start the executive with a fault dependencies file, e.g.
+//
+//   roslaunch ow_plexil ow_exec.launch fault_dependencies_file:="FaultDependenciesModel.xml"
 
 
 #include "ow-interface.h"
@@ -44,61 +47,69 @@ HealthMonitor:
                   CameraOperable &&
                   PowerOperable;
 
-    if !ArmOperable && PrevArm{
-      if Lookup(IsFaulty("Arm")){
-        log_warning("Health Monitor: Arm is Inoperable due to the local fault(s): ", Lookup(ActiveFaults("Arm")));
+    if !ArmOperable && PrevArm {
+      if Lookup(IsFaulty("Arm")) {
+        log_warning("Health Monitor: Arm is Inoperable due to the local fault(s): ",
+                    Lookup(ActiveFaults("Arm")));
       }
-      else{
+      else {
         log_warning("Health Monitor: Arm is Inoperable due to non-local fault(s).");
       }
       PrevArm = false;
     }
-    if ArmOperable && !PrevArm{
-        log_warning("Health Monitor: Arm is now operable.");
-        PrevArm = true;
+    else if ArmOperable && !PrevArm {
+      log_warning("Health Monitor: Arm is now operable.");
+      PrevArm = true;
     }
-
-    if !AntennaOperable && PrevAntenna{
-      if Lookup(IsFaulty("Antenna")){
-        log_warning("Health Monitor: Antenna is Inoperable due to the local fault(s): ", Lookup(ActiveFaults("Antenna")));
+    endif;
+    
+    if !AntennaOperable && PrevAntenna {
+      if Lookup(IsFaulty("Antenna")) {
+        log_warning("Health Monitor: Antenna is Inoperable due to the local fault(s): ",
+                    Lookup(ActiveFaults("Antenna")));
       }
-      else{
+      else {
         log_warning("Health Monitor: Antenna is Inoperable due to non-local fault(s).");
       }
       PrevAntenna = false;
     }
-    if AntennaOperable && !PrevAntenna{
-        log_warning("Health Monitor: Antenna is now operable.");
-        PrevAntenna = true;
+    else if AntennaOperable && !PrevAntenna {
+      log_warning("Health Monitor: Antenna is now operable.");
+      PrevAntenna = true;
     }
+    endif;
 
-    if !CameraOperable && PrevCamera{
-      if Lookup(IsFaulty("Camera")){
-        log_warning("Health Monitor: Camera is Inoperable due to the local fault(s): ", Lookup(ActiveFaults("Camera")));
+    if !CameraOperable && PrevCamera {
+      if Lookup(IsFaulty("Camera")) {
+        log_warning("Health Monitor: Camera is Inoperable due to the local fault(s): ",
+                    Lookup(ActiveFaults("Camera")));
       }
-      else{
+      else {
         log_warning("Health Monitor: Camera is Inoperable due to non-local fault(s).");
       }
+      endif;
       PrevCamera = false;
     }
-    if CameraOperable && !PrevCamera{
-        log_warning("Health Monitor: Camera is now operable.");
-        PrevCamera = true;
+    else if CameraOperable && !PrevCamera {
+      log_warning("Health Monitor: Camera is now operable.");
+      PrevCamera = true;
     }
-
-
-    if !PowerOperable && PrevPower{
-      if Lookup(IsFaulty("Power")){
-        log_warning("Health Monitor: Power is Inoperable due to the local fault(s): ", Lookup(ActiveFaults("Power")));
+    endif;
+    
+    if !PowerOperable && PrevPower {
+      if Lookup(IsFaulty("Power")) {
+        log_warning("Health Monitor: Power is Inoperable due to the local fault(s): ",
+                    Lookup(ActiveFaults("Power")));
       }
-      else{
+      else {
         log_warning("Health Monitor: Power is Inoperable due to non-local fault(s).");
       }
       PrevPower = false;
     }
-    if PowerOperable && !PrevPower{
-        log_warning("Health Monitor: Power is now operable.");
-        PrevPower = true;
+    else if PowerOperable && !PrevPower {
+      log_warning("Health Monitor: Power is now operable.");
+      PrevPower = true;
     }
+    endif;
   }
 }

--- a/ow_plexil/src/plans/HealthMonitor.plp
+++ b/ow_plexil/src/plans/HealthMonitor.plp
@@ -2,12 +2,13 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// This plan monitors the fault dependencies of each subsystem. When a
-// subsystem becomes inoperable, it prints out a message with the
-// status and cause.  Other plans are intended to use the
-// HealthMonitor with the InOut Boolean variables that are updated
-// every second. This is intended to make monitoring faults easier
-// and less verbose in new plans.
+// This plan is a simple prototype for a rudimentary health monitor
+// for the lander.  It monitors the fault dependencies of each
+// subsystem. When a subsystem becomes inoperable, it prints out a
+// message with the status and cause.  Other plans are intended to use
+// the HealthMonitor with the InOut Boolean variables that are updated
+// every second. This is intended to make monitoring faults easier and
+// less verbose in new plans.
 
 // NOTE: this plan requires use of the Fault Dependencies framework,
 // which is documented in OceanWATERS user guide at
@@ -16,9 +17,8 @@
 //
 //   roslaunch ow_plexil ow_exec.launch fault_dependencies_file:="FaultDependenciesModel.xml"
 
-// Also note that this plan is a preliminary example and could be
-// improved by using a reactive (condition-driven) style rather than
-// polling in a continuous loop.
+// Note that this plan could be improved by using a reactive
+// (condition-driven) style rather than polling in a continuous timed loop.
 
 #include "ow-interface.h"
 
@@ -30,10 +30,13 @@ HealthMonitor:
   InOut Boolean CameraOperable = true;
   InOut Boolean PowerOperable = true;
 
-  Boolean PrevArm = true;
-  Boolean PrevAntenna = true;
-  Boolean PrevCamera = true;
-  Boolean PrevPower = true;
+  // For simplicity, we initializing these flags true to be sure we
+  // get 'inoperable' messages for any systems that are inoperable,
+  // even though they may have already been inoperable.
+  Boolean ArmPreviouslyWorking = true;
+  Boolean AntennaPreviouslyWorking = true;
+  Boolean CameraPreviouslyWorking = true;
+  Boolean PowerPreviouslyWorking = true;
 
   LookupLoop:
   {
@@ -50,23 +53,23 @@ HealthMonitor:
                   CameraOperable &&
                   PowerOperable;
 
-    if !ArmOperable && PrevArm {
+    if !ArmOperable && ArmPreviouslyWorking {
       if Lookup(IsFaulty("Arm")) {
-        log_warning("Health Monitor: Arm is Inoperable due to the local fault(s): ",
+        log_warning("Health Monitor: Arm isa Inoperable due to the local fault(s): ",
                     Lookup(ActiveFaults("Arm")));
       }
       else {
         log_warning("Health Monitor: Arm is Inoperable due to non-local fault(s).");
       }
-      PrevArm = false;
+      ArmPreviouslyWorking = false;
     }
-    else if ArmOperable && !PrevArm {
+    else if ArmOperable && !ArmPreviouslyWorking {
       log_warning("Health Monitor: Arm is now operable.");
-      PrevArm = true;
+      ArmPreviouslyWorking = true;
     }
     endif;
     
-    if !AntennaOperable && PrevAntenna {
+    if !AntennaOperable && AntennaPreviouslyWorking {
       if Lookup(IsFaulty("Antenna")) {
         log_warning("Health Monitor: Antenna is Inoperable due to the local fault(s): ",
                     Lookup(ActiveFaults("Antenna")));
@@ -74,15 +77,15 @@ HealthMonitor:
       else {
         log_warning("Health Monitor: Antenna is Inoperable due to non-local fault(s).");
       }
-      PrevAntenna = false;
+      AntennaPreviouslyWorking = false;
     }
-    else if AntennaOperable && !PrevAntenna {
+    else if AntennaOperable && !AntennaPreviouslyWorking {
       log_warning("Health Monitor: Antenna is now operable.");
-      PrevAntenna = true;
+      AntennaPreviouslyWorking = true;
     }
     endif;
 
-    if !CameraOperable && PrevCamera {
+    if !CameraOperable && CameraPreviouslyWorking {
       if Lookup(IsFaulty("Camera")) {
         log_warning("Health Monitor: Camera is Inoperable due to the local fault(s): ",
                     Lookup(ActiveFaults("Camera")));
@@ -91,15 +94,15 @@ HealthMonitor:
         log_warning("Health Monitor: Camera is Inoperable due to non-local fault(s).");
       }
       endif;
-      PrevCamera = false;
+      CameraPreviouslyWorking = false;
     }
-    else if CameraOperable && !PrevCamera {
+    else if CameraOperable && !CameraPreviouslyWorking {
       log_warning("Health Monitor: Camera is now operable.");
-      PrevCamera = true;
+      CameraPreviouslyWorking = true;
     }
     endif;
     
-    if !PowerOperable && PrevPower {
+    if !PowerOperable && PowerPreviouslyWorking {
       if Lookup(IsFaulty("Power")) {
         log_warning("Health Monitor: Power is Inoperable due to the local fault(s): ",
                     Lookup(ActiveFaults("Power")));
@@ -107,11 +110,11 @@ HealthMonitor:
       else {
         log_warning("Health Monitor: Power is Inoperable due to non-local fault(s).");
       }
-      PrevPower = false;
+      PowerPreviouslyWorking = false;
     }
-    else if PowerOperable && !PrevPower {
+    else if PowerOperable && !PowerPreviouslyWorking {
       log_warning("Health Monitor: Power is now operable.");
-      PrevPower = true;
+      PowerPreviouslyWorking = true;
     }
     endif;
   }

--- a/ow_plexil/src/plans/HealthMonitor.plp
+++ b/ow_plexil/src/plans/HealthMonitor.plp
@@ -16,6 +16,9 @@
 //
 //   roslaunch ow_plexil ow_exec.launch fault_dependencies_file:="FaultDependenciesModel.xml"
 
+// Also note that this plan is a preliminary example and could be
+// improved by using a reactive (condition-driven) style rather than
+// polling in a continuous loop.
 
 #include "ow-interface.h"
 

--- a/ow_plexil/src/plans/HealthMonitorDemo.plp
+++ b/ow_plexil/src/plans/HealthMonitorDemo.plp
@@ -2,10 +2,13 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// This plan unstows and stows the arm if the Camera is set as operable
-// from the HealthMonitor. If it is inoperable, and the camera is operable
-// it takes photos. If both the Camera and Arm are inoperable, it prints out an
-// error message and waits for them to be operable.
+// This plan illustrates a basic use of the HealthMonitor plan. It
+// unstows and stows the arm whenever the arm is operable.  If the arm
+// is unoperable, the camera starts taking photos if it is operable.
+// (Note that it is pointing in the antenna's default position).  If
+// the camera is also inoperable, it continues to be tried, since it
+// takes a camera trigger to know if a camera fault persists.  If both
+// the Camera and Arm are inoperable, the plan waits for either to work.
 
 // NOTE: this plan requires use of the Fault Dependencies framework,
 // which is documented in OceanWATERS user guide at
@@ -35,7 +38,6 @@ HealthMonitorDemo: Concurrence
                                PowerOperable = PowerGood);
   }
 
-  /*
   DemoPattern:
   {
     Repeat true;
@@ -59,5 +61,4 @@ HealthMonitorDemo: Concurrence
     }
     endif;
   }
-  */
 }

--- a/ow_plexil/src/plans/HealthMonitorDemo.plp
+++ b/ow_plexil/src/plans/HealthMonitorDemo.plp
@@ -8,7 +8,9 @@
 // (Note that it is pointing in the antenna's default position).  If
 // the camera is also inoperable, it continues to be tried, since it
 // takes a camera trigger to know if a camera fault persists.  If both
-// the Camera and Arm are inoperable, the plan waits for either to work.
+// the Camera and Arm are inoperable, the plan waits for either to
+// work, though keeps attempting pictures.  If Power is inoperable,
+// the plan ceases activity and waits.
 
 // NOTE: this plan requires use of the Fault Dependencies framework,
 // which is documented in OceanWATERS user guide at
@@ -53,12 +55,13 @@ HealthMonitorDemo: Concurrence
       log_info("Arm not operable, attempting CameraCapture to diagnose...");
       LibraryCall CameraCapture();
     }
-    else {
+    else if PowerGood {
       // Trying CameraCapture because the Camera fault state can only be detected when
       // the camera attempts to take a photo.
       LibraryCall CameraCapture();
-      log_info("Waiting for Camera or Arm to become operable....");
+      log_info("Waiting for Camera or Arm to become operable...");
     }
+    else log_info("Waiting for Power to become operable...");
     endif;
   }
 }

--- a/ow_plexil/src/plans/HealthMonitorDemo.plp
+++ b/ow_plexil/src/plans/HealthMonitorDemo.plp
@@ -2,26 +2,28 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Demo unstows and stows the arm if the Camera is set as operable
+// This plan unstows and stows the arm if the Camera is set as operable
 // from the HealthMonitor. If it is inoperable, and the camera is operable
 // it takes photos. If both the Camera and Arm are inoperable, it prints out an
 // error message and waits for them to be operable.
 
 // NOTE: this plan requires use of the Fault Dependencies framework,
 // which is documented in OceanWATERS user guide at
-// https://github.com/nasa/ow_simulator/wiki/Autonomy.
+// https://github.com/nasa/ow_simulator/wiki/Autonomy. In particular
+// you must start the executive with a fault dependencies file, e.g.
+//
+//   roslaunch ow_plexil ow_exec.launch fault_dependencies_file:="FaultDependenciesModel.xml"
 
 #include "ow-interface.h"
 
 HealthMonitorDemo: Concurrence
 {
-
   Boolean AllGood;
   Boolean ArmGood;
   Boolean AntennaGood;
   Boolean CameraGood;
   Boolean PowerGood;
-  
+
   log_info("Starting HealthMonitorDemo...");
 
   Monitor:
@@ -33,27 +35,29 @@ HealthMonitorDemo: Concurrence
                                PowerOperable = PowerGood);
   }
 
+  /*
   DemoPattern:
   {
     Repeat true;
     Wait 3;
 
-    if ArmGood{
+    if ArmGood {
       Invariant ArmGood;
       log_info("Unstowing and stowing arm...");
       LibraryCall ArmUnstow();
       LibraryCall ArmStow();
     }
-    else if CameraGood{
+    else if CameraGood {
       log_info("Arm not operable, attempting CameraCapture to diagnose...");
       LibraryCall CameraCapture();
     }
-    else{
-      // Trying CameraCapture because the Camera fault state can only be detected when 
+    else {
+      // Trying CameraCapture because the Camera fault state can only be detected when
       // the camera attempts to take a photo.
       LibraryCall CameraCapture();
       log_info("Waiting for Camera or Arm to become operable....");
     }
+    endif;
   }
-
+  */
 }


### PR DESCRIPTION
Note: Jira OW-1223 was created for this work after the branch was already pushed, so leaving it be and have noted this in the Jira as well.

### Summary

- Adds correct behavior for no power situation.
- Corrects and elaborates plan comments.
- Corrects if-then groupings to avoid unnecessary checks.
- Adds the `endif` keyword for better clarity and maintenance.
- Improves file formatting.

### Test

1. Build this branch with all other repos on their `master` branches.
2. Start any simulator world.
3. Start the executive with `roslaunch ow_plexil ow_exec.launch fault_dependencies_file:="FaultDependenciesModel.xml"`
4. Start the `HealthMonitorDemo` plan.

The arm will start unstowing and stowing repeatedly.  Now inject and clear a variety of faults as instructed below.  In addition to the faults being reported in both terminals, you'll see `operable` and `inoperable` messages in the executive terminal.

Note that you may have to wait a few seconds to see the expected behavior, due to action timeouts, and also that there may occasional out-of-order messages due to interleaving of concurrent nodes.

1. Inject any arm fault(s).  The arm should stop and be reported inoperable, and the camera should start taking pictures.
2. Inject the camera fault.  The camera will be reported inoperable, but continue to attempt images.
3. Inject a `low_state_of_charge` or `thermal_failure` power fault.   The camera should stop altogether and Power should be reported inoperable.
5. Clear the power fault.  The behavior of (2) should return.
6. Clear the camera fault.  The camera should be reported operable and start operating normally again.
7. Clear the arm fault(s).  The arm should be reported operable and start moving, and the camera should stop.
8. If you like, inject and clear Arm, Camera, and Power faults in any order and see that behavior conforms to the comments in the `HealthMonitorDemo` plan.

### Review Suggestion

One technical review is sufficient, and requesting @AstroStucky for this.  @mogumbo feel free to review or just provide the second approval needed for this hotfix.
