### PR TITLE
Improve ReferenceMission1 sample target search.

### DIFF
--- a/ow_plexil/scripts/identify_sample_location.py
+++ b/ow_plexil/scripts/identify_sample_location.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-#The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
-#Research and Simulation can be found in README.md in the root directory of
-#this repository.
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
 
 import rospy
 import sys
@@ -20,33 +20,38 @@ import message_filters
 from collections import deque
 
 class IdentifySampleLocation:
-  #Constant defining the maximum length of our image history deque
+  # Constant defining the maximum length of our image history deque.
   HISTORY_MAX_LENGTH = 50
 
   def __init__(self):
 
-    #setting up synchronized subscribers for image_rect and point cloud
-    rectified_image_subscriber = message_filters.Subscriber("/StereoCamera/left/image_rect_color", Image)
+    # Set up synchronized subscribers for image_rect and point cloud.
+    rectified_image_subscriber = message_filters.Subscriber("/StereoCamera/left/image_rect_color",
+                                                            Image)
     point_cloud_subscriber = message_filters.Subscriber("/StereoCamera/points2", PointCloud2)
-    time_synchronizer = message_filters.TimeSynchronizer([rectified_image_subscriber, point_cloud_subscriber], 10)
+    time_synchronizer = message_filters.TimeSynchronizer([rectified_image_subscriber,
+                                                          point_cloud_subscriber], 10)
     time_synchronizer.registerCallback(self.site_imaging_callback)
 
-    #publishes modified opencv image with the contours and sample location outlined
+    # Publish modified opencv image with the contours and sample location outlined.
     self.publish_photo = rospy.Publisher('sample_location', Image, queue_size=10)
 
-    #point visualization
-    self.point_visualization_publisher = rospy.Publisher('sample_point_visualization', Marker, queue_size=10)
+    # Point visualization
+    self.point_visualization_publisher = rospy.Publisher('sample_point_visualization',
+                                                         Marker, queue_size=10)
 
-    #action server setup
+    # Action server setup
     self.sample_location_action_server = actionlib.SimpleActionServer("IdentifySampleLocation",
-                                              IdentifyLocationAction, self.sample_location_callback, False)
+                                                                      IdentifyLocationAction,
+                                                                      self.sample_location_callback,
+                                                                      False)
     self.sample_location_action_server.start()
 
-    #listener and CvBridge
+    # Listener and CvBridge
     self.listener = tf.TransformListener()
     self.bridge = CvBridge()
 
-    #member variables
+    # Member variables
     self.image_history = []
     self.largest_area = None
     self.best_sample_location = None
@@ -55,28 +60,40 @@ class IdentifySampleLocation:
 
 
   def sample_location_callback(self, goal):
-    '''Action Server, goal contains the number of images to be processed as well as the filter type to be used. 
-    Each image gets processed and extracts a list of possible 2d sample coordinates and the corresponding countours.
-    The point with the largest contour is then projected to 3d and transformed to the base_link frame. Only the largest
-    point will be sent back as a result and the outlined contour and corresponding 2d point on the original image is republished.'''
-    #resetting our member variables
+    '''
+    Action Server, goal contains the number of images to be processed
+    as well as the filter type to be used.  Each image gets processed
+    and extracts a list of possible 2d sample coordinates and the
+    corresponding countours.  The point with the largest contour is
+    then projected to 3d and transformed to the base_link frame. Only
+    the largest point will be sent back as a result and the outlined
+    contour and corresponding 2d point on the original image is
+    republished.
+    '''
+    # Reset our member variables
     self.largest_area = -1.0
     self.best_sample_location = None
     self.sample_location_image = None
     self.uv = None
 
-    #checking if we have enough images to process and if our goal is greater than 0
+    # Check if we have enough images to process and if our goal is greater than 0.
     if len(self.image_history) > 0 and goal.num_images > 0:
       if goal.num_images > len(self.image_history):
-        rospy.logwarn("Goal is larger than total images recorded, only %s images will be processed.", str(len(self.image_history)))
+        rospy.logwarn("Goal is larger than total images recorded, only %s images will be processed.",
+                      str(len(self.image_history)))
 
-      #we take a subset of length goal.num_images of the images in image history for  processing
+      # Take a subset of length goal.num_images of the images in image
+      # history for processing.
       subset = self.image_history[-goal.num_images:]
       for i in subset:
-        #get our list of pixel coordinates then get the corresponding 3d point with the largest contour
-        sample_points_2d, contour_areas, cv_image = self.identify_sample_spots(i[0], goal.filter_type)
-        sample_point_3d, sample_point_area, uv = self.get_3d_sample_point(i[1], sample_points_2d, contour_areas)
-        #save the 3d point info with the largest contour area
+        # Get list of pixel coordinates then get the corresponding 3d
+        # point with the largest contour.
+        sample_points_2d, contour_areas, cv_image = self.identify_sample_spots(i[0],
+                                                                               goal.filter_type)
+        sample_point_3d, sample_point_area, uv = self.get_3d_sample_point(i[1],
+                                                                          sample_points_2d,
+                                                                          contour_areas)
+        # Save the 3d point info with the largest contour area
         if sample_point_3d is not None and sample_point_area > self.largest_area:
           self.largest_area = sample_point_area
           self.best_sample_location = sample_point_3d
