### PR TITLE
Added DockIngestSample to sample mission plans and decreased dig depth

### DIFF
--- a/ow_plexil/src/plans/EuropaMission.plp
+++ b/ow_plexil/src/plans/EuropaMission.plp
@@ -219,7 +219,7 @@ EuropaMission: Concurrence
                                      X = trench_x,
                                      Y = trench_y,
                                      GroundPos = ground_pos,
-                                     Depth = 0.1105,
+                                     Depth = 0.08,
                                      Length = trench_length,
                                      Parallel = parallel);
       set_checkpoint ("SampleCollected", true, "SampleCollection");

--- a/ow_plexil/src/plans/EuropaMission.plp
+++ b/ow_plexil/src/plans/EuropaMission.plp
@@ -230,6 +230,7 @@ EuropaMission: Concurrence
     {
       SkipCondition
         (DidCrash && !Lookup(IsBootOK(Lookup(CheckpointWhen("SampleAnalyzed")))));
+      LibraryCall DockIngestSample();
       LibraryCall StartSampleAnalysis;
       set_checkpoint("SampleAnalyzed", true, "SampleAnalysis");
       SynchronousCommand flush_checkpoints();

--- a/ow_plexil/src/plans/ReferenceMission1.plp
+++ b/ow_plexil/src/plans/ReferenceMission1.plp
@@ -106,7 +106,7 @@ ReferenceMission1: Concurrence
     LibraryCall CollectSample (X = trench_x,
                                Y = trench_y,
                                GroundPos = ground_pos,
-                               Depth = 0.1105,
+                               Depth = 0.08,
                                Length = trench_length,
                                Parallel = parallel);
     LibraryCall SafeStow();

--- a/ow_plexil/src/plans/ReferenceMission2.plp
+++ b/ow_plexil/src/plans/ReferenceMission2.plp
@@ -163,7 +163,7 @@ ReferenceMission2: Concurrence
       LibraryCall CollectSample (X = trench_x,
                                  Y = trench_y,
                                  GroundPos = ground_pos,
-                                 Depth = 0.1105,
+                                 Depth = 0.08,
                                  Length = trench_length,
                                  Parallel = parallel);
     }

--- a/ow_plexil/src/plans/ReferenceMission2.plp
+++ b/ow_plexil/src/plans/ReferenceMission2.plp
@@ -145,7 +145,7 @@ ReferenceMission2: Concurrence
                              NumPasses = 2,
                              Parallel = parallel);
     }
-    
+
     Clear:
     {
       Start BatteryOK && NoFaults;
@@ -155,7 +155,7 @@ ReferenceMission2: Concurrence
                                   GroundPos = ground_pos,
                                   Parallel = parallel);
     }
-    
+
     Collect:
     {
       Start BatteryOK && NoFaults;
@@ -167,18 +167,19 @@ ReferenceMission2: Concurrence
                                  Length = trench_length,
                                  Parallel = parallel);
     }
-    
+
     Stow:
     {
       Start BatteryOK && NoFaults;
       log_info ("Stowing Arm");
       LibraryCall SafeStow();
     }
-    
+
     Analyze:
     {
       Start BatteryOK && NoFaults;
       log_info ("Analyzing Sample");
+      LibraryCall DockIngestSample();
       LibraryCall StartSampleAnalysis;
     }
 


### PR DESCRIPTION
### Summary ###

To support and compliment https://github.com/nasa/ow_simulator/pull/382, this is a trivial change that has two more sample mission plans ingest the collected sample, so that we can see (via the `/ground_truth/material_ingested` topic) what was collected.

Also, all three sample mission plans had their trench digging depth slightly reduced.  It had been too high for a while.

This PR can be merged independent of (before or after) the sibling PR.

### Test (optional) ###

1. With `ow_simulator` on the same branch, start the Atacama world.
2. `rostopic echo /ground_truth/material_ingested`
3. Run `EuropaMission.plx`
4. See that the plan finished normally and that the trench digs look normal.
5. When it finishes, find a single message on the topic above, something like:
```
header: 
  seq: 0
  stamp: 
    secs: 1916525546
    nsecs: 277499914
  frame_id: ''
volume: 0.0024000000000000002
composition: 
  - 
    id: 1
    name: "MG_HYDRATES"
    proportion: 0.10939699411392212
  - 
    id: 2
    name: "SALT"
    proportion: 0.3638315200805664
  - 
    id: 0
    name: "ICE"
    proportion: 0.5267714858055115
```
The proportions should add up to 1.0.

Repeat the steps above for ReferenceMission1 and 2.

