### PR TITLE
Stoppable goal error monitor

### DIFF
--- a/ow_plexil/src/plans/EuropaMission.plp
+++ b/ow_plexil/src/plans/EuropaMission.plp
@@ -72,7 +72,7 @@ EuropaMission: Concurrence
   // As of Release 13, goal errors are not automatically cleared by
   // the simulator.  Add this call to any plan where this may be
   // important, running it concurrently with the other nodes.
-  LibraryCall ClearGoalErrors();
+  LibraryCall GoalErrorMonitor (continue = MissionInProgress);
 
   Mission:
   {

--- a/ow_plexil/src/plans/GoalErrorMonitor.plp
+++ b/ow_plexil/src/plans/GoalErrorMonitor.plp
@@ -1,0 +1,16 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+// Runs ClearGoalErrors until a flag to terminate this plan is set.
+
+#include "ow-interface.h"
+
+GoalErrorMonitor:
+{
+  In Boolean continue;
+
+  Exit !continue;
+  
+  LibraryCall ClearGoalErrors();
+}

--- a/ow_plexil/src/plans/ReferenceMission1.plp
+++ b/ow_plexil/src/plans/ReferenceMission1.plp
@@ -65,7 +65,7 @@ ReferenceMission1: Concurrence
   // As of Release 13, goal errors are not automatically cleared by
   // the simulator.  Add this call to any plan where this may be
   // important, running it concurrently with the other nodes.
-  LibraryCall ClearGoalErrors();
+  LibraryCall GoalErrorMonitor (continue = MissionInProgress);
 
   Mission:
   {

--- a/ow_plexil/src/plans/ReferenceMission2.plp
+++ b/ow_plexil/src/plans/ReferenceMission2.plp
@@ -76,7 +76,7 @@ ReferenceMission2: Concurrence
   // As of Release 13, goal errors are not automatically cleared by
   // the simulator.  Add this call to any plan where this may be
   // important, running it concurrently with the other nodes.
-  LibraryCall ClearGoalErrors();
+  LibraryCall GoalErrorMonitor (continue = MissionInProgress);
 
   WaitForHealth:
   {

--- a/ow_plexil/src/plans/ow-interface.h
+++ b/ow_plexil/src/plans/ow-interface.h
@@ -92,6 +92,7 @@ LibraryAction TaskScoopLinear (In Integer Frame,
 
 LibraryAction FaultClear (In Integer fault);
 
+LibraryAction GoalErrorMonitor (In Boolean continue);
 LibraryAction ClearGoalErrors();
 LibraryAction ClearGoalErrorAttempt (In String name, In Integer flag);
 LibraryAction ClearGoalErrorOutcome (In Boolean success, In String name);


### PR DESCRIPTION
### Summary

No plans that run the recently added `ClearGoalErrors` plan were terminating, because that plan never terminates.  This work introduces a stoppable wrapper named `GoalErrorMonitor` and has the 3 mission plans use this instead.

### Test

1. Release 13 test 10.13
2. (optional) Run `ReferenceMission2` and `EuropaMission` and see that they terminate -- as indicated in the RQT Plexil Plan Selection dialog.