@@ -86,75 +103,89 @@ class IdentifySampleLocation:
       # If succesful we return our point, otherwise we return an empty list.
       if self.best_sample_location == None:
         rospy.loginfo("identify_sample_location.py: location rejected.")
-        self.sample_location_action_server.set_succeeded(IdentifyLocationResult(success=False, sample_location=None))
+        self.sample_location_action_server.set_succeeded(IdentifyLocationResult(success=False,
+                                                                                sample_location=None))
       else:
         # Publish the modified image showing our sample location choice.
         self.publish_chosen_location_image()
         self.visualize_sample_point(self.best_sample_location)
-        self.sample_location_action_server.set_succeeded(IdentifyLocationResult(success=True, sample_location=self.best_sample_location ))
+        self.sample_location_action_server.set_succeeded(IdentifyLocationResult(success=True,
+                                                                                sample_location=self.best_sample_location))
 
     else:
       rospy.loginfo("identify_sample_location.py: No images have been recorded.")
-      self.sample_location_action_server.set_succeeded(IdentifyLocationResult(success=False, sample_location=None))
-
+      self.sample_location_action_server.set_succeeded(IdentifyLocationResult(success=False,
+                                                                              sample_location=None))
 
   def site_imaging_callback(self, rect_img_msg, points2_msg):
-    '''Synchronizes the pointcloud and the rectified image topic and saves them as a tuple to the image_history list.
-    Starts to delete old messages at a length of 50.'''
-    #get both messages and save them to our image history for later processing
+    '''
+    Synchronizes the pointcloud and the rectified image topic and saves
+    them as a tuple to the image_history list.  Starts to delete old
+    messages at a length of 50.
+    '''
+    # Get both messages and save them to our image history for later processing.
     self.image_history.append((rect_img_msg, points2_msg))
 
-    #prevent our image history from getting too large saves most recent HISTORY_MAX_LENGTH images
+    # Prevent our image history from getting too large saves most
+    # recent HISTORY_MAX_LENGTH images.
     if len(self.image_history) > self.HISTORY_MAX_LENGTH:
       self.image_history = self.image_history[-self.HISTORY_MAX_LENGTH:]
 
   def publish_chosen_location_image(self):
-    '''Publishes the original image with our drawn on contours and chosen sample location. 
-    Used to visualize the chosen sample point.'''
-    #draws a circle where our chosen sample location is located
+    '''
+    Publishes the original image with our drawn on contours and chosen
+    sample location.  Used to visualize the chosen sample point.
+
+    '''
+    # Draw a circle where our chosen sample location is located.
     cv.circle(self.sample_location_image, self.uv, 7, (0,255,0),-1)
-    #converts back to a ros image msg before publishing
+    # Convert back to a ros image msg before publishing.
     try:
       image = self.bridge.cv2_to_imgmsg(self.sample_location_image, "bgr8")
     except CvBridgeError as err:
       rospy.logerror("CV Bridge error: {0}".format(err))
-      return
+      return None, None, None
     self.publish_photo.publish(image)
 
-
   def identify_sample_spots(self, location_image, filter_type):
-    '''Uses OpenCv to process the given image. For filter type Brown we isolate a range of brown colors 
-    on the image and draw the contours. For Dark filter (the default filter) we isolate the darkest spots 
-    in the image (usually shadows) and find the countours. The 2d center location is taken for these contours
-    and are sorted in descending order, we then draw/store the largest 5 contours/center points to return.'''
+    '''
+    Uses OpenCv to process the given image. For filter type Brown we
+    isolate a range of brown colors on the image and draw the
+    contours. For Dark filter (the default filter) we isolate the
+    darkest spots in the image (usually shadows) and find the
+    countours. The 2d center location is taken for these contours and
+    are sorted in descending order, we then draw/store the largest 5
+    contours/center points to return.
+    '''
     try:
       image = self.bridge.imgmsg_to_cv2(location_image, "bgr8")
     except CvBridgeError as err:
       rospy.logerror("CV Bridge error: {0}".format(err))
       return None, None, None
 
-    #defaults to Dark Spot if argument doesnt match or none is given
+    # Defaults to Dark Spot if argument doesn't match or none is given.
     if filter_type.lower() == "brown":
-     #filtering brown spots on image
+     # Filter brown spots on image
       hsv = cv.cvtColor(image, cv.COLOR_BGR2HSV)
       lower = np.array([0,16,32])
       upper = np.array([19,255,255])
       thresh = cv.inRange(hsv, lower, upper)
     elif filter_type.lower() == "dark":
