### PR TITLE
Flipped normal direction in ArmFindSurface calls

### DIFF
--- a/ow_plexil/src/plans/TestActions.plp
+++ b/ow_plexil/src/plans/TestActions.plp
@@ -48,7 +48,7 @@ TestActions: UncheckedSequence
   LibraryCall ArmFindSurface (Frame = BASE_FRAME,
                               Relative = false,
                               Position = #(1.75 0.1 -0.155),
-                              Normal = #(0 0 -1),
+                              Normal = #(0 0 1),
                               Distance = 0.2,
                               Overdrive = 0.05,
                               ForceThreshold = 200,

--- a/ow_plexil/src/plans/TestArmFindSurface.plp
+++ b/ow_plexil/src/plans/TestArmFindSurface.plp
@@ -27,7 +27,7 @@ TestArmFindSurface:
   LibraryCall ArmFindSurface (Frame = BASE_FRAME, // default
                               Relative = false,  // default
                               Position = #(1.45 -0.4 0.25),
-                              Normal = #(0 0 -1),
+                              Normal = #(0 0 1),
                               Distance = Distance,
                               Overdrive = Overdrive,
                               ForceThreshold = ForceThreshold,
@@ -37,7 +37,7 @@ TestArmFindSurface:
   LibraryCall ArmFindSurface (Frame = BASE_FRAME, // default
                               Relative = false,  // default
                               Position = #(1.45 -0.4 0),
-                              Normal = #(0 0 -1),
+                              Normal = #(0 0 1),
                               Distance = Distance,
                               Overdrive = Overdrive,
                               ForceThreshold = ForceThreshold,


### PR DESCRIPTION
## Linked Issues:
Jira Ticket 🎟️ | [OCEANWATER-1185](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1185)

## Sibling PR
https://github.com/nasa/ow_simulator/pull/398

## Summary of Changes
* Normal vector flipped in all calls of ArmFindSurface to reflect the change in parameter meaning. 

## Test
Run all modified plexil plans and verify they succeed.