### PR TITLE
HOTFIX Fixed identify_sample_location on atacama_y1a

### DIFF
--- a/ow_plexil/src/plans/EuropaMission.plp
+++ b/ow_plexil/src/plans/EuropaMission.plp
@@ -156,11 +156,11 @@ EuropaMission: Concurrence
       // destination.
 
       // Note that this node is checkpointed as a single step, because data
-      // needed to checkpoint the indivual steps (trench_x, trench_y,
+      // needed to checkpoint the individual steps (trench_x, trench_y,
       // ground_pos, parallel, and the GroundFound lookup) is not persistent.
       // In other words, there is no checkpointing within this node -- the
       // entire node would be repeated if a crash occurred during its execution.
-      // Jira OW-657 is for making this plan fully interruptable.
+      // Jira OW-657 is for making this plan fully interrutpable.
 
       SkipCondition
         (DidCrash && !Lookup(IsBootOK(Lookup(CheckpointWhen("SampleCollected")))));
@@ -171,7 +171,7 @@ EuropaMission: Concurrence
                                         Y = trench_y,
                                         GroundPos = ground_pos,
                                         Parallel = parallel,
-                                        FilterType = "Dark");
+                                        FilterType = "Brown");
 
       if (! isKnown(ground_pos)) {
         log_warning ("Sampling location could not be found visually. ",

--- a/ow_plexil/src/plans/EuropaMission.plp
+++ b/ow_plexil/src/plans/EuropaMission.plp
@@ -160,7 +160,7 @@ EuropaMission: Concurrence
       // ground_pos, parallel, and the GroundFound lookup) is not persistent.
       // In other words, there is no checkpointing within this node -- the
       // entire node would be repeated if a crash occurred during its execution.
-      // Jira OW-657 is for making this plan fully interrutpable.
+      // Jira OW-657 is for making this plan fully interruptible.
 
       SkipCondition
         (DidCrash && !Lookup(IsBootOK(Lookup(CheckpointWhen("SampleCollected")))));

--- a/ow_plexil/src/plans/ReferenceMission1.plp
+++ b/ow_plexil/src/plans/ReferenceMission1.plp
@@ -86,7 +86,7 @@ ReferenceMission1: Concurrence
                                       Y = trench_y,
                                       GroundPos = ground_pos,
                                       Parallel = parallel,
-                                      FilterType = "Dark");
+                                      FilterType = "Brown");
     if (! isKnown(ground_pos)) {
       log_warning ("Sampling location could not be found visually. ",
                    "Using default dig location.");

--- a/ow_plexil/src/plans/ReferenceMission2.plp
+++ b/ow_plexil/src/plans/ReferenceMission2.plp
@@ -119,7 +119,7 @@ ReferenceMission2: Concurrence
                                         Y = trench_y,
                                         GroundPos = ground_pos,
                                         Parallel = parallel,
-                                        FilterType = "Dark");
+                                        FilterType = "Brown");
     }
 
     if (! isKnown(ground_pos)) {


### PR DESCRIPTION
## Summary of Changes
* The filter type used by the identify sample location script is now brown. 
* Comment typo fixes

## Test
Run each of the mission plans that use IdentifySampleTarget.plp, namely: ReferenceMission1, ReferenceMission2, and EuropaMission. Restart the simulator between each mission plan.

The identified sample location in the case of all 3 plans should be approximately `(1.875331, 0.013813, -0.177397)`. When the lander performs a GuardedMove it will plant approximately in the location in the screencap. 
![default_gzclient_camera(1)-2024-05-14T17_03_44 955278](https://github.com/nasa/ow_autonomy/assets/17039973/d90f6c4f-a7e4-4073-834e-7b8ffdcda5d2)

A sample location should be found for each mission plan execution, and the warning "failed to find a suitable sample target" should not be seen.

Allow the remainder of the plan to execute and ensure there are no errors. Repeat for each of the 3 plans. 

## Caveat 
EuropaMission unstows the arm before imaging the workspace, and so the arm shows up in some of the images. This does not appear to affect the sample location outcome, but should probably be addressed at some point. 