-      #filtering dark spots on image
+      # Filter dark spots on image
       gray = cv.cvtColor(image, cv.COLOR_BGR2GRAY)
       ret, thresh = cv.threshold(gray, 15, 255,cv.THRESH_BINARY_INV)
     else:
       rospy.logerror("Unknown/Unsupported filter type specified!")
       return None, None, None
 
-    #find contours and sort them largest to smallest
+    # Find contours and sort them largest to smallest.
     contours, _ = cv.findContours(thresh, cv.RETR_TREE, cv.CHAIN_APPROX_SIMPLE)
     contours.sort(reverse=True, key=cv.contourArea)
     sample_points_2d = []
     contour_areas = []
 
-    #draw all contours over a certain size; 5000 seems good for now, only taking the largest 5
+    # Draw all contours over a certain size; 5000 seems good for now,
+    # only taking the largest 5.
     for i in contours:
       area = cv.contourArea(i)
       if area >= 5000 and area <= 1000000:
@@ -169,16 +200,19 @@ class IdentifySampleLocation:
 
     return sample_points_2d, contour_areas, image
 
-
   def get_3d_sample_point(self, point_cloud, sample_points_2d, contour_areas):
-    '''Given a list of 2d points we find the corresponding 3d point within the pointcloud. 
-    Takes the first valid point (largest contour with valid point) and transforms it into the
-    base_link frame. Returns the new 3d sample point, its corresponding contour and the original
-    2d location on the image.'''
+    '''
+    Given a list of 2d points we find the corresponding 3d point within
+    the pointcloud.  Takes the first valid point (largest contour with
+    valid point) and transforms it into the base_link frame. Returns
+    the new 3d sample point, its corresponding contour and the
+    original 2d location on the image.
+    '''
     if sample_points_2d:
       site_coordinate = None
       index = 0
-      #finds corresponding 3d point in point cloud from 2d pixel point takes the largest (first valid) point
+      # Find corresponding 3d point in point cloud from 2d pixel point
+      # takes the largest (first valid) point.
       for i in sensor_msgs.point_cloud2.read_points(point_cloud, uvs=sample_points_2d):
         if np.isnan(i[0]) or np.isnan(i[1]) or np.isnan(i[2]):
           #recording the index so that we can also get the corresponding contour
@@ -186,13 +220,14 @@ class IdentifySampleLocation:
         else:
           site_coordinate = (i[0], i[1], i[2])
           break
-      #making sure our site_coordinate is not none
+      # Make sure our site_coordinate is not none.
       if site_coordinate == None:
         return None, None, None
     else:
       return None, None, None
 
-    #create a point stamped message in current frame for transformation to base_link frame
+    # Create a point stamped message in current frame for
+    # transformation to base_link frame.
     identified_location = PointStamped()
     identified_location.header.frame_id = "StereoCameraLeft_optical_frame"
     identified_location.header.stamp = rospy.Time()
@@ -201,22 +236,27 @@ class IdentifySampleLocation:
     identified_location.point.z = site_coordinate[2]
 
     try:
-      #wait for listener then transform point to base_link frame
-      self.listener.waitForTransform("StereoCameraLeft_optical_frame", "base_link", rospy.Time.now(), rospy.Duration(5))
-      transformed_location = self.listener.transformPoint("base_link", identified_location)
-    except (tf.LookupException, tf.ConnectivityException, tf.ExtrapolationException):
+      # Wait for listener then transform point to base_link frame.
+      self.listener.waitForTransform("StereoCameraLeft_optical_frame",
+                                     "base_link",
+                                     rospy.Time.now(),
+                                     rospy.Duration(5))
+      transformed_location = self.listener.transformPoint("base_link",
+                                                          identified_location)
+    except (tf.LookupException,
+            tf.ConnectivityException,
+            tf.ExtrapolationException):
       rospy.loginfo("Could not transform point to base_link frame")
       return None, None, None
-
     
     sample_point = Point()
     sample_point = transformed_location.point
-    #returns our sample point, its contour and the original uv of the point
+    # Return our sample point, its contour and the original uv of the point.
     return sample_point, contour_areas[index], sample_points_2d[index]
 
   def visualize_sample_point(self, sample_point):
     '''Publishes a marker showing the location of our sample point'''
-    #header and action info
+    # Header and action info
     visualized_point = Marker()
     visualized_point.id = 0
     visualized_point.header.frame_id = 'base_link'
@@ -224,7 +264,7 @@ class IdentifySampleLocation:
     visualized_point.type = visualized_point.SPHERE
     visualized_point.action = visualized_point.ADD
 
-    #scaling and color
+    # Scaling and color
     visualized_point.scale.x = 0.1
     visualized_point.scale.y = 0.1
     visualized_point.scale.z = 0.1
