### PR TITLE
Fault handling example plans clear goal errors

### DIFF
--- a/ow_plexil/src/plans/FaultHandlingPattern1.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern1.plp
@@ -8,15 +8,20 @@
 // Pan in 15 degree increments as long as no antenna pan fault is present.  If an
 // antenna pan fault occurs, pause until the fault is removed.
 
-// This plan terminates on a power fault, e.g. injecting low state of
-// charge, instantaneous capacity loss, or thermal failure.  Note that
-// a pan in progress must finish first, i.e. clear a pan fault if needed.
+// This plan terminates on a power fault, e.g. by injecting low state
+// of charge, instantaneous capacity loss, or thermal failure.  Note
+// that because the Pan plan is synchronous, a pan in progress must
+// finish first, i.e. an antenna pan fault must be cleared before the
+// power fault is heeded.
 
 #include "ow-interface.h"
 
 FaultHandlingPattern1:
 {
+  String id;
+
   log_info ("Starting FaultHandlingPattern1 plan...");
+  id = StartPlan ("ClearGoalErrors");
 
   ManyPans: UncheckedSequence
   {
@@ -34,5 +39,6 @@ FaultHandlingPattern1:
     }
   }
 
+  ExitPlan (id);
   log_info ("Finished FaultHandlingPattern1 plan.");
 }

--- a/ow_plexil/src/plans/FaultHandlingPattern2.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern2.plp
@@ -12,18 +12,21 @@
 // If an arm fault but no antenna pan fault is injected, only action 1 occurs.
 // If both antenna pan and arm faults are injected, the plan waits for resolution.
 
-// This plan terminates on a power fault, e.g. injecting low state of
-// charge, instantaneous capacity loss, or thermal failure.  Note that
-// any actions in progress must finish first, i.e. clear relevant
-// faults if needed.
+// This plan terminates on a power fault, e.g. by injecting low state
+// of charge, instantaneous capacity loss, or thermal failure.  Note
+// that because the Pan and SafeStow plans are synchronous, any
+// actions in progress must finish first, i.e. antenna and arm faults
+// must be cleared before the power fault is heeded.
 
 #include "ow-interface.h"
 
 FaultHandlingPattern2:
 {
   Real NewAngle = 0;
+  String id;
 
   log_info ("Starting FaultHandlingPattern2 plan...");
+  id = StartPlan ("ClearGoalErrors");
 
   Run: Concurrence
   {
@@ -56,5 +59,6 @@ FaultHandlingPattern2:
     }
   }
 
+  ExitPlan (id);
   log_info ("Finished FaultHandlingPattern2 plan.");
 }

--- a/ow_plexil/src/plans/FaultHandlingPattern3.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern3.plp
@@ -1,4 +1,4 @@
-/ The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 

--- a/ow_plexil/src/plans/FaultHandlingPattern3.plp
+++ b/ow_plexil/src/plans/FaultHandlingPattern3.plp
@@ -1,4 +1,4 @@
-// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+/ The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
@@ -19,7 +19,9 @@
 
 // CAVEAT: It is possible that the Stow node may somehow start, or
 // complete with success status, even in the presence of an Arm fault.
-// This intermittent bug has been investigated but not yet fixed.
+// It is also possible that the plan hangs with certain combinations
+// of fault injection.  These hard-to-reproduce bugs need
+// investigation.
 
 #include "ow-interface.h"
 
@@ -28,8 +30,10 @@ FaultHandlingPattern3: UncheckedSequence
   Boolean PanSuccess;
   Boolean UnstowSuccess;
   Boolean StowSuccess;
+  String id;
 
   log_info ("Starting FaultHandlingPattern3 plan...");
+  id = StartPlan ("ClearGoalErrors");
 
   PanAntenna:
   {
@@ -74,5 +78,6 @@ FaultHandlingPattern3: UncheckedSequence
 
   log_info ("Outcomes (Pan, Unstow, Stow) = ",
             PanSuccess, " ", UnstowSuccess, " ", StowSuccess);
+  ExitPlan (id);
   log_info ("FaultHandlingPattern3 plan complete.");
 }

--- a/ow_plexil/src/plans/HealthMonitorDemo.plp
+++ b/ow_plexil/src/plans/HealthMonitorDemo.plp
@@ -52,15 +52,17 @@ HealthMonitorDemo:
   Boolean AntennaGood;
   Boolean CameraGood;
   Boolean PowerGood;
-
+  String id;
+  
   log_info("Starting HealthMonitorDemo...");
+  id = StartPlan ("ClearGoalErrors");
 
   Actions: Concurrence
   {
     Exit Lookup(PowerFault);
 
     LibraryCall ClearGoalErrors();
-    
+
     Monitor:
     {
       LibraryCall HealthMonitor (AllOperable = AllGood,
@@ -96,6 +98,7 @@ HealthMonitorDemo:
       endif;
     }
   }
-  
+
+  ExitPlan (id);
   log_info("Finished HealthMonitorDemo.");
 }

--- a/ow_plexil/src/plans/HealthMonitorDemo.plp
+++ b/ow_plexil/src/plans/HealthMonitorDemo.plp
@@ -2,16 +2,18 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// NOTE: As of 4/17/24 this plan is broken, probably because the
-// simulator no longer automatically clears goal errors.  Arm actions
-// are indefinitely attempted.  This occurs with or without the
-// just-added call to ClearGoalErrors().
-
-// NOTE: Another long-standing problem with this plan is that the
-// executive node often crashes after the plan is terminated with a
-// power fault.  This is due to a bug in the PLEXIL executive that
+// NOTE: As of 4/27/24 a long-standing problem with this plan is that
+// the executive node often crashes after the plan is terminated with
+// a power fault.  This is due to a bug in the PLEXIL executive that
 // will crash it if a command handle is received after the plan
 // terminates.
