### PR TITLE
OCEANWATER-1238 Expanded Lookup interface to faults

### DIFF
--- a/ow_plexil/src/plans/FaultHandlingPattern1.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern1.plp
@@ -25,8 +25,8 @@ FaultHandlingPattern1:
 
     OnePan:
     {
-      Start !Lookup(AntennaPanFault);
-      Invariant !Lookup(AntennaPanFault);
+      Start !Lookup(AntennaPanError);
+      Invariant !Lookup(AntennaPanError);
 
       NewAngle = (Lookup(PanDegrees) + 15) mod 360;
       if (NewAngle > 180) NewAngle = NewAngle - 360;

--- a/ow_plexil/src/plans/FaultHandlingPattern2.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern2.plp
@@ -33,8 +33,8 @@ FaultHandlingPattern2:
 
       Pan:
       {
-        Start !Lookup(AntennaPanFault);
-        Invariant !Lookup(AntennaPanFault);
+        Start !Lookup(AntennaPanError);
+        Invariant !Lookup(AntennaPanError);
 
         NewAngle = (Lookup(PanDegrees) + 15) mod 360;
         if (NewAngle > 180) NewAngle = NewAngle - 360;

--- a/ow_plexil/src/plans/FaultHandlingPattern3.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern3.plp
@@ -33,8 +33,8 @@ FaultHandlingPattern3: UncheckedSequence
 
   PanAntenna:
   {
-    Start !Lookup(AntennaPanFault);
-    Invariant !Lookup(AntennaPanFault);
+    Start !Lookup(AntennaPanError);
+    Invariant !Lookup(AntennaPanError);
 
     LibraryCall Pan (Degrees=180);
   }

--- a/ow_plexil/src/plans/Pan.plp
+++ b/ow_plexil/src/plans/Pan.plp
@@ -12,9 +12,9 @@ Pan:
 
   Boolean FaultDetected = false;
 
-  PostCondition !Lookup(AntennaPanFault);
+  PostCondition !Lookup(AntennaPanError);
 
-  if Lookup(AntennaPanFault)
+  if Lookup(AntennaPanError)
   {
     log_error ("Command pan not sent to lander due to active antenna fault(s).");
     FaultDetected = true;
@@ -22,7 +22,7 @@ Pan:
 
   SendPan:
   {
-    Start !Lookup(AntennaPanFault);
+    Start !Lookup(AntennaPanError);
 
     if FaultDetected
     {

--- a/ow_plexil/src/plans/TestFaults.plp
+++ b/ow_plexil/src/plans/TestFaults.plp
@@ -16,10 +16,10 @@ TestFaults:
     if (Lookup(AntennaFault)) log_warning ("Antenna fault present.");
     else log_info ("Antenna is fine.");
 
-    if (Lookup(AntennaPanFault)) log_warning ("Pan fault present.");
+    if (Lookup(AntennaPanError)) log_warning ("Pan fault present.");
     else log_info ("Pan is fine.");
 
-    if (Lookup(AntennaTiltFault)) log_warning ("Tilt fault present.");
+    if (Lookup(AntennaTiltError)) log_warning ("Tilt fault present.");
     else log_info ("Tilt is fine.");
 
     Wait (2);

--- a/ow_plexil/src/plans/TestFaults.plp
+++ b/ow_plexil/src/plans/TestFaults.plp
@@ -13,14 +13,75 @@ TestFaults:
   {
     Repeat true;
 
+    log_info ("Polling for faults...");
+
+    // System
+
+    if (Lookup(SystemFault)) log_warning ("System fault present.");
+
+    // Antenna
+
     if (Lookup(AntennaFault)) log_warning ("Antenna fault present.");
-    else log_info ("Antenna is fine.");
 
-    if (Lookup(AntennaPanError)) log_warning ("Pan fault present.");
-    else log_info ("Pan is fine.");
+    if (Lookup(AntennaPanError)) log_warning ("Pan error present.");
 
-    if (Lookup(AntennaTiltError)) log_warning ("Tilt fault present.");
-    else log_info ("Tilt is fine.");
+    if (Lookup(AntennaTiltError)) log_warning ("Tilt error present.");
+
+    // Arm
+
+    if (Lookup(ArmFault)) log_warning ("Arm fault present.");
+
+    if (Lookup(ArmGoalError)) log_warning ("Arm goal error present.");
+
+    if (Lookup(ArmExecutionError)) log_warning ("Arm execution error present.");
+
+    if (Lookup(ArmHardwareError)) log_warning ("Arm hardware error present.");
+
+    if (Lookup(TrajectoryError)) log_warning ("Trajectory error present.");
+
+    if (Lookup(CollisionError)) log_warning ("Collision error present.");
+
+    // Task
+
+    if (Lookup(TaskGoalError)) log_warning ("Task goal error present.");
+
+    // Camera
+
+    if (Lookup(CameraFault)) log_warning ("Camera fault present.");
+
+    if (Lookup(CameraGoalError)) log_warning ("Camera goal error present.");
+
+    if (Lookup(CameraExecutionError)) {
+      log_warning ("Camera execution error present.");
+    }
+
+    if (Lookup(NoImageError)) log_warning ("No-Image error present.");
+
+    // Power
+
+    if (Lookup(PowerFault)) log_warning ("Power fault present.");
+
+    if (Lookup(PowerExecutionError)) {
+      log_warning ("Power execution error present.");
+    }
+
+    if (Lookup(LowStateOfChargeError)) {
+      log_warning ("Low State of Charge error present.");
+    }
+
+    if (Lookup(InstantaneousCapacityLossError)) {
+      log_warning ("Instantaneous Capacity Loss Error error present.");
+    }
+
+    if (Lookup(ThermalError)) log_warning ("Thermal error present.");
+
+    // Misc
+
+    if (Lookup(MiscSystemError)) {
+      log_warning ("Misc system error present.");
+    }
+    else log_info ("No misc system error.");
+    endif;
 
     Wait (2);
   }

--- a/ow_plexil/src/plans/TestFaults.plp
+++ b/ow_plexil/src/plans/TestFaults.plp
@@ -22,24 +22,27 @@ TestFaults:
     // Antenna
 
     if (Lookup(AntennaFault)) log_warning ("Antenna fault present.");
-
     if (Lookup(AntennaPanError)) log_warning ("Pan error present.");
-
     if (Lookup(AntennaTiltError)) log_warning ("Tilt error present.");
 
     // Arm
 
     if (Lookup(ArmFault)) log_warning ("Arm fault present.");
-
     if (Lookup(ArmGoalError)) log_warning ("Arm goal error present.");
-
     if (Lookup(ArmExecutionError)) log_warning ("Arm execution error present.");
-
     if (Lookup(ArmHardwareError)) log_warning ("Arm hardware error present.");
-
     if (Lookup(TrajectoryError)) log_warning ("Trajectory error present.");
-
     if (Lookup(CollisionError)) log_warning ("Collision error present.");
+    if (Lookup(EmergencyStopError)) log_warning ("Emergency Stop error present.");
+    if (Lookup(PositionLimitError)) log_warning ("Position Limit error present.");
+    if (Lookup(JointTorqueLimitError)) {
+      log_warning ("Joint Torque Limit error present.");
+    }
+    if (Lookup(VelocityLimitError)) log_warning ("Velocity Limit error present.");
+    if (Lookup(NoForceDataError)) log_warning ("No Force Data error present.");
+    if (Lookup(ForceTorqueLimitError)) {
+      log_warning ("Force Torque Limit error present.");
+    }
 
     // Task
 
@@ -48,9 +51,7 @@ TestFaults:
     // Camera
 
     if (Lookup(CameraFault)) log_warning ("Camera fault present.");
-
     if (Lookup(CameraGoalError)) log_warning ("Camera goal error present.");
-
     if (Lookup(CameraExecutionError)) {
       log_warning ("Camera execution error present.");
     }
@@ -60,28 +61,20 @@ TestFaults:
     // Power
 
     if (Lookup(PowerFault)) log_warning ("Power fault present.");
-
     if (Lookup(PowerExecutionError)) {
       log_warning ("Power execution error present.");
     }
-
     if (Lookup(LowStateOfChargeError)) {
       log_warning ("Low State of Charge error present.");
     }
-
     if (Lookup(InstantaneousCapacityLossError)) {
       log_warning ("Instantaneous Capacity Loss Error error present.");
     }
-
     if (Lookup(ThermalError)) log_warning ("Thermal error present.");
 
     // Misc
 
-    if (Lookup(MiscSystemError)) {
-      log_warning ("Misc system error present.");
-    }
-    else log_info ("No misc system error.");
-    endif;
+    if (Lookup(MiscSystemError)) log_warning ("Misc system error present.");
 
     Wait (2);
   }

--- a/ow_plexil/src/plans/TestOwFaults.plp
+++ b/ow_plexil/src/plans/TestOwFaults.plp
@@ -1,0 +1,32 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// This plan sequentially calls every fault Lookup available in
+// OceanWATERS sim, in a repeating loop.
+
+#include "ow-interface.h"
+LibraryAction TestCommonFaults();
+
+TestOwFaults:
+{
+  log_info ("Inject faults and observe messages. ",
+            "Type Control-C to exit plan and exec node.");
+
+  TestLoop:
+  {
+    Repeat true;
+
+    log_info ("Polling for faults...");
+
+    LibraryCall TestCommonFaults();
+
+    // OceanWATERS-specific faults
+
+    if (Lookup(PowerExecutionError)) {
+      log_warning ("Power execution error present.");
+    }
+
+    Wait (2);
+  }
+}

--- a/ow_plexil/src/plans/Tilt.plp
+++ b/ow_plexil/src/plans/Tilt.plp
@@ -12,9 +12,9 @@ Tilt:
 
   Boolean FaultDetected = false;
 
-  PostCondition !Lookup(AntennaTiltFault);
+  PostCondition !Lookup(AntennaTiltError);
 
-  if Lookup(AntennaTiltFault)
+  if Lookup(AntennaTiltError)
   {
     log_error ("Command tilt not sent to lander due to active antenna fault(s).");
     FaultDetected = true;
@@ -22,7 +22,7 @@ Tilt:
 
   SendTilt:
   {
-    Start !Lookup(AntennaTiltFault);
+    Start !Lookup(AntennaTiltError);
 
     if FaultDetected
     {

--- a/ow_plexil/src/plans/common/TestCommonFaults.plp
+++ b/ow_plexil/src/plans/common/TestCommonFaults.plp
@@ -2,19 +2,18 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-#include "ow-interface.h"
+// This plan sequentially calls every fault lookup common to
+// OceanWATERS and OWLAT.  It is intended to be used as a library call
+// in ../TestOwFaults.plp and ../owlat/TestOwlatFaults.plp, which
+// invoke this plan in a loop to which testbed-specific fault Lookups
+// are added.
 
-TestFaults:
+#include "common-interface.h"
+
+TestCommonFaults:
 {
-  log_info ("Inject faults and observe messages. ",
-            "Type Control-C to exit plan and exec node.");
-
-  TestLoop:
+  Tests:
   {
-    Repeat true;
-
-    log_info ("Polling for faults...");
-
     // System
 
     if (Lookup(SystemFault)) log_warning ("System fault present.");
@@ -61,9 +60,6 @@ TestFaults:
     // Power
 
     if (Lookup(PowerFault)) log_warning ("Power fault present.");
-    if (Lookup(PowerExecutionError)) {
-      log_warning ("Power execution error present.");
-    }
     if (Lookup(LowStateOfChargeError)) {
       log_warning ("Low State of Charge error present.");
     }
@@ -75,7 +71,5 @@ TestFaults:
     // Misc
 
     if (Lookup(MiscSystemError)) log_warning ("Misc system error present.");
-
-    Wait (2);
   }
 }

--- a/ow_plexil/src/plans/common/TestCommonFaults.plp
+++ b/ow_plexil/src/plans/common/TestCommonFaults.plp
@@ -21,6 +21,10 @@ TestCommonFaults:
     // Antenna
 
     if (Lookup(AntennaFault)) log_warning ("Antenna fault present.");
+    if (Lookup(PanTiltGoalError)) log_warning ("Pan/Tilt goal error present.");
+    if (Lookup(PanTiltExecutionError)) {
+      log_warning ("Pan/Tilt execution error present.");
+    }
     if (Lookup(AntennaPanError)) log_warning ("Pan error present.");
     if (Lookup(AntennaTiltError)) log_warning ("Tilt error present.");
 
@@ -54,7 +58,6 @@ TestCommonFaults:
     if (Lookup(CameraExecutionError)) {
       log_warning ("Camera execution error present.");
     }
-
     if (Lookup(NoImageError)) log_warning ("No-Image error present.");
 
     // Power

--- a/ow_plexil/src/plans/common/common-interface.h
+++ b/ow_plexil/src/plans/common/common-interface.h
@@ -127,6 +127,16 @@ Boolean Lookup ArmFault;
 Boolean Lookup PowerFault;
 Boolean Lookup CameraFault;
 
+// Specific faults for system
+Boolean Lookup ArmGoalError;
+Boolean Lookup ArmExecutionError;
+Boolean Lookup TaskGoalError;
+Boolean Lookup CameraGoalError;
+Boolean Lookup CameraExecutionError;
+Boolean Lookup PanTiltGoalError;
+Boolean Lookup PanTiltExecutionError;
+Boolean Lookup MiscSystemError;
+
 // Specific faults for antenna
 Boolean Lookup AntennaPanError;
 Boolean Lookup AntennaTiltError;

--- a/ow_plexil/src/plans/common/common-interface.h
+++ b/ow_plexil/src/plans/common/common-interface.h
@@ -93,31 +93,62 @@ LibraryAction TaskDiscardSample (In Integer Frame,
 LibraryAction SafeStow();
 
 
-// Lander queries and telemetry
+///////////////////////// Lander queries and telemetry /////////////////////////
 
-// Antenna
+// Antenna state
 Real Lookup PanRadians;
 Real Lookup PanDegrees;
 Real Lookup TiltRadians;
 Real Lookup TiltDegrees;
 
-// Arm Joints
+// Arm Joint state
 Real Lookup ArmJointAcceleration (Integer joint);
 Real Lookup ArmJointVelocity     (Integer joint);
 Real Lookup ArmJointPosition     (Integer joint);
 Real Lookup ArmJointTorque       (Integer joint);
 
-// Battery
+// Battery state
 Real Lookup BatteryStateOfCharge;
 Real Lookup BatteryRemainingUsefulLife;
 Real Lookup BatteryTemperature;
 
-// Misc
-
+// Misc queries
 Real[6] Lookup ArmEndEffectorForceTorque;
 Real[7] Lookup ArmPose;
 Boolean Lookup UsingOceanWATERS;
 Boolean Lookup UsingOWLAT;
+
+// Faults
+
+// General faults: queries if there are *any* faults in these subsystems.
+Boolean Lookup SystemFault;
+Boolean Lookup AntennaFault;
+Boolean Lookup ArmFault;
+Boolean Lookup PowerFault;
+Boolean Lookup CameraFault;
+
+// Specific faults for antenna
+Boolean Lookup AntennaPanError;
+Boolean Lookup AntennaTiltError;
+
+// Specific faults for camera
+Boolean Lookup NoImageError;
+
+// Specific faults for power
+Boolean Lookup LowStateOfChargeError;
+Boolean Lookup InstantaneousCapacityLossError;
+Boolean Lookup ThermalError;
+
+// Specific faults for arm
+Boolean Lookup ArmHardwareError;
+Boolean Lookup TrajectoryError;
+Boolean Lookup CollisionError;
+Boolean Lookup EmergencyStopError;
+Boolean Lookup PositionLimitError;
+Boolean Lookup JointTorqueLimitError;
+Boolean Lookup VelocityLimitError;
+Boolean Lookup NoForceDataError;
+Boolean Lookup ForceTorqueLimitError;
 
 // Query whether a given operation is running.  Uses the operation names as
 // defined in OwInterface.cpp.  Generally not needed, but supports more

--- a/ow_plexil/src/plans/ow-interface.h
+++ b/ow_plexil/src/plans/ow-interface.h
@@ -89,17 +89,24 @@ Boolean Lookup HardTorqueLimitReached (String joint_name);
 Boolean Lookup SoftTorqueLimitReached (String joint_name);
 
 // Faults
+
 // Returns first 10 faults in a given subsystem, specifying "System" will give you all faults
 String [10] Lookup ActiveFaults(String subsystem_name);
+
 Boolean Lookup IsOperable(String subsystem_name);
 Boolean Lookup IsFaulty(String subsystem_name);
-Boolean Lookup SystemFault;
-Boolean Lookup AntennaFault;
-Boolean Lookup AntennaPanFault;
-Boolean Lookup AntennaTiltFault;
-Boolean Lookup ArmFault;
-Boolean Lookup PowerFault;
-Boolean Lookup CameraFault;
+
+
+// OceanWATERS-specific system faults
+Boolean Lookup ArmGoalError;
+Boolean Lookup ArmExecutionError;
+Boolean Lookup TaskGoalError;
+Boolean Lookup CameraGoalError;
+Boolean Lookup CameraExecutionError;
+Boolean Lookup PanTiltGoalError;
+Boolean Lookup PanTiltExecutionError;
+Boolean Lookup PowerExecutionError;
+Boolean Lookup MiscSystemError; // fault not covered by any of the above
 
 // Relevant with GuardedMove only:
 Boolean Lookup GroundFound;

--- a/ow_plexil/src/plans/ow-interface.h
+++ b/ow_plexil/src/plans/ow-interface.h
@@ -98,15 +98,7 @@ Boolean Lookup IsOperable(String subsystem_name);
 Boolean Lookup IsFaulty(String subsystem_name);
 
 // OceanWATERS-specific system faults
-Boolean Lookup ArmGoalError;
-Boolean Lookup ArmExecutionError;
-Boolean Lookup TaskGoalError;
-Boolean Lookup CameraGoalError;
-Boolean Lookup CameraExecutionError;
-Boolean Lookup PanTiltGoalError;
-Boolean Lookup PanTiltExecutionError;
 Boolean Lookup PowerExecutionError;
-Boolean Lookup MiscSystemError; // for faults not covered explicitly
 
 // Relevant with GuardedMove only:
 Boolean Lookup GroundFound;

--- a/ow_plexil/src/plans/ow-interface.h
+++ b/ow_plexil/src/plans/ow-interface.h
@@ -90,12 +90,12 @@ Boolean Lookup SoftTorqueLimitReached (String joint_name);
 
 // Faults
 
-// Returns first 10 faults in a given subsystem, specifying "System" will give you all faults
+// Returns first 10 faults in a given subsystem.
+// Specifying "System" returns all faults.
 String [10] Lookup ActiveFaults(String subsystem_name);
 
 Boolean Lookup IsOperable(String subsystem_name);
 Boolean Lookup IsFaulty(String subsystem_name);
-
 
 // OceanWATERS-specific system faults
 Boolean Lookup ArmGoalError;
@@ -106,7 +106,7 @@ Boolean Lookup CameraExecutionError;
 Boolean Lookup PanTiltGoalError;
 Boolean Lookup PanTiltExecutionError;
 Boolean Lookup PowerExecutionError;
-Boolean Lookup MiscSystemError; // fault not covered by any of the above
+Boolean Lookup MiscSystemError; // for faults not covered explicitly
 
 // Relevant with GuardedMove only:
 Boolean Lookup GroundFound;

--- a/ow_plexil/src/plans/owlat/TestOwlatFaults.plp
+++ b/ow_plexil/src/plans/owlat/TestOwlatFaults.plp
@@ -1,0 +1,42 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// This plan sequentially calls every fault Lookup available in OWLAT
+// sim, in a repeating loop.  Note that there isn't a way to inject
+// faults in OWLAT sim, so you should only see the "Polling for
+// faults..." message.
+
+#include "owlat-interface.h"
+LibraryAction TestCommonFaults();
+
+TestOwlatFaults:
+{
+  log_info ("Inject faults and observe messages. ",
+            "Type Control-C to exit plan and exec node.");
+
+  TestLoop:
+  {
+    Repeat true;
+
+    log_info ("Polling for faults...");
+
+    LibraryCall TestCommonFaults();
+
+    // OWLAT-specific faults
+
+    if (Lookup(DrillGoalError)) {
+      log_warning ("Drill goal error present.");
+    }
+
+    if (Lookup(DrillExecutionError)) {
+      log_warning ("Drill execution error present.");
+    }
+
+    if (Lookup(LanderExecutionError)) {
+      log_warning ("Lander execution error present.");
+    }
+
+    Wait (2);
+  }
+}

--- a/ow_plexil/src/plans/owlat/owlat-interface.h
+++ b/ow_plexil/src/plans/owlat/owlat-interface.h
@@ -94,17 +94,10 @@ Real Lookup PSPStopReason;
 Real Lookup ShearBevameterStopReason;
 
 // OWLAT-specific system faults
-Boolean Lookup ArmGoalError;
-Boolean Lookup ArmExecutionError;
-Boolean Lookup TaskGoalError;
-Boolean Lookup CameraGoalError;
-Boolean Lookup CameraExecutionError;
-Boolean Lookup PanTiltGoalError;
-Boolean Lookup PanTiltExecutionError;
 Boolean Lookup DrillGoalError;
 Boolean Lookup DrillExecutionError;
 Boolean Lookup LanderExecutionError; // fault in Stewart platform
-Boolean Lookup MiscSystemError; // fault not covered by any of the above
+
 
 
 #endif

--- a/ow_plexil/src/plans/owlat/owlat-interface.h
+++ b/ow_plexil/src/plans/owlat/owlat-interface.h
@@ -2,7 +2,7 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// PLEXIL interface to lander that is OWLAT-specific.
+// OWLAT-specific PLEXIL interface (commands, lookups) and definitions.
 
 #ifndef Owlat_Plan_Interface_H
 #define Owlat_Plan_Interface_H
@@ -81,7 +81,7 @@ LibraryAction TaskPenetrometer (In Integer Frame,
                                 In Real MaxDepth,
                                 In Real MaxForce);
 
-// Telemetry
+////// Telemetry
 
 Real Lookup ArmJointAngles;
 Real Lookup ArmJointAccelerations;
@@ -92,5 +92,19 @@ Real Lookup ArmFTForce;
 Integer Lookup ArmTool;
 Real Lookup PSPStopReason;
 Real Lookup ShearBevameterStopReason;
+
+// OWLAT-specific system faults
+Boolean Lookup ArmGoalError;
+Boolean Lookup ArmExecutionError;
+Boolean Lookup TaskGoalError;
+Boolean Lookup CameraGoalError;
+Boolean Lookup CameraExecutionError;
+Boolean Lookup PanTiltGoalError;
+Boolean Lookup PanTiltExecutionError;
+Boolean Lookup DrillGoalError;
+Boolean Lookup DrillExecutionError;
+Boolean Lookup LanderExecutionError; // fault in Stewart platform
+Boolean Lookup MiscSystemError; // fault not covered by any of the above
+
 
 #endif

--- a/ow_plexil/src/plexil-adapter/LanderAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/LanderAdapter.cpp
@@ -364,7 +364,6 @@ bool LanderAdapter::initialize (AdapterConfiguration* config)
                                         battery_rul);
   config->registerLookupHandlerFunction("BatteryTemperature", battery_temp);
   config->registerLookupHandlerFunction("ActionGoalStatus", action_goal_status);
-  config->setDefaultLookupHandler(default_lookup_handler);
 
   // General faults
   config->registerLookupHandlerFunction("AntennaFault",
@@ -393,8 +392,60 @@ bool LanderAdapter::initialize (AdapterConfiguration* config)
 					lookupHandler_function0<>
                                         (*s_interface,
                                          &LanderInterface::antennaTiltError));
+  config->registerLookupHandlerFunction("NoImageError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::noImageError));
+  config->registerLookupHandlerFunction("LowStateOfChargeError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::lowStateOfChargeError));
+  config->registerLookupHandlerFunction("InstantaneousCapacityLossError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::instantaneousCapacityLossError));
+  config->registerLookupHandlerFunction("ThermalError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::thermalError));
+  config->registerLookupHandlerFunction("ArmHardwareError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::armHardwareError));
+  config->registerLookupHandlerFunction("TrajectoryError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::trajectoryError));
+  config->registerLookupHandlerFunction("CollisionError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::collisionError));
+  config->registerLookupHandlerFunction("EmergencyStopError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::eStopError));
+  config->registerLookupHandlerFunction("PositionLimitError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::positionLimitError));
+  config->registerLookupHandlerFunction("JointTorqueLimitError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::jointTorqueLimitError));
+  config->registerLookupHandlerFunction("VelocityLimitError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::velocityLimitError));
+  config->registerLookupHandlerFunction("NoForceDataError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::noForceDataError));
+  config->registerLookupHandlerFunction("ForceTorqueLimitError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::forceTorqueLimitError));
 
-
+  config->setDefaultLookupHandler(default_lookup_handler);
   debugMsg("LanderAdapter", " initialized.");
   return PlexilAdapter::initialize (config);
 }

--- a/ow_plexil/src/plexil-adapter/LanderAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/LanderAdapter.cpp
@@ -366,6 +366,35 @@ bool LanderAdapter::initialize (AdapterConfiguration* config)
   config->registerLookupHandlerFunction("ActionGoalStatus", action_goal_status);
   config->setDefaultLookupHandler(default_lookup_handler);
 
+  // General faults
+  config->registerLookupHandlerFunction("AntennaFault",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::antennaFault));
+  config->registerLookupHandlerFunction("ArmFault",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::armFault));
+  config->registerLookupHandlerFunction("PowerFault",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::powerFault));
+  config->registerLookupHandlerFunction("CameraFault",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::cameraFault));
+
+  // Specific faults
+  config->registerLookupHandlerFunction("AntennaPanError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::antennaPanError));
+  config->registerLookupHandlerFunction("AntennaTiltError",
+					lookupHandler_function0<>
+                                        (*s_interface,
+                                         &LanderInterface::antennaTiltError));
+
+
   debugMsg("LanderAdapter", " initialized.");
   return PlexilAdapter::initialize (config);
 }

--- a/ow_plexil/src/plexil-adapter/LanderInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/LanderInterface.cpp
@@ -342,7 +342,7 @@ bool LanderInterface::lowStateOfChargeError () const
 
 bool LanderInterface::instantaneousCapacityLossError () const
 {
-  return m_powerErrors.at("InstantaneousCapaciyLossError").second;
+  return m_powerErrors.at("InstantaneousCapacityLossError").second;
 }
 
 bool LanderInterface::thermalError () const

--- a/ow_plexil/src/plexil-adapter/LanderInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/LanderInterface.cpp
@@ -301,17 +301,17 @@ void LanderInterface::armPoseCb (const owl_msgs::ArmPose::ConstPtr& msg)
 
 bool LanderInterface::antennaFault () const
 {
-  return antennaPanFault() || antennaTiltFault();
+  return antennaPanError() || antennaTiltError();
 }
 
-bool LanderInterface::antennaPanFault () const
+bool LanderInterface::antennaPanError () const
 {
-  return m_panTiltErrors.at("AntennaPanFault").second;
+  return m_panTiltErrors.at("AntennaPanError").second;
 }
 
-bool LanderInterface::antennaTiltFault () const
+bool LanderInterface::antennaTiltError () const
 {
-  return m_panTiltErrors.at("AntennaTiltFault").second;
+  return m_panTiltErrors.at("AntennaTiltError").second;
 }
 
 bool LanderInterface::armFault () const

--- a/ow_plexil/src/plexil-adapter/LanderInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/LanderInterface.cpp
@@ -299,6 +299,22 @@ void LanderInterface::armPoseCb (const owl_msgs::ArmPose::ConstPtr& msg)
 
 ////////////////////// Fault support ///////////////////////////////////////
 
+
+bool LanderInterface::armFault () const
+{
+  return faultActive (m_armErrors);
+}
+
+bool LanderInterface::powerFault () const
+{
+  return faultActive (m_powerErrors);
+}
+
+bool LanderInterface::cameraFault () const
+{
+  return faultActive (m_cameraErrors);
+}
+
 bool LanderInterface::antennaFault () const
 {
   return antennaPanError() || antennaTiltError();
@@ -314,19 +330,69 @@ bool LanderInterface::antennaTiltError () const
   return m_panTiltErrors.at("AntennaTiltError").second;
 }
 
-bool LanderInterface::armFault () const
+bool LanderInterface::noImageError () const
 {
-  return faultActive (m_armErrors);
+  return m_cameraErrors.at("NoImageError").second;
 }
 
-bool LanderInterface::powerFault () const
+bool LanderInterface::lowStateOfChargeError () const
 {
-  return faultActive (m_powerErrors);
+  return m_powerErrors.at("LowStateOfChargeError").second;
 }
 
-bool LanderInterface::cameraFault () const
+bool LanderInterface::instantaneousCapacityLossError () const
 {
-  return faultActive (m_cameraErrors);
+  return m_powerErrors.at("InstantaneousCapaciyLossError").second;
+}
+
+bool LanderInterface::thermalError () const
+{
+  return m_powerErrors.at("ThermalError").second;
+}
+
+bool LanderInterface::armHardwareError () const
+{
+  return m_armErrors.at("ArmHardwareError").second;
+}
+
+bool LanderInterface::trajectoryError () const
+{
+  return m_armErrors.at("TrajectoryError").second;
+}
+
+bool LanderInterface::collisionError () const
+{
+  return m_armErrors.at("CollisionError").second;
+}
+
+bool LanderInterface::eStopError () const
+{
+  return m_armErrors.at("EmergencyStopError").second;
+}
+
+bool LanderInterface::positionLimitError () const
+{
+  return m_armErrors.at("PositionLimitError").second;
+}
+
+bool LanderInterface::jointTorqueLimitError () const
+{
+  return m_armErrors.at("JointTorqueLimitError").second;
+}
+
+bool LanderInterface::velocityLimitError () const
+{
+  return m_armErrors.at("VelocityLimitError").second;
+}
+
+bool LanderInterface::noForceDataError () const
+{
+  return m_armErrors.at("NoForceDataError").second;
+}
+
+bool LanderInterface::forceTorqueLimitError () const
+{
+  return m_armErrors.at("ForceTorqueLimitError").second;
 }
 
 

--- a/ow_plexil/src/plexil-adapter/LanderInterface.h
+++ b/ow_plexil/src/plexil-adapter/LanderInterface.h
@@ -81,11 +81,16 @@ using PanTiltMoveJointsActionClient =
 using CameraCaptureActionClient =
   actionlib::SimpleActionClient<owl_msgs::CameraCaptureAction>;
 
-// Maps from specific fault names to the pair:
+// FaultMap: maps from "specific fault" names to the pair:
 //    <fault value, fault active?>.
-// PLEXIL can support Lookups on the specific fault name.  In Release
-// 12, only AntennaPanFault and AntennaTiltFault are supported.
-
+//
+// Specific faults are suffixed "Error" to distinguish them from
+// "general" faults such as ArmFault (which signifies the presence of
+// any of the arm-related specific faults).  PLEXIL can support
+// Lookups on the specific fault name, simply by providing a Lookup
+// declaration.  The specific faults not supported by the simulator
+// are currently not declared or accessible in a PLEXIL plan.
+//
 using FaultMap = std::map<std::string,std::pair<uint64_t, bool>>;
 
 class LanderInterface : public PlexilInterface
@@ -137,8 +142,8 @@ class LanderInterface : public PlexilInterface
   void cameraCapture (int id);
   virtual bool systemFault () const = 0;
   bool antennaFault () const;
-  bool antennaPanFault () const;
-  bool antennaTiltFault () const;
+  bool antennaPanError () const;
+  bool antennaTiltError () const;
   bool armFault () const;
   bool powerFault () const;
   bool cameraFault () const;
@@ -212,47 +217,50 @@ class LanderInterface : public PlexilInterface
   void armPoseCb (const owl_msgs::ArmPose::ConstPtr&);
   void panTiltCb (const owl_msgs::PanTiltPosition::ConstPtr&);
 
+  // See detailed explanation of FaultMap above.
+
   FaultMap m_armErrors = {
-    {"HARDWARE", std::make_pair(
+    {"ArmHardwareError", std::make_pair(
         owl_msgs::ArmFaultsStatus::HARDWARE, false)},
-    {"TRAJECTORY_GENERATION", std::make_pair(
+    {"TrajectoryError", std::make_pair(
         owl_msgs::ArmFaultsStatus::TRAJECTORY_GENERATION, false)},
-    {"COLLISION", std::make_pair(
+    {"CollisionError", std::make_pair(
         owl_msgs::ArmFaultsStatus::COLLISION, false)},
-    {"E_STOP", std::make_pair(
+    {"EmergencyStopError", std::make_pair(
         owl_msgs::ArmFaultsStatus::E_STOP, false)},
-    {"POSITION_LIMIT", std::make_pair(
+    {"PositionLimitError", std::make_pair(
         owl_msgs::ArmFaultsStatus::POSITION_LIMIT, false)},
-    {"JOINT_TORQUE_LIMIT", std::make_pair(
+    {"JointTorqueLimitError", std::make_pair(
         owl_msgs::ArmFaultsStatus::JOINT_TORQUE_LIMIT, false)},
-    {"VELOCITY_LIMIT", std::make_pair(
+    {"VelocityLimitError", std::make_pair(
         owl_msgs::ArmFaultsStatus::VELOCITY_LIMIT, false)},
-    {"NO_FORCE_DATA", std::make_pair(
+    {"NoForceDataError", std::make_pair(
         owl_msgs::ArmFaultsStatus::NO_FORCE_DATA, false)},
-    {"FORCE_TORQUE_LIMIT", std::make_pair(
+    {"ForceTorqueLimitError", std::make_pair(
         owl_msgs::ArmFaultsStatus::FORCE_TORQUE_LIMIT, false)},
   };
 
-  FaultMap m_powerErrors = {
-    {"LOW_STATE_OF_CHARGE", std::make_pair(
+  FaultMap m_powerErrors =
+  {
+    {"LowStateOfChargeError", std::make_pair(
         owl_msgs::PowerFaultsStatus::LOW_STATE_OF_CHARGE, false)},
-    {"INSTANTANEOUS_CAPACITY_LOSS", std::make_pair(
+    {"InstantaneousCapacityLossError", std::make_pair(
         owl_msgs::PowerFaultsStatus::INSTANTANEOUS_CAPACITY_LOSS, false)},
-    {"THERMAL_FAULT", std::make_pair(
+    {"ThermalError", std::make_pair(
         owl_msgs::PowerFaultsStatus::THERMAL_FAULT, false)}
   };
 
   FaultMap m_panTiltErrors =
     {
-     {"AntennaPanFault",
+     {"AntennaPanError",
       std::make_pair(owl_msgs::PanTiltFaultsStatus::PAN_JOINT_LOCKED, false)},
-     {"AntennaTiltFault",
+     {"AntennaTiltError",
       std::make_pair(owl_msgs::PanTiltFaultsStatus::TILT_JOINT_LOCKED, false)}
     };
 
   FaultMap m_cameraErrors =
     {
-     {"NO_IMAGE",
+     {"NoImageError",
       std::make_pair(owl_msgs::CameraFaultsStatus::NO_IMAGE, false)}
     };
 

--- a/ow_plexil/src/plexil-adapter/LanderInterface.h
+++ b/ow_plexil/src/plexil-adapter/LanderInterface.h
@@ -140,13 +140,28 @@ class LanderInterface : public PlexilInterface
   void taskDeliverSample (int id);
   void panTiltMoveJoints (double pan_degrees, double tilt_degrees, int id);
   void cameraCapture (int id);
+
+  // Support for fault-related Lookups
   virtual bool systemFault () const = 0;
   bool antennaFault () const;
-  bool antennaPanError () const;
-  bool antennaTiltError () const;
   bool armFault () const;
   bool powerFault () const;
   bool cameraFault () const;
+  bool antennaPanError () const;
+  bool antennaTiltError () const;
+  bool noImageError () const;
+  bool lowStateOfChargeError () const;
+  bool instantaneousCapacityLossError () const;
+  bool thermalError () const;
+  bool armHardwareError () const;
+  bool trajectoryError () const;
+  bool collisionError () const;
+  bool eStopError () const;
+  bool positionLimitError () const;
+  bool jointTorqueLimitError () const;
+  bool velocityLimitError () const;
+  bool noForceDataError () const;
+  bool forceTorqueLimitError () const;
 
   // Telemetry
   virtual std::vector<double> getArmEndEffectorFT () const = 0;

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -394,11 +394,53 @@ bool OwAdapter::initialize (AdapterConfiguration* config)
                                         (*OwInterface::instance(),
                                          &OwInterface::getArmEndEffectorFT));
 
-  // Faults specific to OceanWATERS
+  // System faults specific to OceanWATERS
   config->registerLookupHandlerFunction("SystemFault",
 					lookupHandler_function0<>
                                         (*OwInterface::instance(),
                                          &OwInterface::systemFault));
+  config->registerLookupHandlerFunction("ArmGoalError",
+					lookupHandler_function0<>
+                                        (*OwInterface::instance(),
+                                         &OwInterface::armGoalError));
+  config->registerLookupHandlerFunction("ArmExecutionError",
+					lookupHandler_function0<>
+                                        (*OwInterface::instance(),
+                                         &OwInterface::armExecutionError));
+  config->registerLookupHandlerFunction("TaskGoalError",
+					lookupHandler_function0<>
+                                        (*OwInterface::instance(),
+                                         &OwInterface::taskGoalError));
+  config->registerLookupHandlerFunction("CameraGoalError",
+					lookupHandler_function0<>
+                                        (*OwInterface::instance(),
+                                         &OwInterface::cameraGoalError));
+  config->registerLookupHandlerFunction("CameraExecutionError",
+					lookupHandler_function0<>
+                                        (*OwInterface::instance(),
+                                         &OwInterface::cameraExecutionError));
+  config->registerLookupHandlerFunction("PanTiltGoalError",
+					lookupHandler_function0<>
+                                        (*OwInterface::instance(),
+                                         &OwInterface::panTiltGoalError));
+  config->registerLookupHandlerFunction("PanTiltExecutionError",
+					lookupHandler_function0<>
+                                        (*OwInterface::instance(),
+                                         &OwInterface::panTiltExecutionError));
+  config->registerLookupHandlerFunction("PowerExecutionError",
+					lookupHandler_function0<>
+                                        (*OwInterface::instance(),
+                                         &OwInterface::powerExecutionError));
+  config->registerLookupHandlerFunction("MiscSystemError",
+					lookupHandler_function0<>
+                                        (*OwInterface::instance(),
+                                         &OwInterface::miscSystemError));
+
+
+
+
+
+
   debugMsg("OwAdapter", " initialized.");
   return LanderAdapter::initialize (config);
 }

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -399,30 +399,6 @@ bool OwAdapter::initialize (AdapterConfiguration* config)
 					lookupHandler_function0<>
                                         (*OwInterface::instance(),
                                          &OwInterface::systemFault));
-  config->registerLookupHandlerFunction("AntennaFault",
-					lookupHandler_function0<>
-                                        (*OwInterface::instance(),
-                                         &LanderInterface::antennaFault));
-  config->registerLookupHandlerFunction("AntennaPanFault",
-					lookupHandler_function0<>
-                                        (*OwInterface::instance(),
-                                         &LanderInterface::antennaPanFault));
-  config->registerLookupHandlerFunction("AntennaTiltFault",
-					lookupHandler_function0<>
-                                        (*OwInterface::instance(),
-                                         &LanderInterface::antennaTiltFault));
-  config->registerLookupHandlerFunction("ArmFault",
-					lookupHandler_function0<>
-                                        (*OwInterface::instance(),
-                                         &LanderInterface::armFault));
-  config->registerLookupHandlerFunction("PowerFault",
-					lookupHandler_function0<>
-                                        (*OwInterface::instance(),
-                                         &LanderInterface::powerFault));
-  config->registerLookupHandlerFunction("CameraFault",
-					lookupHandler_function0<>
-                                        (*OwInterface::instance(),
-                                         &LanderInterface::cameraFault));
   debugMsg("OwAdapter", " initialized.");
   return LanderAdapter::initialize (config);
 }

--- a/ow_plexil/src/plexil-adapter/OwAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwAdapter.cpp
@@ -436,11 +436,6 @@ bool OwAdapter::initialize (AdapterConfiguration* config)
                                         (*OwInterface::instance(),
                                          &OwInterface::miscSystemError));
 
-
-
-
-
-
   debugMsg("OwAdapter", " initialized.");
   return LanderAdapter::initialize (config);
 }

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -949,10 +949,12 @@ bool OwInterface::softTorqueLimitReached (const string& joint_name) const
           JointsAtSoftTorqueLimit.end());
 }
 
-vector<double> OwInterface::getEndEffectorFT () const
+vector<double> OwInterface::getArmEndEffectorFT () const
 {
   return m_end_effector_ft;
 }
+
+// Faults
 
 vector<string> OwInterface::getActiveFaults (const string& subsystem_name) const
 {
@@ -1042,10 +1044,4 @@ bool OwInterface::powerExecutionError () const
 bool OwInterface::miscSystemError () const
 {
   return m_systemErrors.at("MiscSystemError").second;
-}
-
-
-vector<double> OwInterface::getArmEndEffectorFT () const
-{
-  return m_end_effector_ft;
 }

--- a/ow_plexil/src/plexil-adapter/OwInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwInterface.cpp
@@ -999,6 +999,52 @@ bool OwInterface::systemFault () const
   return faultActive (m_systemErrors);
 }
 
+bool OwInterface::armGoalError () const
+{
+  return m_systemErrors.at("ArmGoalError").second;
+}
+
+bool OwInterface::armExecutionError () const
+{
+  return m_systemErrors.at("ArmExecutionError").second;
+}
+
+bool OwInterface::taskGoalError () const
+{
+  return m_systemErrors.at("TaskGoalError").second;
+}
+
+bool OwInterface::cameraGoalError () const
+{
+  return m_systemErrors.at("CameraGoalError").second;
+}
+
+bool OwInterface::cameraExecutionError () const
+{
+  return m_systemErrors.at("CameraExecutionError").second;
+}
+
+bool OwInterface::panTiltGoalError () const
+{
+  return m_systemErrors.at("PanTiltGoalError").second;
+}
+
+bool OwInterface::panTiltExecutionError () const
+{
+  return m_systemErrors.at("PanTiltExecutionError").second;
+}
+
+bool OwInterface::powerExecutionError () const
+{
+  return m_systemErrors.at("PowerExecutionError").second;
+}
+
+bool OwInterface::miscSystemError () const
+{
+  return m_systemErrors.at("MiscSystemError").second;
+}
+
+
 vector<double> OwInterface::getArmEndEffectorFT () const
 {
   return m_end_effector_ft;

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -128,7 +128,7 @@ class OwInterface : public LanderInterface
                             double probability) const;
 
   // State/Lookup interface
-  std::vector<double> getEndEffectorFT () const;
+  std::vector<double> getArmEndEffectorFT () const override;
   bool groundFound () const;
   double groundPosition () const;
   bool hardTorqueLimitReached (const std::string& joint_name) const;
@@ -145,11 +145,9 @@ class OwInterface : public LanderInterface
   bool panTiltExecutionError () const;
   bool powerExecutionError () const;
   bool miscSystemError () const;
-
   std::vector<std::string> getActiveFaults (const std::string& subsystem) const;
   bool   isOperable (const std::string& subsystem_name) const;
   bool   isFaulty (const std::string& subsystem_name) const;
-  std::vector<double> getArmEndEffectorFT () const override;
 
  private:
   void armFindSurfaceAction (int frame, bool relative,
@@ -214,10 +212,10 @@ class OwInterface : public LanderInterface
     {"PowerExecutionError", std::make_pair(
         owl_msgs::SystemFaultsStatus::POWER_EXECUTION_ERROR,false)}
   };
-  
+
   bool m_fault_dependencies_on;
 
-  
+
   // Action clients
 
   std::unique_ptr<ArmFindSurfaceActionClient> m_armFindSurfaceClient;

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -179,25 +179,27 @@ class OwInterface : public LanderInterface
   void ftCallback (const owl_msgs::ArmEndEffectorForceTorque::ConstPtr&);
   void systemFaultMessageCallback (const owl_msgs::SystemFaultsStatus::ConstPtr& msg);
 
-  // System-level faults
+  // See detailed explanation of FaultMap in LanderInterface.h
+  
   FaultMap m_systemErrors = {
-    {"SYSTEM", std::make_pair(
+  {  // The first flag covers faults that don't have their own flag.
+     "MiscSystemError", std::make_pair(
         owl_msgs::SystemFaultsStatus::SYSTEM,false)},
-    {"ARM_GOAL_ERROR", std::make_pair(
+    {"ArmGoalError", std::make_pair(
         owl_msgs::SystemFaultsStatus::ARM_GOAL_ERROR,false)},
-    {"ARM_EXECUTION_ERROR", std::make_pair(
+    {"ArmExecutionError", std::make_pair(
         owl_msgs::SystemFaultsStatus::ARM_EXECUTION_ERROR,false)},
-    {"TASK_GOAL_ERROR", std::make_pair(
+    {"TaskGoalError", std::make_pair(
         owl_msgs::SystemFaultsStatus::TASK_GOAL_ERROR,false)},
-    {"CAMERA_GOAL_ERROR", std::make_pair(
+    {"CameraGoalError", std::make_pair(
         owl_msgs::SystemFaultsStatus::CAMERA_GOAL_ERROR,false)},
-    {"CAMERA_EXECUTION_ERROR", std::make_pair(
+    {"CameraExecutionError", std::make_pair(
         owl_msgs::SystemFaultsStatus::CAMERA_EXECUTION_ERROR,false)},
-    {"PAN_TILT_GOAL_ERROR", std::make_pair(
+    {"PanTiltGoalError", std::make_pair(
         owl_msgs::SystemFaultsStatus::PAN_TILT_GOAL_ERROR,false)},
-    {"PAN_TILT_EXECUTION_ERROR", std::make_pair(
+    {"PanTiltExecutionError", std::make_pair(
         owl_msgs::SystemFaultsStatus::PAN_TILT_EXECUTION_ERROR,false)},
-    {"POWER_EXECUTION_ERROR", std::make_pair(
+    {"PowerExecutionError", std::make_pair(
         owl_msgs::SystemFaultsStatus::POWER_EXECUTION_ERROR,false)}
   };
   bool m_fault_dependencies_on;

--- a/ow_plexil/src/plexil-adapter/OwInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwInterface.h
@@ -129,11 +129,23 @@ class OwInterface : public LanderInterface
 
   // State/Lookup interface
   std::vector<double> getEndEffectorFT () const;
-  bool   groundFound () const;
+  bool groundFound () const;
   double groundPosition () const;
-  bool   hardTorqueLimitReached (const std::string& joint_name) const;
-  bool   softTorqueLimitReached (const std::string& joint_name) const;
-  bool   systemFault () const override;
+  bool hardTorqueLimitReached (const std::string& joint_name) const;
+  bool softTorqueLimitReached (const std::string& joint_name) const;
+
+  // Fault-related Lookup support
+  bool systemFault () const override;
+  bool armGoalError () const;
+  bool armExecutionError () const;
+  bool taskGoalError () const;
+  bool cameraGoalError () const;
+  bool cameraExecutionError () const;
+  bool panTiltGoalError () const;
+  bool panTiltExecutionError () const;
+  bool powerExecutionError () const;
+  bool miscSystemError () const;
+
   std::vector<std::string> getActiveFaults (const std::string& subsystem) const;
   bool   isOperable (const std::string& subsystem_name) const;
   bool   isFaulty (const std::string& subsystem_name) const;
@@ -180,10 +192,10 @@ class OwInterface : public LanderInterface
   void systemFaultMessageCallback (const owl_msgs::SystemFaultsStatus::ConstPtr& msg);
 
   // See detailed explanation of FaultMap in LanderInterface.h
-  
-  FaultMap m_systemErrors = {
-  {  // The first flag covers faults that don't have their own flag.
-     "MiscSystemError", std::make_pair(
+  FaultMap m_systemErrors =
+  {
+    // The first flag covers faults that don't have their own flag.
+    {"MiscSystemError", std::make_pair(
         owl_msgs::SystemFaultsStatus::SYSTEM,false)},
     {"ArmGoalError", std::make_pair(
         owl_msgs::SystemFaultsStatus::ARM_GOAL_ERROR,false)},
@@ -202,8 +214,10 @@ class OwInterface : public LanderInterface
     {"PowerExecutionError", std::make_pair(
         owl_msgs::SystemFaultsStatus::POWER_EXECUTION_ERROR,false)}
   };
+  
   bool m_fault_dependencies_on;
 
+  
   // Action clients
 
   std::unique_ptr<ArmFindSurfaceActionClient> m_armFindSurfaceClient;

--- a/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatAdapter.cpp
@@ -233,6 +233,56 @@ bool OwlatAdapter::initialize (AdapterConfiguration* config)
 					lookupHandler_constant<bool>(false));
   config->registerLookupHandlerFunction("ArmTool", arm_tool);
 
+  // System faults specific to OWLAT
+  config->registerLookupHandlerFunction("SystemFault",
+					lookupHandler_function0<>
+                                        (*OwlatInterface::instance(),
+                                         &OwlatInterface::systemFault));
+  config->registerLookupHandlerFunction("ArmGoalError",
+					lookupHandler_function0<>
+                                        (*OwlatInterface::instance(),
+                                         &OwlatInterface::armGoalError));
+  config->registerLookupHandlerFunction("ArmExecutionError",
+					lookupHandler_function0<>
+                                        (*OwlatInterface::instance(),
+                                         &OwlatInterface::armExecutionError));
+  config->registerLookupHandlerFunction("TaskGoalError",
+					lookupHandler_function0<>
+                                        (*OwlatInterface::instance(),
+                                         &OwlatInterface::taskGoalError));
+  config->registerLookupHandlerFunction("CameraGoalError",
+					lookupHandler_function0<>
+                                        (*OwlatInterface::instance(),
+                                         &OwlatInterface::cameraGoalError));
+  config->registerLookupHandlerFunction("CameraExecutionError",
+					lookupHandler_function0<>
+                                        (*OwlatInterface::instance(),
+                                         &OwlatInterface::cameraExecutionError));
+  config->registerLookupHandlerFunction("PanTiltGoalError",
+					lookupHandler_function0<>
+                                        (*OwlatInterface::instance(),
+                                         &OwlatInterface::panTiltGoalError));
+  config->registerLookupHandlerFunction("PanTiltExecutionError",
+					lookupHandler_function0<>
+                                        (*OwlatInterface::instance(),
+                                         &OwlatInterface::panTiltExecutionError));
+  config->registerLookupHandlerFunction("DrillGoalError",
+					lookupHandler_function0<>
+                                        (*OwlatInterface::instance(),
+                                         &OwlatInterface::drillGoalError));
+  config->registerLookupHandlerFunction("DrillExecutionError",
+					lookupHandler_function0<>
+                                        (*OwlatInterface::instance(),
+                                         &OwlatInterface::drillExecutionError));
+  config->registerLookupHandlerFunction("LanderExecutionError",
+					lookupHandler_function0<>
+                                        (*OwlatInterface::instance(),
+                                         &OwlatInterface::landerExecutionError));
+  config->registerLookupHandlerFunction("MiscSystemError",
+					lookupHandler_function0<>
+                                        (*OwlatInterface::instance(),
+                                         &OwlatInterface::miscSystemError));
+
   debugMsg("OwlatAdapter", " initialized.");
   return LanderAdapter::initialize (config);
 }

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.cpp
@@ -570,12 +570,69 @@ Value OwlatInterface::getArmTool() const
   return(Value(m_arm_tool));
 }
 
+vector<double> OwlatInterface::getArmEndEffectorFT () const
+{
+  return m_end_effector_ft;
+}
+
+// Faults
+
 bool OwlatInterface::systemFault () const
 {
   return faultActive (m_systemErrors);
 }
 
-vector<double> OwlatInterface::getArmEndEffectorFT () const
+bool OwlatInterface::armGoalError () const
 {
-  return m_end_effector_ft;
+  return m_systemErrors.at("ArmGoalError").second;
+}
+
+bool OwlatInterface::armExecutionError () const
+{
+  return m_systemErrors.at("ArmExecutionError").second;
+}
+
+bool OwlatInterface::taskGoalError () const
+{
+  return m_systemErrors.at("TaskGoalError").second;
+}
+
+bool OwlatInterface::cameraGoalError () const
+{
+  return m_systemErrors.at("CameraGoalError").second;
+}
+
+bool OwlatInterface::cameraExecutionError () const
+{
+  return m_systemErrors.at("CameraExecutionError").second;
+}
+
+bool OwlatInterface::panTiltGoalError () const
+{
+  return m_systemErrors.at("PanTiltGoalError").second;
+}
+
+bool OwlatInterface::panTiltExecutionError () const
+{
+  return m_systemErrors.at("PanTiltExecutionError").second;
+}
+
+bool OwlatInterface::drillGoalError () const
+{
+  return m_systemErrors.at("DrillGoalError").second;
+}
+
+bool OwlatInterface::drillExecutionError () const
+{
+  return m_systemErrors.at("DrillExecutionError").second;
+}
+
+bool OwlatInterface::landerExecutionError () const
+{
+  return m_systemErrors.at("LanderExecutionError").second;
+}
+
+bool OwlatInterface::miscSystemError () const
+{
+  return m_systemErrors.at("MiscSystemError").second;
 }

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.h
@@ -177,29 +177,31 @@ class OwlatInterface : public LanderInterface
 
   // Member variables
 
-  // System-level faults:
+  // See detailed explanation of FaultMap in LanderInterface.h
+  
   FaultMap m_systemErrors = {
-    {"SYSTEM", std::make_pair(
+  {  // The first flag covers faults that don't have their own flag.
+   { "MiscSystemError", std::make_pair(
         owl_msgs::SystemFaultsStatus::SYSTEM,false)},
-    {"ARM_GOAL_ERROR", std::make_pair(
+    {"ArmGoalError", std::make_pair(
         owl_msgs::SystemFaultsStatus::ARM_GOAL_ERROR,false)},
-    {"ARM_EXECUTION_ERROR", std::make_pair(
+    {"ArmExecutionError", std::make_pair(
         owl_msgs::SystemFaultsStatus::ARM_EXECUTION_ERROR,false)},
-    {"TASK_GOAL_ERROR", std::make_pair(
+    {"TaskGoalError", std::make_pair(
         owl_msgs::SystemFaultsStatus::TASK_GOAL_ERROR,false)},
-    {"CAMERA_GOAL_ERROR", std::make_pair(
+    {"CameraGoalError", std::make_pair(
         owl_msgs::SystemFaultsStatus::CAMERA_GOAL_ERROR,false)},
-    {"CAMERA_EXECUTION_ERROR", std::make_pair(
+    {"CameraExecutionError", std::make_pair(
         owl_msgs::SystemFaultsStatus::CAMERA_EXECUTION_ERROR,false)},
-    {"PAN_TILT_GOAL_ERROR", std::make_pair(
+    {"PanTiltGoalError", std::make_pair(
         owl_msgs::SystemFaultsStatus::PAN_TILT_GOAL_ERROR,false)},
-    {"PAN_TILT_EXECUTION_ERROR", std::make_pair(
+    {"PanTiltExecutionError", std::make_pair(
         owl_msgs::SystemFaultsStatus::PAN_TILT_EXECUTION_ERROR,false)},
-    {"DRILL_GOAL_ERROR", std::make_pair(
+    {"DrillGoalError", std::make_pair(
         owl_msgs::SystemFaultsStatus::DRILL_GOAL_ERROR,false)},
-    {"DRILL_EXECUTION_ERROR", std::make_pair(
+    {"DrillExecutionError", std::make_pair(
         owl_msgs::SystemFaultsStatus::DRILL_EXECUTION_ERROR,false)},
-    {"LANDER_EXECUTION_ERROR", std::make_pair(
+    {"LanderExecutionError", std::make_pair( // fault in the Stewart platform
         owl_msgs::SystemFaultsStatus::LANDER_EXECUTION_ERROR,false)}
   };
 

--- a/ow_plexil/src/plexil-adapter/OwlatInterface.h
+++ b/ow_plexil/src/plexil-adapter/OwlatInterface.h
@@ -62,6 +62,20 @@ class OwlatInterface : public LanderInterface
 
   void initialize();
 
+  // Fault-related Lookup support
+  bool systemFault () const override;
+  bool armGoalError () const;
+  bool armExecutionError () const;
+  bool taskGoalError () const;
+  bool cameraGoalError () const;
+  bool cameraExecutionError () const;
+  bool panTiltGoalError () const;
+  bool panTiltExecutionError () const;
+  bool drillGoalError () const;
+  bool drillExecutionError () const;
+  bool landerExecutionError () const;
+  bool miscSystemError () const;
+
   // Lander interface
   void armFindSurface (int frame,
                        bool relative,
@@ -111,7 +125,6 @@ class OwlatInterface : public LanderInterface
 
   // Lookups
   PLEXIL::Value getArmTool() const;
-  bool systemFault () const override;
   std::vector<double> getArmEndEffectorFT () const override;
 
  private:
@@ -178,8 +191,8 @@ class OwlatInterface : public LanderInterface
   // Member variables
 
   // See detailed explanation of FaultMap in LanderInterface.h
-  
-  FaultMap m_systemErrors = {
+
+  FaultMap m_systemErrors =
   {  // The first flag covers faults that don't have their own flag.
    { "MiscSystemError", std::make_pair(
         owl_msgs::SystemFaultsStatus::SYSTEM,false)},


### PR DESCRIPTION
## Summary
- Introduces the notion of _general_ and _specific_ faults.  Please see the attached user guide chapters for background.  Specifically, read the new/edited sections "Execution and Goal Errors", "Fault Categories", and "Fault Flags" in the Fault document, and "General and Specific Faults" in Autonomy.  These documents are also found on the `release13-fault-modeling` branch of ow_simulator.wiki`.
- Some of the concepts above are briefly explained in `LanderInterface.h`.  Note that general fault Lookup names end with `Fault`, and specific ones end with `Error`.
- Fleshes out Lookup support for all fault flags defined in the testbeds (OceanWATERS, OWLAT, common).  Some code refactoring was needed to do this cleanly.
- Adds testbed-specific fault Lookup test plans.  Some plan refactoring was needed to do this cleanly.
- Renames `AntennaPanFault` and '`AntennaTiltFault` to `Antenna*Error` everywhere, to follow naming convention for specific faults.
- Unrelated: Removed unused and redundant OwInterface::getEndEffectorFT()

## Test

These instructions are very brief for now.

### OWLAT Test
- Build ow_plexil for OWLAT
- Start OWLAT (3 separate processes)
- Start the OWLAT Exec 
- Execute the plan `TestOwlatFaults`
- Since there is no way to inject faults, you'll just see "Polling for faults..." repeating.
- Ctrl-C in each window to quit.

### OceanWATERS Test
- Build ow_plexil for OceanWATERS
- Start any sim world
- Start the OW Exec
- Execute the plan `TestOwFaults`
- Using the Faults menu in RQT, inject various combinations of faults and observe results.
- When satisfied, Ctrl-C in each window to quit.

## Caveat

During this work, it was realized that the injectable force-torque sensor faults (zero value, signal bias) are not detectable by the `OwFaultDetection` node.  Hence, their associated Lookups always returns false because nothing sets the relevant fault flag.  Adding detection of F/T faults would be a separate work.

## Attachments

[Fault-Injection-and-Modeling.pdf](https://github.com/nasa/ow_autonomy/files/14910884/Fault-Injection-and-Modeling.pdf)

[Autonomy.pdf](https://github.com/nasa/ow_autonomy/files/14910883/Autonomy.pdf)