@@ -233,14 +273,13 @@ class IdentifySampleLocation:
     visualized_point.color.b = 0.0
     visualized_point.color.a = 1.0
 
-    #point location
+    # Point location
     visualized_point.pose.position.x = sample_point.x
     visualized_point.pose.position.y = sample_point.y
     visualized_point.pose.position.z = sample_point.z
 
     # Add the marker, and publish it out.
     self.point_visualization_publisher.publish(visualized_point)
-
 
 if __name__ == '__main__':
   rospy.init_node('test_node', argv=sys.argv)

--- a/ow_plexil/scripts/identify_sample_location.py
+++ b/ow_plexil/scripts/identify_sample_location.py
@@ -83,18 +83,18 @@ class IdentifySampleLocation:
           self.sample_location_image = cv_image
           self.uv = uv
 
-      #if succesful we return our point, otherwise we return an empty list
+      # If succesful we return our point, otherwise we return an empty list.
       if self.best_sample_location == None:
-        rospy.loginfo("Could not find valid sample location")
+        rospy.loginfo("identify_sample_location.py: location rejected.")
         self.sample_location_action_server.set_succeeded(IdentifyLocationResult(success=False, sample_location=None))
       else:
-        #publishes the modified image showing our sample location choice
+        # Publish the modified image showing our sample location choice.
         self.publish_chosen_location_image()
         self.visualize_sample_point(self.best_sample_location)
         self.sample_location_action_server.set_succeeded(IdentifyLocationResult(success=True, sample_location=self.best_sample_location ))
 
     else:
-      rospy.loginfo("No images have been recorded")
+      rospy.loginfo("identify_sample_location.py: No images have been recorded.")
       self.sample_location_action_server.set_succeeded(IdentifyLocationResult(success=False, sample_location=None))
 
 

--- a/ow_plexil/scripts/identify_sample_location.py
+++ b/ow_plexil/scripts/identify_sample_location.py
@@ -14,37 +14,39 @@ from cv_bridge import CvBridge, CvBridgeError
 from sensor_msgs.msg import Image, PointCloud2
 from geometry_msgs.msg import PointStamped, Point
 import sensor_msgs.point_cloud2
-from ow_plexil.msg import IdentifyLocationAction, IdentifyLocationGoal, IdentifyLocationFeedback, IdentifyLocationResult
+from ow_plexil.msg import IdentifyLocationAction, IdentifyLocationResult
 from visualization_msgs.msg import Marker 
 import message_filters
-from collections import deque
 
 class IdentifySampleLocation:
-  # Constant defining the maximum length of our image history deque.
+
+  # Constant defining the maximum length of our image history list.
   HISTORY_MAX_LENGTH = 50
 
   def __init__(self):
 
     # Set up synchronized subscribers for image_rect and point cloud.
-    rectified_image_subscriber = message_filters.Subscriber("/StereoCamera/left/image_rect_color",
-                                                            Image)
-    point_cloud_subscriber = message_filters.Subscriber("/StereoCamera/points2", PointCloud2)
-    time_synchronizer = message_filters.TimeSynchronizer([rectified_image_subscriber,
-                                                          point_cloud_subscriber], 10)
+    rectified_image_subscriber = message_filters.Subscriber(
+      "/StereoCamera/left/image_rect_color", Image)
+    point_cloud_subscriber = message_filters.Subscriber(
+      "/StereoCamera/points2", PointCloud2)
+    time_synchronizer = message_filters.TimeSynchronizer(
+      [rectified_image_subscriber, point_cloud_subscriber], 10)
     time_synchronizer.registerCallback(self.site_imaging_callback)
 
-    # Publish modified opencv image with the contours and sample location outlined.
-    self.publish_photo = rospy.Publisher('sample_location', Image, queue_size=10)
+    # Publish modified image with the contours and sample location outlined.
+    self.publish_photo = rospy.Publisher(
+      'sample_location', Image, queue_size=10)
 
     # Point visualization
-    self.point_visualization_publisher = rospy.Publisher('sample_point_visualization',
-                                                         Marker, queue_size=10)
+    self.point_visualization_publisher = rospy.Publisher(
+      'sample_point_visualization', Marker, queue_size=10)
 
     # Action server setup
-    self.sample_location_action_server = actionlib.SimpleActionServer("IdentifySampleLocation",
-                                                                      IdentifyLocationAction,
-                                                                      self.sample_location_callback,
-                                                                      False)
+    self.sample_location_action_server = actionlib.SimpleActionServer(
+      "IdentifySampleLocation", IdentifyLocationAction,
+      self.sample_location_callback, False
+    )
     self.sample_location_action_server.start()
 
     # Listener and CvBridge
@@ -60,8 +62,7 @@ class IdentifySampleLocation:
 
 
   def sample_location_callback(self, goal):