+
+// NOTE: this plan requires use of the Fault Dependencies framework,
+// which is documented in OceanWATERS user guide at
+// https://github.com/nasa/ow_simulator/wiki/Autonomy.  You must start
+// the executive with the fault_dependencies_file option, e.g:
+//
+//   roslaunch ow_plexil ow_exec.launch fault_dependencies_file:="FaultDependenciesModel.xml"
 
 // This plan demonstrates the effects of the Health Monitor, with
 // respect to operability of the arm and camera.
@@ -33,15 +35,8 @@
 // are the low_state_of_charge, instantaneous_capacity_loss, and
 // thermal_failure.
 
-// IMPORTANT NOTE: goal errors are effectively ignored
-// (i.e. automatically cleared) for now.
-
-// NOTE: this plan requires use of the Fault Dependencies framework,
-// which is documented in OceanWATERS user guide at
-// https://github.com/nasa/ow_simulator/wiki/Autonomy.  You must start
-// the executive with the fault_dependencies_file option, e.g:
-//
-//   roslaunch ow_plexil ow_exec.launch fault_dependencies_file:="FaultDependenciesModel.xml"
+// NOTE: goal errors are effectively ignored (i.e. automatically
+// cleared) for now.
 
 #include "ow-interface.h"
 
@@ -53,15 +48,13 @@ HealthMonitorDemo:
   Boolean CameraGood;
   Boolean PowerGood;
   String id;
-  
+
   log_info("Starting HealthMonitorDemo...");
   id = StartPlan ("ClearGoalErrors");
 
   Actions: Concurrence
   {
     Exit Lookup(PowerFault);
-
-    LibraryCall ClearGoalErrors();
 
     Monitor:
     {

--- a/ow_plexil/src/plans/MonitorFaults.plp
+++ b/ow_plexil/src/plans/MonitorFaults.plp
@@ -2,13 +2,8 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// Check for a variety of faults at regular intervals, and set a general health
-// variable accordingly.
-
-
-// Note that the fault queries (lookups) are for categories of faults, but that
-// the exact faults (outlined in ../plexil-adapter/OwInterface.h) are not yet
-// detectable in PLEXIL.
+// Check for the presence of general faults at a regular interval, and
+// set a general health variable accordingly.
 
 #include "ow-interface.h"
 

--- a/ow_plexil/src/plans/StartSampleAnalysis.plp
+++ b/ow_plexil/src/plans/StartSampleAnalysis.plp
@@ -2,15 +2,13 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// This plan "spawns" another plan that does the analysis, just for a single
-// instrument for now.  The spawned plan's execution persists after this one
-// finishes.  We could do more here, such as monitor its execution (e.g. time,
-// energy, temperature) and abort it if needed.
+// This plan "spawns" (asynchonously starts) another plan that does
+// the analysis, just for a single instrument for now.  The spawned
+// plan's execution persists after this one finishes.  We could do
+// more here, such as monitor its execution (e.g. time, energy,
+// temperature) and abort it if needed.
 
-// NOTE: The following declaration should work, but for some reason does not:
-// String Command StartPlan(String plan_name, ...);
-
-String Command StartPlan(...);
+#include "ow-interface.h"
 
 StartSampleAnalysis:
 {

--- a/ow_plexil/src/plans/common/common-interface.h
+++ b/ow_plexil/src/plans/common/common-interface.h
@@ -28,7 +28,23 @@
 #define ACTION_RECALLED 8
 #define ACTION_LOST 9
 
-// Utility commands; issue ROS_INFO, ROS_WARN, and ROS_ERROR, respectively.
+// PLEXIL utilities for starting plans asynchronously ("launching" or
+// "spawning" them).
+
+// Spawns a given plan.  The first argument (required) is a string
+// specifying the plan (node) name, the remaining arguments (optional)
+// are the node's arguments (In and InOut variables, given
+// positionally).  E.g. StartPlan("AddEntry", "John", 23).  The
+// returned value is an ID for the spawned plan.
+String Command StartPlan(...);
+
+// Terminate a plan that was launched earlier with StartPlan.  The id
+// is the value that was returned by StartPlan.
+Command ExitPlan(String id);
+
+
+// Utility commands; issue ROS_INFO, ROS_WARN, ROS_ERROR, and
+// ROS_DEBUG, respectively.
 Command log_info (...);
 Command log_warning (...);
 Command log_error (...);


### PR DESCRIPTION
### Summary

The plans `FaultHandlingPatternN` now automatically clear goal errors.  Without this, they didn't work.  The fix was to "spawn" `ClearGoalErrors` when they start, and terminate this plan before they finish.

The `HealthMonitorDemo` was also improved with this fix, but it is still flawed and left untested for now.

This fix makes more widespread the use of the PLEXIL commands `StartPlan` and `ExitPlan`, and so their declarations were added/moved to the interface headers.

### Test 

1. New Release 13 test 10.16
2. New Release 13 test 10.17.
3. Examine and lightly test FaultHandlingPattern3. (It has caveats but should still be a useful example):
     a. Do the comments in the plan seem clear and complete?
     b. Run this plan in any world, a few times, in the following ways.  Before each run, reset the antenna pan to 0, e.g. by clicking on the pan message in RQT's Control and Viz.
     c. Let the plan finish without any intervention.
     d. Experiment with different combinations and orders of pan and arm faults.  Does the plan behave as documented?
     e.  Note that if the plan hangs, the executive node must be interrupted.