-    '''
-    Action Server, goal contains the number of images to be processed
+    '''Action Server, goal contains the number of images to be processed
     as well as the filter type to be used.  Each image gets processed
     and extracts a list of possible 2d sample coordinates and the
     corresponding countours.  The point with the largest contour is
@@ -76,11 +77,11 @@ class IdentifySampleLocation:
     self.sample_location_image = None
     self.uv = None
 
-    # Check if we have enough images to process and if our goal is greater than 0.
+    # Check if we have enough images to process and if goal is positive.
     if len(self.image_history) > 0 and goal.num_images > 0:
       if goal.num_images > len(self.image_history):
-        rospy.logwarn("Goal is larger than total images recorded, only %s images will be processed.",
-                      str(len(self.image_history)))
+        rospy.logwarn("Goal is larger than total images recorded, only "
+                      f"{len(self.image_history)} images will be processed.")
 
       # Take a subset of length goal.num_images of the images in image
       # history for processing.
@@ -88,13 +89,13 @@ class IdentifySampleLocation:
       for i in subset:
         # Get list of pixel coordinates then get the corresponding 3d
         # point with the largest contour.
-        sample_points_2d, contour_areas, cv_image = self.identify_sample_spots(i[0],
-                                                                               goal.filter_type)
-        sample_point_3d, sample_point_area, uv = self.get_3d_sample_point(i[1],
-                                                                          sample_points_2d,
-                                                                          contour_areas)
+        sample_points_2d, contour_areas, cv_image = self.identify_sample_spots(
+          i[0], goal.filter_type)
+        sample_point_3d, sample_point_area, uv = self.get_3d_sample_point(
+          i[1], sample_points_2d, contour_areas)
         # Save the 3d point info with the largest contour area
-        if sample_point_3d is not None and sample_point_area > self.largest_area:
+        if (sample_point_3d is not None
+            and sample_point_area > self.largest_area):
           self.largest_area = sample_point_area
           self.best_sample_location = sample_point_3d
           self.sample_location_image = cv_image
@@ -103,23 +104,24 @@ class IdentifySampleLocation:
       # If succesful we return our point, otherwise we return an empty list.
       if self.best_sample_location == None:
         rospy.loginfo("identify_sample_location.py: location rejected.")
-        self.sample_location_action_server.set_succeeded(IdentifyLocationResult(success=False,
-                                                                                sample_location=None))
+        self.sample_location_action_server.set_succeeded(
+          IdentifyLocationResult(success=False, sample_location=None))
       else:
         # Publish the modified image showing our sample location choice.
         self.publish_chosen_location_image()
         self.visualize_sample_point(self.best_sample_location)
-        self.sample_location_action_server.set_succeeded(IdentifyLocationResult(success=True,
-                                                                                sample_location=self.best_sample_location))
+        self.sample_location_action_server.set_succeeded(
+          IdentifyLocationResult(success=True,
+                                 sample_location=self.best_sample_location)
+        )
 
     else:
-      rospy.loginfo("identify_sample_location.py: No images have been recorded.")
-      self.sample_location_action_server.set_succeeded(IdentifyLocationResult(success=False,
-                                                                              sample_location=None))
+      rospy.loginfo("identify_sample_location.py: No images recorded.")
+      self.sample_location_action_server.set_succeeded(
+        IdentifyLocationResult(success=False, sample_location=None))
 
   def site_imaging_callback(self, rect_img_msg, points2_msg):
-    '''
-    Synchronizes the pointcloud and the rectified image topic and saves
+    '''Synchronizes the pointcloud and the rectified image topic and saves
     them as a tuple to the image_history list.  Starts to delete old
     messages at a length of 50.
     '''
@@ -132,10 +134,8 @@ class IdentifySampleLocation:
       self.image_history = self.image_history[-self.HISTORY_MAX_LENGTH:]
 
   def publish_chosen_location_image(self):
-    '''
-    Publishes the original image with our drawn on contours and chosen
+    '''Publishes the original image with our drawn on contours and chosen
     sample location.  Used to visualize the chosen sample point.
-
     '''
     # Draw a circle where our chosen sample location is located.
     cv.circle(self.sample_location_image, self.uv, 7, (0,255,0),-1)
@@ -148,12 +148,11 @@ class IdentifySampleLocation:
     self.publish_photo.publish(image)
 
   def identify_sample_spots(self, location_image, filter_type):
-    '''
-    Uses OpenCv to process the given image. For filter type Brown we
+    '''Uses OpenCv to process the given image. For filter type Brown we
     isolate a range of brown colors on the image and draw the
     contours. For Dark filter (the default filter) we isolate the
     darkest spots in the image (usually shadows) and find the
-    countours. The 2d center location is taken for these contours and
+    contours. The 2D center location is taken for these contours and
     are sorted in descending order, we then draw/store the largest 5
     contours/center points to return.
     '''
@@ -201,19 +200,19 @@ class IdentifySampleLocation:
     return sample_points_2d, contour_areas, image
 
   def get_3d_sample_point(self, point_cloud, sample_points_2d, contour_areas):
-    '''
-    Given a list of 2d points we find the corresponding 3d point within
-    the pointcloud.  Takes the first valid point (largest contour with
+    '''Given a list of 2D points we find the corresponding 3D point within
+    the point cloud. Takes the first valid point (largest contour with
     valid point) and transforms it into the base_link frame. Returns
-    the new 3d sample point, its corresponding contour and the
-    original 2d location on the image.
+    the new 3D sample point, its corresponding contour and the
+    original 2D location on the image.
     '''
     if sample_points_2d:
       site_coordinate = None
       index = 0
       # Find corresponding 3d point in point cloud from 2d pixel point
       # takes the largest (first valid) point.
-      for i in sensor_msgs.point_cloud2.read_points(point_cloud, uvs=sample_points_2d):
+      for i in sensor_msgs.point_cloud2.read_points(point_cloud,
+                                                    uvs=sample_points_2d):
         if np.isnan(i[0]) or np.isnan(i[1]) or np.isnan(i[2]):
           #recording the index so that we can also get the corresponding contour
           index+=1

--- a/ow_plexil/src/plans/EuropaMission.plp
+++ b/ow_plexil/src/plans/EuropaMission.plp
@@ -169,11 +169,13 @@ EuropaMission: Concurrence
                                         Parallel = parallel,
                                         FilterType = "Dark");
 
-      if (! Lookup(GroundFound)) {
-        // Note that the default value of GroundFound is false, so
-        log_error ("Failed to find ground. Stowing arm and stopping.");
-        LibraryCall SafeStow();
-        MissionInProgress = false;
+      if (! isKnown(ground_pos)) {
+        log_warning ("Sampling location could not be found visually. ",
+                     "Using default dig location.");
+        ground_pos = -0.18;
+        trench_x = 1.77;
+        trench_y = -0.08;
+        parallel = true;
       }
 
       DigAndImage: Concurrence {

--- a/ow_plexil/src/plans/IdentifySampleTarget.plp
+++ b/ow_plexil/src/plans/IdentifySampleTarget.plp
@@ -18,8 +18,8 @@ IdentifySampleTarget:
   InOut Boolean Parallel;
   In String FilterType;
   Real result[3];
-  Real start_pan = 60;
-  Real pan_limit = 90;
+  Real start_pan = 70;
+  Real pan_limit = 80;
   Real tilt = 50;
   Real tilt_limit = 30;
   Real delta = 5;

--- a/ow_plexil/src/plans/IdentifySampleTarget.plp
+++ b/ow_plexil/src/plans/IdentifySampleTarget.plp
@@ -18,19 +18,33 @@ IdentifySampleTarget:
   InOut Boolean Parallel;
   In String FilterType;
   Real result[3];
-  Real c_pan = 70;
-  Real c_tilt = 50;
+  Real start_pan = 60;
+  Real pan_limit = 90;
+  Real tilt = 50;
+  Real tilt_limit = 30;
   Real delta = 5;
   Post Lookup (GroundFound);
 
   // Take pictures in front of the lander for processing in
   // identify_sample_location.
 
-  LibraryCall Tilt(Degrees = c_tilt);
-  LibraryCall PanAndShoot(PanAngle = c_pan - delta);
-  LibraryCall PanAndShoot(PanAngle = c_pan);
-  LibraryCall PanAndShoot(PanAngle = c_pan + delta);
-  SynchronousCommand result = identify_sample_location(3, FilterType);
+  while (tilt >= tilt_limit &&
+         (!isKnown(result[0]) ||
+          !isKnown(result[1]) ||
+          !isKnown(result[2]))) {
+    Real pan;
+    pan = start_pan;
+    LibraryCall Tilt(Degrees = tilt);
+    tilt = tilt - delta;
+    while (pan <= pan_limit &&
+           (!isKnown(result[0]) ||
+            !isKnown(result[1]) ||
+            !isKnown(result[2]))) {
+      LibraryCall PanAndShoot(PanAngle = pan);
+      pan = pan + delta;
+      SynchronousCommand result = identify_sample_location(3, FilterType);
+    }
+  }
 
   if (isKnown(result[0]) && isKnown(result[1]) && isKnown(result[2])) {
     // Guarded move is an attempt to find the ground position.  The chosen start
@@ -40,17 +54,17 @@ IdentifySampleTarget:
                              DirX = 0, DirY = 0, DirZ = 1,
                              SearchDistance = 0.5);
 
-    //check for ground position
+    // Check for ground position.
     if (Lookup (GroundFound)) GroundPos = Lookup (GroundPosition);
     else log_error ("IdentifySampleTarget: GuardedMove failed to find ground.");
     endif;
 
-    // The chosen X/Y sampling location, as well as choice for Parallel trench
+    // The chosen X/Y sampling location, as well as choice for Parallel trench.
     X = result[0];
     Y = result[1];
     Parallel = true;  // arbitrary for now
   }
-  else log_error ("IdentifySampleTarget: failed to find one.");
+  else log_warning ("IdentifySampleTarget: failed to find a suitable sample target.");
   endif;
 
 }

--- a/ow_plexil/src/plans/ReferenceMission1.plp
+++ b/ow_plexil/src/plans/ReferenceMission1.plp
@@ -82,36 +82,38 @@ ReferenceMission1: Concurrence
                                       GroundPos = ground_pos,
                                       Parallel = parallel,
                                       FilterType = "Dark");
-    if (isKnown(ground_pos)) {
-      LibraryCall ArmUnstow();
-      LibraryCall DigTrench (X = trench_x,
-                             Y = trench_y,
-                             GroundPos = ground_pos,
-                             Length = trench_length,
-                             BiteDepth = 0.03,
-                             NumPasses = 2,
-                             Parallel = parallel);
-      LibraryCall RemoveTailings (X = trench_x,
-                                  Y = trench_y,
-                                  GroundPos = ground_pos,
-                                  Parallel = parallel);
-      LibraryCall CollectSample (X = trench_x,
-                                 Y = trench_y,
-                                 GroundPos = ground_pos,
-                                 Depth = 0.1105,
-                                 Length = trench_length,
-                                 Parallel = parallel);
-      LibraryCall SafeStow();
-      LibraryCall DockIngestSample();
-      LibraryCall StartSampleAnalysis;
-      Wait 2;  // Wait for (stubbed) sample analysis to finish.
+    if (! isKnown(ground_pos)) {
+      log_warning ("Sampling location could not be found visually. ",
+                   "Using default dig location.");
+      ground_pos = -0.18;
+      trench_x = 1.77;
+      trench_y = -0.08;
+      parallel = true;
     }
-    else
-    {
-      log_error ("Mission aborted because a sampling location was not found.");
-    }
-    endif
-    MissionInProgress = false;
-    log_info ("Reference Mission 1, Sol 0 complete.");
+    endif;
+    LibraryCall ArmUnstow();
+    LibraryCall DigTrench (X = trench_x,
+                           Y = trench_y,
+                           GroundPos = ground_pos,
+                           Length = trench_length,
+                           BiteDepth = 0.03,
+                           NumPasses = 2,
+                           Parallel = parallel);
+    LibraryCall RemoveTailings (X = trench_x,
+                                Y = trench_y,
+                                GroundPos = ground_pos,
+                                Parallel = parallel);
+    LibraryCall CollectSample (X = trench_x,
+                               Y = trench_y,
+                               GroundPos = ground_pos,
+                               Depth = 0.1105,
+                               Length = trench_length,
+                               Parallel = parallel);
+    LibraryCall SafeStow();
+    LibraryCall DockIngestSample();
+    LibraryCall StartSampleAnalysis;
+    Wait 2;  // Wait for (stubbed) sample analysis to finish.
   }
+  MissionInProgress = false;
+  log_info ("Reference Mission 1, Sol 0 complete.");
 }

--- a/ow_plexil/src/plans/ReferenceMission2.plp
+++ b/ow_plexil/src/plans/ReferenceMission2.plp
@@ -116,69 +116,72 @@ ReferenceMission2: Concurrence
                                         Parallel = parallel,
                                         FilterType = "Dark");
     }
-    if (Lookup(GroundFound)) {
-      Unstow:
-      {
-        Start BatteryOK && NoFaults;
-        log_info ("Unstowing Arm");
-        LibraryCall ArmUnstow;
-      }
 
-      Dig:
-      {
-        Start BatteryOK && NoFaults;
-        log_info ("Digging Trench");
-        LibraryCall DigTrench (X = trench_x,
-                               Y = trench_y,
-                               GroundPos = ground_pos,
-                               Length = trench_length,
-                               BiteDepth = 0.03,
-                               NumPasses = 2,
-                               Parallel = parallel);
-      }
-      Clear:
-      {
-        Start BatteryOK && NoFaults;
-        log_info ("Removing Tailings");
-        LibraryCall RemoveTailings (X = trench_x,
-                                    Y = trench_y,
-                                    GroundPos = ground_pos,
-                                    Parallel = parallel);
-      }
-      Collect:
-      {
-        Start BatteryOK && NoFaults;
-        log_info ("Collecting Sample");
-        LibraryCall CollectSample (X = trench_x,
-                                   Y = trench_y,
-                                   GroundPos = ground_pos,
-                                   Depth = 0.1105,
-                                   Length = trench_length,
-                                   Parallel = parallel);
-      }
-      Stow:
-      {
-        Start BatteryOK && NoFaults;
-        log_info ("Stowing Arm");
-        LibraryCall SafeStow();
-      }
-      Analyze:
-      {
-        Start BatteryOK && NoFaults;
-        log_info ("Analyzing Sample");
-        LibraryCall StartSampleAnalysis;
-      }
+    if (! isKnown(ground_pos)) {
+      log_warning ("Sampling location could not be found visually. ",
+                   "Using default dig location.");
+      ground_pos = -0.18;
+      trench_x = 1.77;
+      trench_y = -0.08;
+      parallel = true;
     }
-    else {
-     log_error ("Failed to find ground, aborting.");
-     FailStow:
-     {
-       Start BatteryOK && NoFaults;
-       log_info ("Stowing Arm");
-       LibraryCall SafeStow();
-     }
+
+    Unstow:
+    {
+      Start BatteryOK && NoFaults;
+      log_info ("Unstowing Arm");
+      LibraryCall ArmUnstow;
     }
-    endif;
+
+    Dig:
+    {
+      Start BatteryOK && NoFaults;
+      log_info ("Digging Trench");
+      LibraryCall DigTrench (X = trench_x,
+                             Y = trench_y,
+                             GroundPos = ground_pos,
+                             Length = trench_length,
+                             BiteDepth = 0.03,
+                             NumPasses = 2,
+                             Parallel = parallel);
+    }
+    
+    Clear:
+    {
+      Start BatteryOK && NoFaults;
+      log_info ("Removing Tailings");
+      LibraryCall RemoveTailings (X = trench_x,
+                                  Y = trench_y,
+                                  GroundPos = ground_pos,
+                                  Parallel = parallel);
+    }
+    
+    Collect:
+    {
+      Start BatteryOK && NoFaults;
+      log_info ("Collecting Sample");
+      LibraryCall CollectSample (X = trench_x,
+                                 Y = trench_y,
+                                 GroundPos = ground_pos,
+                                 Depth = 0.1105,
+                                 Length = trench_length,
+                                 Parallel = parallel);
+    }
+    
+    Stow:
+    {
+      Start BatteryOK && NoFaults;
+      log_info ("Stowing Arm");
+      LibraryCall SafeStow();
+    }
+    
+    Analyze:
+    {
+      Start BatteryOK && NoFaults;
+      log_info ("Analyzing Sample");
+      LibraryCall StartSampleAnalysis;
+    }
+
     log_info ("ReferenceMission2 plan complete.");
     MissionInProgress = false;
   }

--- a/ow_plexil/src/plans/RemoveTailings.plp
+++ b/ow_plexil/src/plans/RemoveTailings.plp
@@ -16,7 +16,7 @@ RemoveTailings:
 
   // NOTE: These values selected only to save time during testing, as each pass
   // takes several minutes.
-  Real bite_depth = 0.05;
+  Real bite_depth = 0.03;
   Integer num_passes = 2;
 
   for (Integer pass = 1; pass <= num_passes; pass + 1) {

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -219,11 +219,8 @@ static void identify_sample_location_done_cb
     SamplePoint.push_back(result->sample_location.x);
     SamplePoint.push_back(result->sample_location.y);
     SamplePoint.push_back(result->sample_location.z);
-    ROS_INFO ("Possible sample location identified at (%f, %f, %f)",
+    ROS_INFO ("Candidate sample location identified at (%f, %f, %f)",
            SamplePoint[0], SamplePoint[1], SamplePoint[2]);
-  }
-  else{
-    ROS_ERROR("Could not get sample point from IdentifySampleLocation");
   }
   GotSampleLocation = true;
 }


### PR DESCRIPTION
### Summary
- This work supports the same branch's PRs in ow_simulator and ow_europa and should be merged when they are.  However, the improvements are independent of those PRs and work in noetic-devel, so this could be merged by itself.   There are also a few extra improvements.
 - An actual search for a suitable sample target is performed, instead of using a pre-chosen point.
 - Because the current image search parameters fail to find a suitable target, a default one is used.  Hence, ReferenceMission1 always does a sampling attempt.
 - Unrelated but minor: reduce bite depth to 0.3 in RemoveTailings to lower the risks of excessive force on the scoop that resulted from recent work.
 - Misc/minor: Python script always returns 3 values explicitly.  Many lines were shortened.  (And many are still quite long).  Comments were cleaned up.

### Test

Run ReferenceMission1 twice, using two different branches of ow_simulator and ow_europa: the feature branch and noetic-devel.

In both branches, it will do a longer scan of the workspace, which includes pans and tilts.  Using noetic-devel, a target location is found quickly.  Using the feature branch, a target location is not found and these warnings appear:
```
 [ WARN]: PLEXIL: IdentifySampleTarget: failed to find a suitable sample target.
[ WARN]: PLEXIL: Sampling location could not be found visually. Using default dig location.
```
In both branches, the plan completes the sampling operation as it did before.